### PR TITLE
CART-573 swim: Clean error messages for memory allocations

### DIFF
--- a/src/swim/swim_internal.h
+++ b/src/swim/swim_internal.h
@@ -57,17 +57,8 @@
 #include <gurt/common.h>
 
 /* Use debug capability from CaRT */
-#define SWIM_GOTO	D_GOTO
-#define SWIM_DEBUG	D_DEBUG
-#define SWIM_ALLOC	D_ALLOC
-#define SWIM_FREE	D_FREE
-
-#define SWIM_INFO(fmt, ...)	SWIM_DEBUG(DLOG_INFO,  fmt, ##__VA_ARGS__)
-#define SWIM_NOTE(fmt, ...)	SWIM_DEBUG(DLOG_NOTE,  fmt, ##__VA_ARGS__)
-#define SWIM_WARN(fmt, ...)	SWIM_DEBUG(DLOG_WARN,  fmt, ##__VA_ARGS__)
-#define SWIM_ERROR(fmt, ...)	SWIM_DEBUG(DLOG_ERR,   fmt, ##__VA_ARGS__)
-#define SWIM_CRIT(fmt, ...)	SWIM_DEBUG(DLOG_CRIT,  fmt, ##__VA_ARGS__)
-#define SWIM_FATAL(fmt, ...)	SWIM_DEBUG(DLOG_EMERG, fmt, ##__VA_ARGS__)
+#define SWIM_INFO(fmt, ...)	D_DEBUG(DLOG_INFO, fmt, ##__VA_ARGS__)
+#define SWIM_ERROR(fmt, ...)	D_DEBUG(DLOG_ERR,  fmt, ##__VA_ARGS__)
 
 #ifdef _USE_ABT_SYNC_
 #define SWIM_MUTEX_T		ABT_mutex

--- a/src/utest/SConscript
+++ b/src/utest/SConscript
@@ -48,8 +48,10 @@ LIBPATH = [Dir('../cart'), Dir('../gurt')]
 def scons():
     """Scons function"""
 
+    # pylint: disable=too-many-locals
     Import('env', 'prereqs', 'cart_targets', 'swim_targets', 'gurt_targets')
     Import('cart_lib')
+    # pylint: enable=too-many-locals
 
     #Use full path to wrap_cmocka.h for configure test.  Since standalone
     #cmocka header can't be included without including other headers,


### PR DESCRIPTION
Clean memory allocation code from additional error messages.

Change-Id: Ic415e256567f21d34b3641a52d40e8f8d0f33649
Signed-off-by: Dmitry Eremin <dmitry.eremin@intel.com>