### PR TITLE
CART-565 hlc: Initial Hybrid Logical Clocks implementation

### DIFF
--- a/src/cart/SConscript
+++ b/src/cart/SConscript
@@ -50,7 +50,7 @@ SRC = ['crt_barrier.c', 'crt_bulk.c', 'crt_context.c', 'crt_corpc.c',
        'crt_init.c', 'crt_iv.c', 'crt_lm.c', 'crt_pmix.c', 'crt_register.c',
        'crt_rpc.c', 'crt_self_test_client.c', 'crt_self_test_service.c',
        'crt_swim.c', 'crt_tree.c', 'crt_tree_flat.c', 'crt_tree_kary.c',
-       'crt_tree_knomial.c']
+       'crt_tree_knomial.c', 'crt_hlc.c']
 
 # pylint: disable=unused-argument
 def macro_expand(target, source, env):
@@ -94,7 +94,7 @@ def scons():
 
     denv.AppendUnique(CPPPATH=['#/src/cart'])
     denv.AppendUnique(LIBS=['gurt'])
-    prereqs.require(denv, 'mercury', 'pmix')
+    prereqs.require(denv, 'mercury', 'openpa', 'pmix')
     denv.AppendUnique(RPATH=['$PREFIX/lib'])
 
     pp_env = Environment(TOOLS=['default', 'extra'])

--- a/src/cart/crt_hlc.h
+++ b/src/cart/crt_hlc.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2016-2019 Intel Corporation
+/* Copyright (C) 2019 Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -16,9 +16,9 @@
  *    code must carry prominent notices stating that the original code was
  *    changed and the date of the change.
  *
- *  4. All publications or advertising materials mentioning features or use of
- *     this software are asked, but not required, to acknowledge that it was
- *     developed by Intel Corporation and credit the contributors.
+ * 4. All publications or advertising materials mentioning features or use of
+ *    this software are asked, but not required, to acknowledge that it was
+ *    developed by Intel Corporation and credit the contributors.
  *
  * 5. Neither the name of Intel Corporation, nor the name of any Contributor
  *    may be used to endorse or promote products derived from this software
@@ -36,49 +36,16 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 /**
- * This file is part of CaRT. It it the common header file which be included by
- * all other .c files of CaRT.
+ * This file is part of CaRT. It's the header for crt_hlc.c.
  */
 
-#ifndef __CRT_INTERNAL_H__
-#define __CRT_INTERNAL_H__
+#ifndef __CRT_HLC_H__
+#define __CRT_HLC_H__
 
-#include "crt_debug.h"
+#include <stdint.h>
 
-#include <gurt/common.h>
-#include <gurt/fault_inject.h>
-#include <cart/api.h>
+uint64_t crt_hlc_get_last(void);
+int crt_hlc_send(uint64_t *time);
+int crt_hlc_receive(uint64_t *time, uint64_t msg);
 
