### PR TITLE
CART-578 gurt: reset d_fi_gdata during d_fi_gdata_destroy

### DIFF
--- a/src/gurt/fault_inject.c
+++ b/src/gurt/fault_inject.c
@@ -379,6 +379,8 @@ d_fi_gdata_destroy(void)
 	D_RWLOCK_DESTROY(&d_fi_gdata.dfg_rwlock);
 	d_fi_gdata.dfg_refcount = 0;
 	d_fi_gdata.dfg_inited = 0;
+	d_fi_gdata.dfg_fa_capacity = 0;
+	d_fi_gdata.dfg_fa = NULL;
 }
 /**
  * parse config file


### PR DESCRIPTION
Reset all fields of d_fi_gdata in d_fi_gdata_destroy(),
otherwise d_fi_gdata might include invalid fields if it
does d_fi_gdata_fini() then d_fi_gdata_init() again.

Change-Id: Ifcffb42cc76d96e8a568d5326c1efcddee50aae7
Signed-off-by: Wang Di <di.wang@intel.com>