### PR TITLE
CORCI-413 Only map /opt/intel to builder

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -474,7 +474,7 @@ pipeline {
                             dir 'utils/docker'
                             label 'docker_runner'
                             additionalBuildArgs '$BUILDARGS'
-                            args '-v /opt:/opt'
+                            args '-v /opt/intel:/opt/intel'
                         }
                     }
                     steps {


### PR DESCRIPTION
It doesn't need all of /opt.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>
Change-Id: I71c5bf431d7082de15a160967af0975017610d3c