### PR TITLE
CART-571 rpc: Automatically generate structures from macros

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (C) 2016-2017 Intel Corporation
+Copyright (C) 2016-2019 Intel Corporation
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -16,9 +16,9 @@ provided that the following conditions are met:
    code must carry prominent notices stating that the original code was
    changed and the date of the change.
 
- 4. All publications or advertising materials mentioning features or use of
-    this software are asked, but not required, to acknowledge that it was
-    developed by Intel Corporation and credit the contributors.
+4. All publications or advertising materials mentioning features or use of
+   this software are asked, but not required, to acknowledge that it was
+   developed by Intel Corporation and credit the contributors.
 
 5. Neither the name of Intel Corporation, nor the name of any Contributor
    may be used to endorse or promote products derived from this software

--- a/site_scons
+++ b/site_scons
@@ -1,0 +1,1 @@
+scons_local

--- a/src/cart/SConscript
+++ b/src/cart/SConscript
@@ -37,12 +37,51 @@
 # THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """Build cart src"""
 
+import os
+
+# pylint: disable=no-name-in-module
+# pylint: disable=import-error
+import SCons.Action
+# pylint: enable=import-error
+# pylint: enable=no-name-in-module
+
 SRC = ['crt_barrier.c', 'crt_bulk.c', 'crt_context.c', 'crt_corpc.c',
        'crt_ctl.c', 'crt_debug.c', 'crt_group.c', 'crt_hg.c', 'crt_hg_proc.c',
        'crt_init.c', 'crt_iv.c', 'crt_lm.c', 'crt_pmix.c', 'crt_register.c',
        'crt_rpc.c', 'crt_self_test_client.c', 'crt_self_test_service.c',
        'crt_swim.c', 'crt_tree.c', 'crt_tree_flat.c', 'crt_tree_kary.c',
        'crt_tree_knomial.c']
+
+# pylint: disable=unused-argument
+def macro_expand(target, source, env):
+    """Function for PostAction"""
+    scope = r"'/struct [^ ]*_\(in\|out\) {/,/};/p'"
+    sed_e = r"-e 's/\s\s*/ /g' -e 's/};struct /};\nstruct /g'"
+    sed_d = r"-e 's/\([{;]\) /\1\t/g' -e 's/\([{;]\)/\1\n/g'"
+    grepv = r"'struct sockaddr_in {'"
+    tgts = ""
+    for tgt in target:
+        tgts += "%s_grep " % tgt.abspath
+        os.system("sed -n %s %s | tr -d '\\n' | sed %s > %s_grep"
+                  % (scope, tgt.abspath, sed_e, tgt.abspath))
+    h_name = "src/cart/_structures_from_macros_.h"
+    h_file = os.path.join(Dir('#').abspath, h_name)
+    with open(h_file, "w") as outfile:
+        outfile.write("/* Automatically generated with structures\n"
+                      " * expanded from CRT_RPC_DECLARE() macros\n *\n")
+        with open("LICENSE", "r") as infile:
+            for line in infile.readlines():
+                if line == "\n":
+                    outfile.write(" *\n")
+                else:
+                    outfile.write(" * " + line)
+            infile.close()
+        outfile.write(" */\n\n")
+        outfile.close()
+    if tgts != "":
+        os.system("cat %s | grep -v %s | sort -u | sed %s >> %s"
+                  % (tgts, grepv, sed_d, h_file))
+# pylint: enable=unused-argument
 
 def scons():
     """Scons function"""
@@ -58,7 +97,17 @@ def scons():
     prereqs.require(denv, 'mercury', 'pmix')
     denv.AppendUnique(RPATH=['$PREFIX/lib'])
 
+    pp_env = Environment(TOOLS=['default', 'extra'])
+    pp_env.AppendUnique(CPPPATH=['src/include', 'src/cart'])
+    prereqs.require(pp_env, 'mercury', 'pmix', headers_only=True)
+
+    # pylint: disable=no-member
+    pp_files = pp_env.Preprocess(SRC)
+    pp_env.AddPostAction(pp_files, SCons.Action.Action(macro_expand, None))
+    # pylint: enable=no-member
+
     cart_targets = denv.SharedObject(SRC)
