### PR TITLE
CART-89 debug: chagne warn to debug

### DIFF
--- a/src/cart/crt_group.c
+++ b/src/cart/crt_group.c
@@ -731,9 +731,9 @@ crt_grp_lc_addr_insert(struct crt_grp_priv *grp_priv,
 	if (li->li_tag_addr[tag] == NULL) {
 		li->li_tag_addr[tag] = *hg_addr;
 	} else {
-		D_WARN("NA address already exits. "
-		       " grp_priv %p ctx_idx %d, rank: %d, tag %d, rlink %p\n",
-		       grp_priv, ctx_idx, rank, tag, &li->li_link);
+		D_DEBUG(DB_TRACE, "NA address already exits. "
+			" grp_priv %p ctx_idx %d, rank: %d, tag %d, rlink %p\n",
+			grp_priv, ctx_idx, rank, tag, &li->li_link);
 		rc = crt_hg_addr_free(&crt_ctx->cc_hg_ctx, *hg_addr);
 		if (rc != 0) {
 			D_ERROR("crt_hg_addr_free failed, crt_idx %d, *hg_addr"
@@ -2206,17 +2206,17 @@ crt_hdlr_uri_lookup(crt_rpc_t *rpc_req)
 	crt_ctx = rpc_req->cr_ctx;
 
 	if (ul_in->ul_rank >= grp_priv->gp_size) {
-		D_WARN("Lookup of invalid rank %d in group %s (%d)\n",
-		       ul_in->ul_rank, grp_priv->gp_pub.cg_grpid,
-		       grp_priv->gp_size);
+		D_ERROR("Lookup of invalid rank %d in group %s (%d)\n",
+			ul_in->ul_rank, grp_priv->gp_pub.cg_grpid,
+			grp_priv->gp_size);
 		D_GOTO(out, rc = -DER_OOG);
 	}
 
 	if (ul_in->ul_tag >= CRT_SRV_CONTEXT_NUM) {
-		D_WARN("Looking up invalid tag %d of rank %d "
-		       "in group %s (%d)\n",
-		       ul_in->ul_tag, ul_in->ul_rank,
-		       grp_priv->gp_pub.cg_grpid, grp_priv->gp_size);
+		D_ERROR("Looking up invalid tag %d of rank %d "
+			"in group %s (%d)\n",
+			ul_in->ul_tag, ul_in->ul_rank,
+			grp_priv->gp_pub.cg_grpid, grp_priv->gp_size);
 		D_GOTO(out, rc = -DER_INVAL);
 	}
 

--- a/src/cart/crt_register.c
+++ b/src/cart/crt_register.c
@@ -338,12 +338,12 @@ crt_opc_lookup(struct crt_opc_map *map, crt_opcode_t opc, int locked)
 		D_GOTO(out, 0);
 	}
 	if (L2_idx >= map->com_map[L1_idx].L2_num_slots_total) {
-		D_WARN("version number %d out of range [0, %d]\n", L2_idx,
-			map->com_map[L1_idx].L2_num_slots_total);
+		D_DEBUG(DB_ALL, "version number %d out of range [0, %d]\n",
+			L2_idx, map->com_map[L1_idx].L2_num_slots_total);
 		D_GOTO(out, 0);
 	}
 	if (L3_idx >= map->com_map[L1_idx].L2_map[L2_idx].L3_num_slots_total) {
-		D_WARN("rpc id %d out of range [0, %d]\n", L3_idx,
+		D_DEBUG(DB_ALL, "rpc id %d out of range [0, %d]\n", L3_idx,
 			map->com_map[L1_idx].L2_map[L2_idx].L3_num_slots_total);
 		D_GOTO(out, 0);
 	}

--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -798,8 +798,7 @@ crt_req_ep_lc_lookup(struct crt_rpc_priv *rpc_priv, crt_phy_addr_t *base_addr)
 		D_GOTO(out, rc);
 	}
 
-	if (base_addr != NULL && *base_addr != NULL &&
-	    rpc_priv->crp_hg_addr == NULL) {
+	if (base_addr != NULL && *base_addr != NULL) {
 		rc = crt_req_get_tgt_uri(rpc_priv, *base_addr);
 		if (rc != 0)
 			D_ERROR("crt_req_get_tgt_uri failed, "


### PR DESCRIPTION
Change D_WARN to D_DEBUG so the iof child job won't fail.

See: IOF-343

Change-Id: I5760444d530b42f14b4e904e73ed5af0bbfae065
Signed-off-by: Yulu Jia <yulu.jia@intel.com>