-#include "crt_hg.h"
-#include "crt_internal_types.h"
-#include "crt_internal_fns.h"
-#include "crt_rpc.h"
-#include "crt_group.h"
-#include "crt_tree.h"
-#include "crt_self_test.h"
-#include "crt_ctl.h"
-#include "crt_swim.h"
-#include "crt_hlc.h"
-
-#include "crt_pmix.h"
-#include "crt_lm.h"
-
-/* A wrapper around D_TRACE_DEBUG that ensures the ptr option is a RPC */
-#define RPC_TRACE(mask, rpc, fmt, ...)					\
-	do {								\
-		/* no-op statement that type-checks the rpc pointer */	\
-		if (false && (rpc)->crp_refcount)			\
-			;						\
-		D_TRACE_DEBUG(mask, rpc, fmt,  ## __VA_ARGS__);		\
-	} while (0)
-
-/* Log an error with a RPC descriptor */
-#define RPC_ERROR(rpc, fmt, ...)					\
-	do {								\
-		/* no-op statement that type-checks the rpc pointer */	\
-		if (false && (rpc)->crp_refcount)			\
-			;						\
-		D_TRACE_ERROR(rpc, fmt,  ## __VA_ARGS__);		\
-	} while (0)
-
-#endif /* __CRT_INTERNAL_H__ */
+#endif /* __CRT_HLC_H__ */

--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -1269,6 +1269,30 @@ out:
 	return rc;
 }
 
+uint64_t
+crt_hlc_send_get(crt_rpc_t *req)
+{
+	struct crt_rpc_priv	*rpc_priv;
+
+	D_ASSERT(req != NULL);
+
+	rpc_priv = container_of(req, struct crt_rpc_priv, crp_pub);
+
+	return rpc_priv->crp_req_hdr.cch_hlc;
+}
+
+uint64_t
+crt_hlc_receive_get(crt_rpc_t *req)
+{
+	struct crt_rpc_priv	*rpc_priv;
+
+	D_ASSERT(req != NULL);
+
+	rpc_priv = container_of(req, struct crt_rpc_priv, crp_pub);
+
+	return rpc_priv->crp_reply_hdr.cch_hlc;
+}
+
 static void
 crt_rpc_inout_buff_fini(struct crt_rpc_priv *rpc_priv)
 {

--- a/src/cart/crt_rpc.h
+++ b/src/cart/crt_rpc.h
@@ -90,6 +90,8 @@ struct crt_common_hdr {
 	uint32_t	cch_opc;
 	/* RPC request flag, see enum crt_rpc_flags_internal */
 	uint32_t	cch_flags;
+	/* HLC timestamp */
+	uint64_t	cch_hlc;
 	/* gid and rank identify the rpc request sender */
 	d_rank_t	cch_rank;
 	/* used in crp_reply_hdr to propagate rpc failure back to sender */
@@ -145,11 +147,11 @@ struct crt_corpc_info {
 
 struct crt_rpc_priv {
 	/* link to crt_ep_inflight::epi_req_q/::epi_req_waitq */
-	d_list_t			crp_epi_link;
+	d_list_t		crp_epi_link;
 	/* tmp_link used in crt_context_req_untrack */
-	d_list_t			crp_tmp_link;
+	d_list_t		crp_tmp_link;
 	/* link to parent RPC crp_opc_info->co_child_rpcs/co_replied_rpcs */
-	d_list_t			crp_parent_link;
+	d_list_t		crp_parent_link;
 	/* binheap node for timeout management, in crt_context::cc_bh_timeout */
 	struct d_binheap_node	crp_timeout_bp_node;
 	/* the timeout in seconds set by user */

--- a/src/include/cart/api.h
+++ b/src/include/cart/api.h
@@ -408,6 +408,26 @@ crt_reply_get(crt_rpc_t *rpc)
 }
 
 /**
+ * Return HLC timestamp of RPC was sent
+ *
+ * \param[in] req              pointer to RPC request
+ *
+ * \return                     HLC timestamp
+ */
+uint64_t
+crt_hlc_send_get(crt_rpc_t *req);
+
+/**
+ * Return HLC timestamp of RPC (new or reply) was received
+ *
+ * \param[in] req              pointer to RPC request
+ *
+ * \return                     HLC timestamp
+ */
+uint64_t
+crt_hlc_receive_get(crt_rpc_t *req);
+
+/**
  * Abort an RPC request.
  *
  * \param[in] req              pointer to RPC request

--- a/src/test/SConscript
+++ b/src/test/SConscript
@@ -52,6 +52,7 @@ IV_TESTS = ['iv_client.c', 'iv_server.c']
 TEST_RPC_ERR_SRC = 'test_rpc_error.c'
 CRT_RPC_TESTS = ['rpc_test_cli.c', 'rpc_test_srv.c', 'rpc_test_srv2.c']
 SWIM_TESTS = ['test_swim.c', 'test_swim_net.c']
+HLC_TESTS = ['test_hlc_net.c']
 
 def scons():
     """scons function"""
@@ -62,7 +63,7 @@ def scons():
 
     tenv.AppendUnique(RPATH="$PREFIX/lib")
     tenv.AppendUnique(LIBS=['cart', 'gurt', 'pthread'])
-    prereqs.require(tenv, 'crypto', 'pmix', 'mercury')
+    prereqs.require(tenv, 'crypto', 'pmix', 'mercury', 'openpa')
 
     # Compile all of the tests
     for test in SIMPLE_TEST_SRC:
@@ -86,6 +87,11 @@ def scons():
         tenv.Install(os.path.join("$PREFIX", 'TESTING', 'tests'), target)
 
     for test in SWIM_TESTS:
+        target = tenv.Program(test)
+        tenv.Requires(target, [cart_lib, gurt_lib])
+        tenv.Install(os.path.join("$PREFIX", 'TESTING', 'tests'), target)
+
+    for test in HLC_TESTS:
         target = tenv.Program(test)
         tenv.Requires(target, [cart_lib, gurt_lib])
         tenv.Install(os.path.join("$PREFIX", 'TESTING', 'tests'), target)

--- a/src/test/test_hlc_net.c
+++ b/src/test/test_hlc_net.c
@@ -1,0 +1,315 @@
+/* Copyright (C) 2019 Intel Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted for any purpose (including commercial purposes)
+ * provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions, and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions, and the following disclaimer in the
+ *    documentation and/or materials provided with the distribution.
+ *
+ * 3. In addition, redistributions of modified forms of the source or binary
+ *    code must carry prominent notices stating that the original code was
+ *    changed and the date of the change.
+ *
+ * 4. All publications or advertising materials mentioning features or use of
+ *    this software are asked, but not required, to acknowledge that it was
+ *    developed by Intel Corporation and credit the contributors.
+ *
+ * 5. Neither the name of Intel Corporation, nor the name of any Contributor
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <sched.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <assert.h>
+#include <pthread.h>
+#include <cart/api.h>
+#include <cart/types.h>
+#include <gurt/common.h>
+
+/* CRT internal opcode definitions, must be 0xFF00xxxx.*/
+#define CRT_OPC_TEST_PROTO (0x10000000)
+
+#define DEBUG		1
+#define MAX_SEQ		1000
+
+#define CRT_ISEQ_RPC_TEST	/* input fields */		 \
+	((uint64_t)		(seq)			CRT_VAR) \
+	((uint32_t)		(src)			CRT_VAR) \
+	((uint32_t)		(dst)			CRT_VAR)
+
+#define CRT_OSEQ_RPC_TEST	/* output fields */		 \
+	((uint64_t)		(seq)			CRT_VAR) \
+	((uint32_t)		(src)			CRT_VAR) \
+	((uint32_t)		(dst)			CRT_VAR)
+
+CRT_RPC_DECLARE(crt_rpc_test, CRT_ISEQ_RPC_TEST, CRT_OSEQ_RPC_TEST)
+CRT_RPC_DEFINE(crt_rpc_test, CRT_ISEQ_RPC_TEST, CRT_OSEQ_RPC_TEST)
+
+static void test_srv_cb(crt_rpc_t *rpc);
+
+static struct crt_proto_rpc_format test_proto_rpc_fmt[] = {
+	{
+		.prf_flags	= 0,
+		.prf_req_fmt	= &CQF_crt_rpc_test,
+		.prf_hdlr	= test_srv_cb,
+		.prf_co_ops	= NULL,
+	}
+};
+
+static struct crt_proto_format test_proto_fmt = {
+	.cpf_name	= "test-proto",
+	.cpf_ver	= 0,
+	.cpf_count	= ARRAY_SIZE(test_proto_rpc_fmt),
+	.cpf_prf	= &test_proto_rpc_fmt[0],
+	.cpf_base	= CRT_OPC_TEST_PROTO,
+};
+
+struct global_srv {
+	crt_context_t		 crt_ctx;
+	pthread_t		 progress_thid;
+	uint64_t		 seq;
+	uint32_t		 my_rank;
+	uint32_t		 grp_size;
+	uint32_t		 shutdown;
+};
+
+#if DEBUG == 1
+#define dbg(fmt, ...)	D_DEBUG(DB_TEST, fmt, ##__VA_ARGS__)
+#else
+#define dbg(fmt, ...)							\
+	printf("%s[%d]\t[%d]\t"fmt"\n",					\
+	(strrchr(__FILE__, '/')+1), __LINE__, getpid(), ##__VA_ARGS__)
+#endif
+
+/*========================== GLOBAL ===========================*/
+
+static struct global_srv global_srv;
+
+/*========================== GLOBAL ===========================*/
+
+static void test_srv_cb(crt_rpc_t *rpc)
+{
+	struct crt_rpc_test_in	*rpc_input;
+	struct crt_rpc_test_out	*rpc_output;
+	int			 rc;
+
+	dbg("---%s--->", __func__);
+
+	rpc_input = crt_req_get(rpc);
+	D_ASSERT(rpc_input != NULL);
+
+	rpc_output = crt_reply_get(rpc);
+	D_ASSERT(rpc_output != NULL);
+
+	dbg("HLC=0x%lx recv RPC %02u.%03lu %02u send HLC=0x%lx\n",
+	    crt_hlc_receive_get(rpc), rpc_input->src, rpc_input->seq,
+	    rpc_input->dst, crt_hlc_send_get(rpc));
+
+	/* send HLC should be early than receive HLC */
+	D_ASSERT(crt_hlc_send_get(rpc) < crt_hlc_receive_get(rpc));
+
+	rpc_output->seq = rpc_input->seq;
+	rpc_output->src = rpc_input->src;
+	rpc_output->dst = rpc_input->dst;
+
+	rc = crt_reply_send(rpc);
+	D_ASSERTF(rc == 0, "crt_reply_send failed %d\n", rc);
+
+	dbg("<---%s---", __func__);
+}
+
+static void test_cli_cb(const struct crt_cb_info *cb_info)
+{
+	struct crt_rpc_test_in	*rpc_input;
+	struct crt_rpc_test_out	*rpc_output;
+	crt_rpc_t		*rpc = cb_info->cci_rpc;
+
+	dbg("---%s--->", __func__);
+
+	rpc_input = crt_req_get(rpc);
+	D_ASSERT(rpc_input != NULL);
+
+	rpc_output = crt_reply_get(rpc);
+	D_ASSERT(rpc_output != NULL);
+
+	dbg("opc: %#x cci_rc: %d", rpc->cr_opc, cb_info->cci_rc);
+
+	if (cb_info->cci_rc == 0) {
+		dbg("HLC=0x%lx send RPC %02u.%03lu %02u repl HLC=0x%lx\n",
+		    crt_hlc_send_get(rpc), rpc_input->src, rpc_input->seq,
+		    rpc_input->dst, crt_hlc_receive_get(rpc));
+
+		D_ASSERT(rpc_output->seq == rpc_input->seq);
+		D_ASSERT(rpc_output->src == rpc_input->src);
+		D_ASSERT(rpc_output->dst == rpc_input->dst);
+
+		/* send HLC should be early than reply HLC */
+		D_ASSERT(crt_hlc_send_get(rpc) < crt_hlc_receive_get(rpc));
+	}
+
+	dbg("<---%s---", __func__);
+}
+
+static int test_send_rpc(d_rank_t to)
+{
+	struct crt_rpc_test_in *rpc_input;
+	crt_rpc_t *rpc;
+	crt_endpoint_t ep;
+	crt_opcode_t opc;
+	int rc = 0;
+
+	dbg("---%s--->", __func__);
+
+	if (global_srv.seq >= MAX_SEQ)
+		return -DER_SHUTDOWN;
+
+	ep.ep_grp  = NULL;
+	ep.ep_rank = to;
+	ep.ep_tag  = 0;
+
+	/* get the opcode of the first RPC in version 0 of OPC_SWIM_PROTO */
+	opc = CRT_PROTO_OPC(CRT_OPC_TEST_PROTO, 0, 0);
+	rc = crt_req_create(global_srv.crt_ctx, &ep, opc, &rpc);
+	D_ASSERTF(rc == 0, "crt_req_create() failed rc=%d", rc);
+
+	rc = crt_req_set_timeout(rpc, 1);
+	D_ASSERTF(rc == 0, "crt_req_set_timeout() failed rc=%d", rc);
+
+	rpc_input = crt_req_get(rpc);
+	D_ASSERT(rpc_input != NULL);
+	rpc_input->seq = global_srv.seq++;
+	rpc_input->src = global_srv.my_rank;
+	rpc_input->dst = to;
+
+	rc = crt_req_send(rpc, test_cli_cb, NULL);
+	D_ASSERTF(rc == 0, "crt_req_send() failed rc=%d", rc);
+
+	dbg("<---%s---", __func__);
+	return rc;
+}
+
+static void *srv_progress(void *data)
+{
+	crt_context_t *ctx = (crt_context_t *)data;
+	int rc = 0;
+
+	dbg("---%s--->", __func__);
+
+	D_ASSERTF(ctx != NULL, "ctx=%p\n", ctx);
+
+	while (global_srv.shutdown == 0) {
+		rc = crt_progress(*ctx, 1000, NULL, NULL);
+		if (rc != 0 && rc != -DER_TIMEDOUT) {
+			D_ERROR("crt_progress() failed rc=%d\n", rc);
+			break;
+		}
+	}
+
+	dbg("<---%s---", __func__);
+	return NULL;
+}
+
+static void srv_fini(void)
+{
+	int rc = 0;
+
+	dbg("---%s--->", __func__);
+
+	global_srv.shutdown = 1;
+	dbg("main thread wait progress thread...");
+
+	if (global_srv.progress_thid)
+		pthread_join(global_srv.progress_thid, NULL);
+
+	rc = crt_context_destroy(global_srv.crt_ctx, true);
+	D_ASSERTF(rc == 0, "crt_context_destroy failed rc=%d\n", rc);
+
+	rc = crt_finalize();
+	D_ASSERTF(rc == 0, "crt_finalize failed rc=%d\n", rc);
+
+	dbg("<---%s---", __func__);
+}
+
+static int srv_init(void)
+{
+	int rc = 0;
+
+	dbg("---%s--->", __func__);
+
+	rc = crt_init(CRT_DEFAULT_SRV_GRPID, CRT_FLAG_BIT_SERVER);
+	D_ASSERTF(rc == 0, " crt_init failed %d\n", rc);
+
+	rc = crt_proto_register(&test_proto_fmt);
+	D_ASSERT(rc == 0);
+
+	rc = crt_group_rank(NULL, &global_srv.my_rank);
+	D_ASSERTF(rc == 0, "crt_group_rank failed %d\n", rc);
+
+	rc = crt_group_size(NULL, &global_srv.grp_size);
+	D_ASSERTF(rc == 0, "crt_group_size failed %d\n", rc);
+
+	rc = crt_context_create(&global_srv.crt_ctx);
+	D_ASSERTF(rc == 0, "crt_context_create() failed %d\n", rc);
+
+	/* create progress thread */
+	rc = pthread_create(&global_srv.progress_thid, NULL,
+			    srv_progress, &global_srv.crt_ctx);
+	if (rc != 0)
+		D_ERROR("progress thread creating failed, rc=%d\n", rc);
+
+	dbg("my_rank=%u, group_size=%u srv_pid=%d",
+	    global_srv.my_rank, global_srv.grp_size, getpid());
+
+	dbg("<---%s---", __func__);
+	return rc;
+}
+
+int main(int argc, char *argv[])
+{
+	int i, rc;
+
+	dbg("---%s--->", __func__);
+
+	/* default value */
+
+	srv_init();
+
+	/* print the state of all members from all targets */
+	while (!global_srv.shutdown) {
+		for (i = 0; i < global_srv.grp_size; i++) {
+			if (i != global_srv.my_rank) {
+				rc = test_send_rpc(i);
+				if (rc)
+					break;
+			}
+		}
+		if (rc)
+			break;
+		sched_yield();
+	}
+
+	sleep(5); /* wait until other threads complete */
+	srv_fini();
+
+	dbg("<---%s---", __func__);
+	return 0;
+}

--- a/src/utest/SConscript
+++ b/src/utest/SConscript
@@ -38,7 +38,7 @@
 
 import os
 
-TEST_SRC = ['test_gurt_v1.c', 'test_linkage.cpp', 'test_gurt.c']
+TEST_SRC = ['test_gurt_v1.c', 'test_linkage.cpp', 'test_gurt.c', 'utest_hlc.c']
 WRAPPERS = {'test_linkage.cpp':['PMIx_Init', 'PMIx_Get',
                                 'PMIx_Publish', 'PMIx_Lookup',
                                 'PMIx_Fence', 'PMIx_Unpublish',
@@ -69,7 +69,7 @@ def scons():
         return
 
     test_env = env.Clone()
-    prereqs.require(test_env, "pmix", "mercury", "uuid", "cmocka")
+    prereqs.require(test_env, "pmix", "mercury", "openpa", "uuid", "cmocka")
     test_env.AppendUnique(LIBS=['pthread'])
     test_env.AppendUnique(CPPPATH=['../include'])
     test_env.AppendUnique(CXXFLAGS=['-std=c++0x'])


### PR DESCRIPTION
Inserted HLC timestamps to all RPCs send and received.
This allow to arrange them according the time.

For example, when you sent a RPC and got a reply you will know both
timestamps when this happens comparing to different RPCs.

uint64_t send_time    = crt_hlc_send_get(rpc);
uint64_t receive_time = crt_hlc_receive_get(rpc);

On server side you will know the time when this RPC was received on
server from crt_hlc_receive_get(rpc) function. And when this RPC was
sent by source node from crt_hlc_send_get(rpc) function.

So, you always have both times and can calculate the time when this
RPC was in flight. The time is consistent across all nodes.

Change-Id: I90752ec68b538a4e4ed2ee0ea01345d04505f331
Signed-off-by: Dmitry Eremin <dmitry.eremin@intel.com>