### PR TITLE
CART-566 ft: hash table to store fault attr

### DIFF
--- a/src/gurt/fault_inject.c
+++ b/src/gurt/fault_inject.c
@@ -45,14 +45,66 @@
 
 #define FI_MAX_FAULT_ID 8192
 
+/* (1 << D_FA_TABLE_BITS) is the number of buckets of fa hash table */
+#define D_FA_TABLE_BITS		(13)
+
 #include <gurt/common.h>
+#include <gurt/hash.h>
+
+struct d_fault_attr {
+	d_list_t		fa_link;
+	struct d_fault_attr_t	fa_attr;
+};
+
+static struct d_fault_attr *
+fa_link2ptr(d_list_t *rlink)
+{
+	D_ASSERT(rlink != NULL);
+	return container_of(rlink, struct d_fault_attr, fa_link);
+}
+
+static bool
+fa_op_key_cmp(struct d_hash_table *htab, d_list_t *rlink, const void *key,
+	      unsigned int ksize)
+{
+	struct d_fault_attr *fa_ptr = fa_link2ptr(rlink);
+
+	D_ASSERT(ksize == sizeof(uint32_t));
+
+	return fa_ptr->fa_attr.fa_id == *(uint32_t *)key;
+}
+
+static void
+fa_op_rec_free(struct d_hash_table *htab, d_list_t *rlink)
+{
+	struct d_fault_attr	*ht_rec = fa_link2ptr(rlink);
+	int			 rc;
+
+	D_FREE(ht_rec->fa_attr.fa_argument);
+	rc = D_SPIN_DESTROY(&ht_rec->fa_attr.fa_lock);
+	if (rc != DER_SUCCESS)
+		D_ERROR("Can't destroy spinlock for fault id: %d\n",
+			ht_rec->fa_attr.fa_id);
+	D_FREE(ht_rec);
+}
+
+static bool
+fa_op_rec_decref(struct d_hash_table *htab, d_list_t *rlink)
+{
+	return true;
+}
+
+static d_hash_table_ops_t fa_table_ops = {
+	.hop_key_cmp	= fa_op_key_cmp,
+	.hop_rec_decref	= fa_op_rec_decref,
+	.hop_rec_free	= fa_op_rec_free,
+};
 
 struct d_fi_gdata_t {
 	unsigned int		  dfg_refcount;
 	unsigned int		  dfg_inited;
 	pthread_rwlock_t	  dfg_rwlock;
-	struct d_fault_attr_t	**dfg_fa;
-	uint32_t		  dfg_fa_capacity;
+	struct d_hash_table	  dfg_fa_table;
 };
 
 /**
@@ -70,13 +122,11 @@ static inline int
 fault_attr_set(uint32_t fault_id, struct d_fault_attr_t fa_in, bool take_lock)
 {
 	struct d_fault_attr_t	 *fault_attr;
-	struct d_fault_attr_t	 *new_fault_attr;
-	struct d_fault_attr_t	**new_fa_arr;
-	uint32_t		  new_capacity;
-	void			 *start;
-	size_t			  num_bytes;
 	char			 *fa_argument = NULL;
 	bool			  should_free = true;
+	struct d_fault_attr	 *new_rec = NULL;
+	struct d_fault_attr	 *rec = NULL;
+	d_list_t		 *rlink = NULL;
 	int			  rc = DER_SUCCESS;
 
 	if (fault_id > FI_MAX_FAULT_ID) {
@@ -85,8 +135,8 @@ fault_attr_set(uint32_t fault_id, struct d_fault_attr_t fa_in, bool take_lock)
 		return -DER_INVAL;
 	}
 
-	D_ALLOC_PTR(new_fault_attr);
-	if (new_fault_attr == NULL)
+	D_ALLOC_PTR(new_rec);
+	if (new_rec == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
 	if (fa_in.fa_argument) {
@@ -99,31 +149,28 @@ fault_attr_set(uint32_t fault_id, struct d_fault_attr_t fa_in, bool take_lock)
 	if (take_lock)
 		D_RWLOCK_WRLOCK(&d_fi_gdata.dfg_rwlock);
 
-	if (fault_id >= d_fi_gdata.dfg_fa_capacity) {
-		new_capacity = fault_id + 1;
-		D_REALLOC_ARRAY(new_fa_arr, d_fi_gdata.dfg_fa, new_capacity);
-		if (new_fa_arr == NULL)
-			D_GOTO(out_unlock, rc = -DER_NOMEM);
-
-		start = new_fa_arr + d_fi_gdata.dfg_fa_capacity;
-		num_bytes = sizeof(*new_fa_arr)
-			    * (new_capacity - d_fi_gdata.dfg_fa_capacity);
-		memset(start, 0, num_bytes);
-		d_fi_gdata.dfg_fa = new_fa_arr;
-		d_fi_gdata.dfg_fa_capacity = new_capacity;
-	}
-
-	fault_attr = d_fi_gdata.dfg_fa[fault_id];
-	if (fault_attr == NULL) {
-		fault_attr = new_fault_attr;
+	rlink = d_hash_rec_find(&d_fi_gdata.dfg_fa_table, &fault_id,
+				sizeof(fault_id));
+	if (rlink == NULL) {
+		fault_attr = &new_rec->fa_attr;
 
 		rc = D_SPIN_INIT(&fault_attr->fa_lock,
 				 PTHREAD_PROCESS_PRIVATE);
 		if (rc != DER_SUCCESS)
 			D_GOTO(out_unlock, rc);
 
-		d_fi_gdata.dfg_fa[fault_id] = fault_attr;
+		rc = d_hash_rec_insert(&d_fi_gdata.dfg_fa_table, &fault_id,
+				       sizeof(fault_id), &new_rec->fa_link,
+				       true /* exclusive */);
+		if (rc != 0) {
+			D_ERROR("d_hash_rec_insert failed, rc: %d.\n", rc);
+			D_GOTO(out_unlock, rc);
+		}
 		should_free = false;