+    denv.Requires(cart_targets, pp_files)
     cart_lib = denv.SharedLibrary('libcart', [cart_targets, swim_targets])
     denv.Requires(cart_lib, [swim_targets, gurt_lib])
     denv.Install('$PREFIX/lib/', cart_lib)

--- a/src/cart/_structures_from_macros_.h
+++ b/src/cart/_structures_from_macros_.h
@@ -1,0 +1,287 @@
+/* Automatically generated with structures
+ * expanded from CRT_RPC_DECLARE() macros
+ *
+ * Copyright (C) 2016-2019 Intel Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted for any purpose (including commercial purposes)
+ * provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions, and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions, and the following disclaimer in the
+ *    documentation and/or materials provided with the distribution.
+ *
+ * 3. In addition, redistributions of modified forms of the source or binary
+ *    code must carry prominent notices stating that the original code was
+ *    changed and the date of the change.
+ *
+ * 4. All publications or advertising materials mentioning features or use of
+ *    this software are asked, but not required, to acknowledge that it was
+ *    developed by Intel Corporation and credit the contributors.
+ *
+ * 5. Neither the name of Intel Corporation, nor the name of any Contributor
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+struct crt_barrier_in {
+	int32_t b_num;
+};
+
+struct crt_barrier_out {
+	int32_t b_rc;
+};
+
+struct crt_ctl_ep_ls_in {
+	crt_group_id_t cel_grp_id;
+	d_rank_t cel_rank;
+};
+
+struct crt_ctl_ep_ls_out {
+	d_iov_t cel_addr_str;
+	int32_t cel_ctx_num;
+	int32_t cel_rc;
+};
+
+struct crt_ctl_fi_attr_set_in {
+	uint32_t fa_fault_id;
+	uint32_t fa_interval;
+	uint64_t fa_max_faults;
+	uint32_t fa_err_code;
+	uint32_t fa_probability_x;
+	uint32_t fa_probability_y;
+	d_string_t fa_argument;
+};
+
+struct crt_ctl_fi_attr_set_out {
+	int32_t fa_ret;
+};
+
+struct crt_ctl_fi_toggle_in {
+	_Bool op;
+};
+
+struct crt_ctl_fi_toggle_out {
+	int32_t rc;
+};
+
+struct crt_ctl_get_host_in {
+	crt_group_id_t cel_grp_id;
+	d_rank_t cel_rank;
+};
+
+struct crt_ctl_get_host_out {
+	d_iov_t cgh_hostname;
+	int32_t cgh_rc;
+};
+
+struct crt_ctl_get_pid_in {
+	crt_group_id_t cel_grp_id;
+	d_rank_t cel_rank;
+};
+
+struct crt_ctl_get_pid_out {
+	int32_t cgp_pid;
+	int32_t cgp_rc;
+};
+
+struct crt_grp_create_in {
+	crt_group_id_t gc_grp_id;
+	uint64_t gc_int_grpid;
+	d_rank_list_t *gc_membs;
+	d_rank_t gc_initiate_rank;
+};
+
+struct crt_grp_create_out {
+	d_rank_list_t *gc_failed_ranks;
+	d_rank_t gc_rank;
+	int32_t gc_rc;
+};
+
+struct crt_grp_destroy_in {
+	crt_group_id_t gd_grp_id;
+	d_rank_t gd_initiate_rank;
+};
+
+struct crt_grp_destroy_out {
+	d_rank_list_t *gd_failed_ranks;
+	d_rank_t gd_rank;
+	int32_t gd_rc;
+};
+
+struct crt_iv_fetch_in {
+	d_iov_t ifi_nsid;
+	d_iov_t ifi_key;
+	crt_bulk_t ifi_value_bulk;
+	int32_t ifi_class_id;
+	d_rank_t ifi_root_node;
+};
+
+struct crt_iv_fetch_out {
+	int32_t ifo_rc;
+};
+
+struct crt_iv_sync_in {
+	d_iov_t ivs_nsid;
+	d_iov_t ivs_key;
+	d_iov_t ivs_sync_type;
+	uint32_t ivs_class_id;
+};
+
+struct crt_iv_sync_out {
+	int32_t rc;
+};
+
+struct crt_iv_update_in {
+	d_iov_t ivu_nsid;
+	d_iov_t ivu_key;
+	d_iov_t ivu_sync_type;
+	crt_bulk_t ivu_iv_value_bulk;
+	d_rank_t ivu_root_node;
+	d_rank_t ivu_caller_node;
+	uint32_t ivu_class_id;
+	uint32_t padding;
+};
+
+struct crt_iv_update_out {
+	uint64_t rc;
+};
+
+struct crt_lm_evict_in {
+	d_rank_t clei_rank;
+	uint32_t clei_ver;
+};
+
+struct crt_lm_evict_out {
+	int32_t cleo_succeeded;
+	int32_t cleo_rc;
+};
+
+struct crt_lm_memb_sample_in {
+	uint32_t msi_ver;
+};
+
+struct crt_lm_memb_sample_out {
+	d_iov_t mso_delta;
+	uint32_t mso_ver;
+	int32_t mso_rc;
+};
+
+struct crt_proto_query_in {
+	d_iov_t pq_ver;
+	int32_t pq_ver_count;
+	uint32_t pq_base_opc;
+};
+
+struct crt_proto_query_out {
+	uint32_t pq_ver;
+	int32_t pq_rc;
+};
+
+struct crt_st_both_bulk_in {
+	uint64_t unused1;
+	crt_bulk_t unused2;
+};
+
+struct crt_st_both_iov_in {
+	uint64_t unused1;
+	d_iov_t unused2;
+};
+
+struct crt_st_both_iov_out {
+	d_iov_t unused1;
+};
+
+struct crt_st_close_session_in {
+	uint64_t unused1;
+};
+
+struct crt_st_open_session_in {
+	uint32_t unused1;
+	uint32_t unused2;
+	uint32_t unused3;
+	uint32_t unused4;
+};
+
+struct crt_st_open_session_out {
+	uint64_t unused1;
+};
+
+struct crt_st_send_bulk_reply_iov_in {
+	uint64_t unused1;
+	crt_bulk_t unused2;
+};
+
+struct crt_st_send_bulk_reply_iov_out {
+	d_iov_t unused1;
+};
+
+struct crt_st_send_id_reply_iov_in {
+	uint64_t unused1;
+};
+
+struct crt_st_send_id_reply_iov_out {
+	d_iov_t unused1;
+};
+
+struct crt_st_send_iov_reply_bulk_in {
+	uint64_t unused1;
+	d_iov_t unused2;
+	crt_bulk_t unused3;
+};
+
+struct crt_st_send_iov_reply_empty_in {
+	uint64_t unused1;
+	d_iov_t unused2;
+};
+
+struct crt_st_start_in {
+	crt_group_id_t unused1;
+	d_iov_t unused2;
+	uint32_t unused3;
+	uint32_t unused4;
+	uint32_t unused5;
+	uint32_t unused6;
+	uint32_t unused7;
+};
+
+struct crt_st_start_out {
+	int32_t unused1;
+};
+
+struct crt_st_status_req_in {
+	crt_bulk_t unused1;
+};
+
+struct crt_st_status_req_out {
+	uint64_t test_duration_ns;
+	uint32_t num_remaining;
+	int32_t status;
+};
+
+struct crt_uri_lookup_in {
+	crt_group_id_t ul_grp_id;
+	d_rank_t ul_rank;
+	uint32_t ul_tag;
+};
+
+struct crt_uri_lookup_out {
+	crt_phy_addr_t ul_uri;
+	int32_t ul_rc;
+};
+


### PR DESCRIPTION
Expands structures from CRT_RPC_DECLARE() macros and place them
in special header file for subsequent indexing.

Change-Id: Id28b51e0791646630bfbfd25a8a9b0f51030b8ec
Signed-off-by: Dmitry Eremin <dmitry.eremin@intel.com>