+	} else {
+		rec = fa_link2ptr(rlink);
+		D_ASSERT(rec->fa_attr.fa_id == fault_id);
+		fault_attr = &rec->fa_attr;
 	}
 
 	D_SPIN_LOCK(&fault_attr->fa_lock);
@@ -145,7 +192,7 @@ out_unlock:
 		D_RWLOCK_UNLOCK(&d_fi_gdata.dfg_rwlock);
 out:
 	if (should_free) {
-		D_FREE(new_fault_attr);
+		D_FREE(new_rec);
 		if (fa_in.fa_argument)
 			D_FREE(fa_argument);
 	}
@@ -159,19 +206,37 @@ d_fault_attr_set(uint32_t fault_id, struct d_fault_attr_t fa_in)
 	return fault_attr_set(fault_id, fa_in, true);
 }
 
+struct d_fault_attr_t *
+d_fault_attr_lookup(uint32_t fault_id)
+{
+	struct d_fault_attr_t	*fault_attr;
+	struct d_fault_attr	*ht_rec;
+	d_list_t		*rlink;
+
+	D_RWLOCK_RDLOCK(&d_fi_gdata.dfg_rwlock);
+	rlink = d_hash_rec_find(&d_fi_gdata.dfg_fa_table, (void *)&fault_id,
+				sizeof(fault_id));
+	D_RWLOCK_UNLOCK(&d_fi_gdata.dfg_rwlock);
+	if (rlink == NULL) {
+		D_DEBUG(DB_ALL, "fault attr for fault ID %d not set yet.\n",
+			fault_id);
+		fault_attr = NULL;
+	} else {
+		ht_rec = fa_link2ptr(rlink);
+		D_ASSERT(ht_rec->fa_attr.fa_id == fault_id);
+		fault_attr = &ht_rec->fa_attr;
+	}
+
+	return fault_attr;
+}
+
 int
 d_fault_attr_err_code(uint32_t fault_id)
 {
 	struct d_fault_attr_t	*fault_attr;
 	uint32_t		 err_code;
 
-	if (fault_id >= d_fi_gdata.dfg_fa_capacity) {
-		D_ERROR("fault id (%u) out of range [0, %u]\n",
-			fault_id, d_fi_gdata.dfg_fa_capacity);
-		return -DER_INVAL;
-	}
-
-	fault_attr = d_fi_gdata.dfg_fa[fault_id];
+	fault_attr = d_fault_attr_lookup(fault_id);
 	if (fault_attr == NULL) {
 		D_ERROR("fault id: %u not set.\n", fault_id);
 		return -DER_INVAL;
@@ -368,20 +433,35 @@ out:
 static void
 d_fi_gdata_init(void)
 {
+	int rc;
+
 	d_fi_gdata.dfg_refcount = 0;
 	d_fi_gdata.dfg_inited = 1;
 	D_RWLOCK_INIT(&d_fi_gdata.dfg_rwlock, NULL);
+	rc =  d_hash_table_create_inplace(D_HASH_FT_NOLOCK, D_FA_TABLE_BITS,
+					  NULL, &fa_table_ops,
+					  &d_fi_gdata.dfg_fa_table);
+	if (rc != 0)
+		D_ERROR("d_hash_table_create_inplace() failed, rc: %d.\n", rc);
 }
 
 static void
 d_fi_gdata_destroy(void)
 {
+	int rc;
+
+	rc = d_hash_table_destroy_inplace(&d_fi_gdata.dfg_fa_table,
+					  true /* force */);
+	if (rc != 0) {
+		D_ERROR("failed to destroy fault attr data. force: %d, "
+			"d_hash_table_destroy_inplace failed, rc: %d\n",
+			true, rc);
+	}
 	D_RWLOCK_DESTROY(&d_fi_gdata.dfg_rwlock);
 	d_fi_gdata.dfg_refcount = 0;
 	d_fi_gdata.dfg_inited = 0;
-	d_fi_gdata.dfg_fa_capacity = 0;
-	d_fi_gdata.dfg_fa = NULL;
 }
+
 /**
  * parse config file
  */
@@ -479,6 +559,13 @@ d_fault_inject_init(void)
 		D_GOTO(out, rc);
 	}
 
+	d_fault_id_mem = 0;
+	d_fault_attr_mem = d_fault_attr_lookup(d_fault_id_mem);
+	if (!d_fault_attr_mem) {
+		D_ERROR("d_fault_attr_lookup(%d) failed.\n", d_fault_id_mem);
+		D_GOTO(out, rc = -DER_MISC);
+	}
+
 out:
 	if (fp)
 		fclose(fp);
@@ -488,7 +575,6 @@ out:
 int
 d_fault_inject_fini()
 {
-	int	i;
 	int	rc = 0;
 
 	if (d_fi_gdata.dfg_inited == 0) {
@@ -502,24 +588,6 @@ d_fault_inject_fini()
 		D_RWLOCK_UNLOCK(&d_fi_gdata.dfg_rwlock);
 		return rc;
 	}
-
-	for (i = 0; i < d_fi_gdata.dfg_fa_capacity; i++) {
-		int	local_rc;
-
-		if (d_fi_gdata.dfg_fa[i] == NULL)
-			continue;
-
-		local_rc = D_SPIN_DESTROY(&d_fi_gdata.dfg_fa[i]->fa_lock);
-		if (local_rc != DER_SUCCESS)
-			D_ERROR("Can't destroy spinlock for fault id: %d\n", i);
-		if (rc == 0 && local_rc)
-			rc = local_rc;
-		if (d_fi_gdata.dfg_fa[i]->fa_argument)
-			D_FREE(d_fi_gdata.dfg_fa[i]->fa_argument);
-
-		D_FREE(d_fi_gdata.dfg_fa[i]);
-	}
-	D_FREE(d_fi_gdata.dfg_fa);
 
 	D_RWLOCK_UNLOCK(&d_fi_gdata.dfg_rwlock);
 	d_fi_gdata_destroy();
@@ -565,9 +633,8 @@ d_fi_initialized()
  *                           support injecting X faults in Y occurances
  */
 bool
-d_should_fail(uint32_t fault_id)
+d_should_fail(struct d_fault_attr_t *fault_attr)
 {
-	struct d_fault_attr_t	*fault_attr;
 	bool			 rc = true;
 
 	if (!d_fi_initialized()) {
@@ -579,15 +646,8 @@ d_should_fail(uint32_t fault_id)
 	 * based on the state of fault_attr, decide if a fault should
 	 * be injected
 	 */
-	if (fault_id >= d_fi_gdata.dfg_fa_capacity) {
-		D_ERROR("fault id (%u) out of range [0, %u]\n",
-			fault_id, d_fi_gdata.dfg_fa_capacity - 1);
-		return false;
-	}
-
-	fault_attr = d_fi_gdata.dfg_fa[fault_id];
-
 	if (!fault_attr) {
+		D_DEBUG(DB_ALL, "fault_attr is NULL.\n");
 		return false;
 	}
 

--- a/src/include/gurt/common.h
+++ b/src/include/gurt/common.h
@@ -116,6 +116,9 @@ typedef struct {
 	d_iov_t		*sg_iovs;
 } d_sg_list_t;
 
+struct d_fault_attr_t *d_fault_attr_mem;
+int d_fault_id_mem;
+
 static inline void
 d_iov_set(d_iov_t *iov, void *buf, size_t size)
 {
@@ -128,7 +131,7 @@ d_iov_set(d_iov_t *iov, void *buf, size_t size)
 #define D_CHECK_ALLOC(func, cond, ptr, name, size, count, cname,	\
 			on_error)					\
 	do {								\
-		if (D_SHOULD_FAIL(0)) {					\
+		if (D_SHOULD_FAIL(d_fault_attr_mem)) {			\
 			free(ptr);					\
 			ptr = NULL;					\
 		}							\

--- a/src/include/gurt/fault_inject.h
+++ b/src/include/gurt/fault_inject.h
@@ -137,19 +137,19 @@ void d_fault_inject_enable(void);
 void d_fault_inject_disable(void);
 
 
-bool d_should_fail(uint32_t fault_id);
+bool d_should_fail(struct d_fault_attr_t *fault_attr_ptr);
 
 /**
  * use this macro to determine if a fault should be injected at a specific call
  * site
  */
-#define D_SHOULD_FAIL(fault_id)						\
+#define D_SHOULD_FAIL(fault_attr)			\
 	({								\
 		bool __rc;						\
-		__rc = d_fault_inject && d_should_fail(fault_id);	\
+		__rc = d_fault_inject && d_should_fail(fault_attr);	\
 		if (__rc)						\
 			D_WARN("fault_id %d, injecting fault.\n",	\
-				fault_id);				\
+				fault_attr->fa_id);			\
 		__rc;							\
 	})
 
@@ -180,6 +180,16 @@ d_fault_attr_set(uint32_t fault_id, struct d_fault_attr_t fa_in);
  */
 int
 d_fault_attr_err_code(uint32_t fault_id);
+
+/**
+ * lookup the attributes struct address of a fault id.
+ *
+ * \param[in] fault_id          id of the fault
+ *
+ * \return                      address of the fault attributes for fault_id
+ */
+struct d_fault_attr_t *
+d_fault_attr_lookup(uint32_t fault_id);
 
 #if defined(__cplusplus)
 }

--- a/src/test/test_corpc_version.c
+++ b/src/test/test_corpc_version.c
@@ -173,7 +173,8 @@ static void *progress_thread(void *arg)
 		sched_yield();
 	} while (1);
 
-	D_ASSERT(rc == 0 || rc == -DER_TIMEDOUT);
+	D_ASSERTF(rc == 0 || rc == -DER_TIMEDOUT,
+		  "progress_thread failed rc: %d\n", rc);
 	fprintf(stderr, "progress_thread: progress thread exit ...\n");
 
 	pthread_exit(NULL);
@@ -207,16 +208,11 @@ corpc_ver_mismatch_hdlr(crt_rpc_t *rpc_req)
 static void
 test_shutdown_hdlr(crt_rpc_t *rpc_req)
 {
-	int		rc = 0;
-
 	fprintf(stderr, "rpc err server received shutdown request, "
 		"opc: 0x%x.\n", rpc_req->cr_opc);
 	D_ASSERTF(rpc_req->cr_input == NULL, "RPC request has invalid input\n");
 	D_ASSERTF(rpc_req->cr_output == NULL, "RPC request output is NULL\n");
 
-	rc = crt_reply_send(rpc_req);
-	D_ASSERT(rc == 0);
-	printf("rpc err server sent shutdown response.\n");
 	test.t_shutdown = 1;
 	fprintf(stderr, "server set shutdown flag.\n");
 }
@@ -602,8 +598,8 @@ test_init(void)
 				    corpc_ver_mismatch_hdlr,
 				    &corpc_ver_mismatch_ops);
 	D_ASSERTF(rc == 0, "crt_rpc_srv_register() failed, rc: %d\n", rc);
-	rc = crt_rpc_srv_register(TEST_OPC_SHUTDOWN, 0, NULL,
-				  test_shutdown_hdlr);
+	rc = crt_rpc_srv_register(TEST_OPC_SHUTDOWN, CRT_RPC_FEAT_NO_REPLY,
+				  NULL, test_shutdown_hdlr);
 	D_ASSERTF(rc == 0, "crt_rpc_srv_register() failed, rc: %d\n", rc);
 
 	rc = CRT_RPC_SRV_REGISTER(TEST_OPC_RANK_EVICT, 0, rank_evict,

--- a/src/test/test_group.c
+++ b/src/test/test_group.c
@@ -74,6 +74,8 @@ struct test_t {
 	pthread_t	 t_tid[TEST_CTX_MAX_NUM];
 	sem_t		 t_token_to_proceed;
 	int		 t_roomno;
+	struct d_fault_attr_t	 *t_fault_attr_1000;
+	struct d_fault_attr_t	 *t_fault_attr_5000;
 };
 
 struct test_t test_g = { .t_hold_time = 0, .t_ctx_num = 1, .t_roomno = 1082 };
@@ -132,7 +134,7 @@ test_checkin_handler(crt_rpc_t *rpc_req)
 	e_reply->ret = 0;
 	e_reply->room_no = test_g.t_roomno++;
 	e_reply->bool_val = e_req->bool_val;
-	if (D_SHOULD_FAIL(5000)) {
+	if (D_SHOULD_FAIL(test_g.t_fault_attr_5000)) {
 		e_reply->ret = -DER_MISC;
 		e_reply->room_no = -1;
 	} else {
@@ -287,6 +289,9 @@ test_init(void)
 	rc = crt_init(test_g.t_local_group_name, flag);
 	D_ASSERTF(rc == 0, "crt_init() failed, rc: %d\n", rc);
 
+	test_g.t_fault_attr_1000 = d_fault_attr_lookup(1000);
+	test_g.t_fault_attr_5000 = d_fault_attr_lookup(5000);
+
 	rc = crt_group_rank(NULL, &test_g.t_my_rank);
 	D_ASSERTF(rc == 0, "crt_group_rank() failed. rc: %d\n", rc);
 	if (test_g.t_is_service) {
@@ -360,7 +365,7 @@ check_in(crt_group_t *remote_group, int rank)
 	 * config file: under fault id 1000, change the probability from 0 to
 	 * anything in [1, 100]
 	 */
-	if (D_SHOULD_FAIL(1000)) {
+	if (D_SHOULD_FAIL(test_g.t_fault_attr_1000)) {
 		buffer = NULL;
 	} else {
 		D_ALLOC(buffer, 256);

--- a/utils/test_cart_lib.sh
+++ b/utils/test_cart_lib.sh
@@ -57,7 +57,8 @@ else
     echo "checking libcart.so"
     nm -g "${SL_PREFIX}/lib/libcart.so" |
         grep -v " U " |  grep -v " w " |  grep -v " crt_" | grep -v " swim_" |
-        grep -v "D CMF_" | grep -v "D CQF_" |
+        grep -v "D CMF_" | grep -v "D CQF_" | grep -v "d_fault_attr_mem" |
+        grep -v "d_fault_id_mem" |
         grep -v "\bd_\w*_logfac\b" |
         grep -v " D _edata" | grep -v " T _fini" | grep -v " T _init" |
         grep -v " B __bss_start" | grep -v " B _end";


### PR DESCRIPTION
Use a hash table to map fault IDs to fault attributes. Fault IDs don't
need to be sequential. The number of fault IDs is only limited by the
range of uint32_t: UINT32_MAX.

Change-Id: Ia96e7bcee98e11a2aed9f5782d6aac41ae2c1ffa
Signed-off-by: Yulu Jia <yulu.jia@intel.com>