### PR TITLE
CART-584 log: Cleanup some log functions

### DIFF
--- a/src/SConscript
+++ b/src/SConscript
@@ -40,7 +40,7 @@ import os
 
 HEADERS = ['api.h', 'iv.h', 'types.h', 'swim.h']
 HEADERS_GURT = ['dlog.h', 'debug.h', 'common.h', 'hash.h', 'list.h',
-                'heap.h', 'errno.h', 'fault_inject.h']
+                'heap.h', 'errno.h', 'fault_inject.h', 'debug_setup.h']
 
 def scons():
     """Scons function"""

--- a/src/cart/crt_debug.h
+++ b/src/cart/crt_debug.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2016-2018 Intel Corporation
+/* Copyright (C) 2016-2019 Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -38,8 +38,8 @@
 
 #ifndef __CRT_DEBUG_H__
 #define __CRT_DEBUG_H__
-
-#define DD_FAC(name)	(d_##name##_logfac)
+#include <gurt/dlog.h>
+#include <gurt/debug.h>
 
 extern int DD_FAC(rpc);
 extern int DD_FAC(bulk);

--- a/src/gurt/debug.c
+++ b/src/gurt/debug.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2016-2018 Intel Corporation
+/* Copyright (C) 2016-2019 Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -57,29 +57,29 @@ void (*d_alt_assert)(const int, const char*, const char*, const int);
 /*
  * Debug bits for common logic paths, can only have up to 16 different bits.
  */
-uint64_t DB_ANY; /** generic messages, no classification */
+d_dbug_t DB_ANY; /** generic messages, no classification */
 /** function trace, tree/hash/lru operations, a very expensive one */
-uint64_t DB_TRACE;
-uint64_t DB_MEM; /**< memory operation */
-uint64_t DB_NET; /**< network operation */
-uint64_t DB_IO;	/**< object I/O */
-uint64_t DB_TEST; /**< test programs */
+d_dbug_t DB_TRACE;
+d_dbug_t DB_MEM; /**< memory operation */
+d_dbug_t DB_NET; /**< network operation */
+d_dbug_t DB_IO;	/**< object I/O */
+d_dbug_t DB_TEST; /**< test programs */
 /**
  * all of masks - can be used to set all streams, or used to log specific
  * messages by default.
  */
-uint64_t DB_ALL; /** < = DLOG_DBG */
+d_dbug_t DB_ALL; /** < = DLOG_DBG */
 /** Configurable debug bits (project-specific) */
-static uint64_t DB_OPT1;
-static uint64_t DB_OPT2;
-static uint64_t DB_OPT3;
-static uint64_t DB_OPT4;
-static uint64_t DB_OPT5;
-static uint64_t DB_OPT6;
-static uint64_t DB_OPT7;
-static uint64_t DB_OPT8;
-static uint64_t DB_OPT9;
-static uint64_t DB_OPT10;
+static d_dbug_t DB_OPT1;
+static d_dbug_t DB_OPT2;
+static d_dbug_t DB_OPT3;
+static d_dbug_t DB_OPT4;
+static d_dbug_t DB_OPT5;
+static d_dbug_t DB_OPT6;
+static d_dbug_t DB_OPT7;
+static d_dbug_t DB_OPT8;
+static d_dbug_t DB_OPT9;
+static d_dbug_t DB_OPT10;
 
 #define DBG_ENV_MAX_LEN	(32)
 
@@ -209,12 +209,12 @@ d_log_dbg_bit_dealloc(char *name)
  * \return		0 on success, -1 on error
  */
 int
-d_log_dbg_bit_alloc(uint64_t *dbgbit, char *name, char *lname)
+d_log_dbg_bit_alloc(d_dbug_t *dbgbit, char *name, char *lname)
 {
 	size_t		   name_sz;
 	size_t		   lname_sz;
 	int		   i;
-	uint64_t	   bit = 0;
+	d_dbug_t	   bit = 0;
 	struct d_debug_bit *d;
 
 	if (name == NULL || dbgbit == NULL)
@@ -330,7 +330,7 @@ d_log_dbg_grp_dealloc(char *name)
  * \return			0 on success, -1 on error
  */
 int
-d_log_dbg_grp_alloc(uint64_t dbgmask, char *grpname)
+d_log_dbg_grp_alloc(d_dbug_t dbgmask, char *grpname)
 {
 	int		   i;
 	size_t		   name_sz;
@@ -550,7 +550,7 @@ static inline int
 setup_dbg_namebit(void)
 {
 	struct d_debug_bit *d;
-	uint64_t	    allocd_dbg_bit;
+	d_dbug_t	    allocd_dbg_bit;
 	int		    i;
 	int		    rc;
 
@@ -577,7 +577,7 @@ setup_dbg_namebit(void)
 
 int
 d_log_init_adv(char *log_tag, char *log_file, unsigned int flavor,
-		 uint64_t def_mask, uint64_t err_mask)
+		 d_dbug_t def_mask, d_dbug_t err_mask)
 {
 	int rc = 0;
 
@@ -652,7 +652,7 @@ void d_log_fini(void)
  *
  * \return		0 on success, -1 on error
  */
-int d_log_getdbgbit(uint64_t *dbgbit, char *bitname)
+int d_log_getdbgbit(d_dbug_t *dbgbit, char *bitname)
 {
 	int		   i;
 	int		   num_dbg_bit_entries;

--- a/src/include/gurt/debug_setup.h
+++ b/src/include/gurt/debug_setup.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2018-2019 Intel Corporation
+/* Copyright (C) 2019 Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -35,92 +35,33 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-#include <semaphore.h>
 
-#include <gurt/common.h>
-#include <cart/api.h>
+#ifndef __GURT_DEBUG_SETUP_H__
+#define __GURT_DEBUG_SETUP_H__
 
-#include "test_proto_common.h"
+#include <gurt/dlog.h>
+/**
+ * \file
+ * Debug macros and functions
+ */
 
-static void
-test_init()
-{
-	uint32_t	flag;
-	int		rc;
+/** @addtogroup GURT_DEBUG
+ * @{
+ */
+#define DD_FAC(name)	(d_##name##_logfac)
 
-	fprintf(stderr, "local group: %s remote group: %s\n",
-		test.tg_local_group_name, test.tg_remote_group_name);
+#ifndef D_LOGFAC
+#define D_LOGFAC	DD_FAC(misc)
+#endif
 
-	rc = d_log_init();
-	assert(rc == 0);
+extern d_dbug_t DB_ANY;
+extern d_dbug_t DB_TRACE;
+extern d_dbug_t DB_MEM;
+extern d_dbug_t DB_NET;
+extern d_dbug_t DB_IO;
+extern d_dbug_t DB_TEST;
+extern d_dbug_t DB_ALL;
 
-	rc = sem_init(&test.tg_token_to_proceed, 0, 0);
-	D_ASSERTF(rc == 0, "sem_init() failed.\n");
-
-	flag = test.tg_is_service ? CRT_FLAG_BIT_SERVER : 0;
-	rc = crt_init(test.tg_local_group_name, flag);
-	D_ASSERTF(rc == 0, "crt_init() failed, rc: %d\n", rc);
-
-	rc = crt_group_rank(NULL, &test.tg_my_rank);
-	D_ASSERTF(rc == 0, "crt_group_rank() failed. rc: %d\n", rc);
-
-	rc = crt_proto_register(&my_proto_fmt_0);
-	D_ASSERT(rc == 0);
-	rc = crt_proto_register(&my_proto_fmt_1);
-	D_ASSERT(rc == 0);
-
-	rc = crt_context_create(&test.tg_crt_ctx);
-	D_ASSERTF(rc == 0, "crt_context_create() failed. rc: %d\n", rc);
-
-	rc = pthread_create(&test.tg_tid, NULL, progress_thread,
-			    &test.tg_thread_id);
-	D_ASSERTF(rc == 0, "pthread_create() failed. rc: %d\n", rc);
-}
-
-static void
-test_run()
-{
-	D_DEBUG(DB_TRACE, "test_run\n");
-}
-
-/************************************************/
-static void
-test_fini()
-{
-	int	rc;
-
-	rc = pthread_join(test.tg_tid, NULL);
-	D_ASSERTF(rc == 0, "pthread_join failed. rc: %d\n", rc);
-	D_DEBUG(DB_TRACE, "joined progress thread.\n");
-
-
-	rc = crt_context_destroy(test.tg_crt_ctx, 0);
-	D_ASSERTF(rc == 0, "crt_context_destroy() failed. rc: %d\n", rc);
-
-	rc = sem_destroy(&test.tg_token_to_proceed);
-	D_ASSERTF(rc == 0, "sem_destroy() failed.\n");
-
-	rc = crt_finalize();
-	D_ASSERTF(rc == 0, "crt_finalize() failed. rc: %d\n", rc);
-	D_DEBUG(DB_TRACE, "exiting.\n");
-
-	d_log_fini();
-}
-
-int
-main(int argc, char **argv)
-{
-	int	rc;
-
-	rc = test_parse_args(argc, argv);
-	if (rc != 0) {
-		fprintf(stderr, "test_parse_args() failed, rc: %d.\n", rc);
-		return rc;
-	}
-
-	test_init();
-	test_run();
-	test_fini();
-
-	return rc;
-}
+/** @}
+ */
+#endif /* __GURT_DEBUG_SETUP_H__ */

--- a/src/include/gurt/dlog.h
+++ b/src/include/gurt/dlog.h
@@ -81,6 +81,14 @@
 #include <stdbool.h>
 #include <stdlib.h>
 
+/** Define a typedef for the debug bits.   The log mask is only 32-bits but
+ *  for whatever reason, the debug mask is 64-bits.   In order to maintain
+ *  compatibility, redefine it to a 64-bit type which we can change to 32
+ *  once downstream libraries have upgraded.  Also, choose a type that is
+ *  the same length as the original.
+ */
+typedef uint64_t d_dbug_t;
+
 /* clog open flavor */
 #define DLOG_FLV_LOGPID	(1 << 0)	/**< include pid in log tag */
 #define DLOG_FLV_FQDN	(1 << 1)	/**< log fully quallified domain name */
@@ -137,15 +145,15 @@ struct d_log_xstate {
 	char			*tag; /**< tag string */
 	/* note that tag is NULL if clog is not open/inited */
 	struct dlog_fac		*dlog_facs; /**< array of facility */
-	int			 fac_cnt; /**< # of facilities */
 	char			*nodename; /**< pointer to our utsname */
+	int			 fac_cnt; /**< # of facilities */
 };
 
 struct d_debug_data {
 	/** debug bitmask, e.g. DB_IO */
-	uint64_t		dd_mask;
+	d_dbug_t		dd_mask;
 	/** priority level that should be output to stderr */
-	uint64_t		dd_prio_err;
+	d_dbug_t		dd_prio_err;
 	/** alloc'd debug bit count */
 	int			dbg_bit_cnt;
 	/** alloc'd debug group count */
@@ -162,7 +170,7 @@ struct d_debug_data {
  */
 struct d_debug_priority {
 	char			*dd_name;
-	uint64_t		 dd_prio;
+	d_dbug_t		 dd_prio;
 	size_t			 dd_name_size;
 };
 
@@ -171,7 +179,7 @@ struct d_debug_priority {
  * of the system, e.g. DB_MEM, DB_IO, DB_TRACE...
  */
 struct d_debug_bit {
-	uint64_t		*db_bit;
+	d_dbug_t		*db_bit;
 	char			*db_name;
 	char			*db_lname;
 	size_t			 db_name_size;
@@ -185,7 +193,7 @@ struct d_debug_bit {
 struct d_debug_grp {
 	char			*dg_name;
 	size_t			 dg_name_size;
-	uint64_t		 dg_mask;
+	d_dbug_t		 dg_mask;
 };
 
 #if defined(__cplusplus)
@@ -214,7 +222,7 @@ int d_log_dbg_bit_dealloc(char *name);
  * \return		0 on success, -1 on error
  *
  */
-int d_log_dbg_bit_alloc(uint64_t *dbgbit, char *name, char *lname);
+int d_log_dbg_bit_alloc(d_dbug_t *dbgbit, char *name, char *lname);
 
 /**
  * Reset optional debug group
@@ -233,7 +241,7 @@ int d_log_dbg_grp_dealloc(char *grpname);
  *
  * \return		0 on success, -1 on error
  */
-int d_log_dbg_grp_alloc(uint64_t dbgmask, char *grpname);
+int d_log_dbg_grp_alloc(d_dbug_t dbgmask, char *grpname);
 
 /**
  * log a message using stdarg list without checking filtering
@@ -365,7 +373,7 @@ int d_log_init(void);
  * \return			0 on success, -1 on failure
  */
 int d_log_init_adv(char *log_tag, char *log_file, unsigned int flavor,
-		     uint64_t def_mask, uint64_t err_mask);
+		     d_dbug_t def_mask, d_dbug_t err_mask);
 
 /**
  * Remove a reference on the default cart log.  Calls d_log_close

--- a/src/swim/swim.c
+++ b/src/swim/swim.c
@@ -36,9 +36,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-#define DD_FAC(name)	(d_##name##_logfac)
 #define D_LOGFAC	DD_FAC(swim)
-extern int DD_FAC(swim);
 
 #include "swim_internal.h"
 #include <assert.h>

--- a/src/swim/swim_internal.h
+++ b/src/swim/swim_internal.h
@@ -1,5 +1,5 @@
 /* Copyright (c) 2016 UChicago Argonne, LLC
- * Copyright (C) 2018 Intel Corporation
+ * Copyright (C) 2018-2019 Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -54,6 +54,7 @@
 #include <time.h>
 
 #include <cart/swim.h>
+#include <gurt/debug.h>
 #include <gurt/common.h>
 
 /* Use debug capability from CaRT */

--- a/src/test/crt_echo.h
+++ b/src/test/crt_echo.h
@@ -195,6 +195,9 @@ echo_init(int server, bool tier2)
 	struct crt_proto_format *cpf;
 	char *name;
 
+	rc = d_log_init();
+	assert(rc == 0);
+
 	/* Put the protocol name into a char * to avoid compiler warnings about
 	 * const use
 	 */
@@ -321,6 +324,8 @@ echo_fini(void)
 
 	rc = crt_finalize();
 	assert(rc == 0);
+
+	d_log_fini();
 }
 
 /* convert to string just to facilitate the pack/unpack */

--- a/src/test/rpc_test_cli.c
+++ b/src/test/rpc_test_cli.c
@@ -1,5 +1,4 @@
-
-/* Copyright (C) 2017 Intel Corporation
+/* Copyright (C) 2017-2019 Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -587,6 +586,7 @@ main(int argc, char *argv[])
 {
 	int	ch;
 
+	assert(d_log_init() == 0);
 	dbg("---%s--->", __func__);
 
 	dbg("cli_pid:=%d", getpid());
@@ -632,5 +632,6 @@ main(int argc, char *argv[])
 	cli_rpc_finalize();
 
 	dbg("<---%s---", __func__);
+	d_log_fini();
 	return 0;
 } /* main */

--- a/src/test/rpc_test_srv.c
+++ b/src/test/rpc_test_srv.c
@@ -1,5 +1,4 @@
-
-/* Copyright (C) 2017-2018 Intel Corporation
+/* Copyright (C) 2017-2019 Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -616,6 +615,8 @@ main(int argc, char *argv[])
 {
 	int	ch;
 
+	assert(d_log_init() == 0);
+
 	dbg("---%s--->", __func__);
 
 	dbg("srv_pid:=%d", getpid());
@@ -655,6 +656,7 @@ main(int argc, char *argv[])
 	srv_rpc_finalize();
 
 	dbg("<---%s---", __func__);
+	d_log_fini();
 
 	return 0;
 } /* main */

--- a/src/test/rpc_test_srv2.c
+++ b/src/test/rpc_test_srv2.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2017-2018 Intel Corporation
+/* Copyright (C) 2017-2019 Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -253,6 +253,7 @@ main(int argc, char *argv[])
 {
 	int	ch;
 
+	assert(d_log_init() == 0);
 	dbg("---%s--->", __func__);
 
 	dbg("srv2_pid:=%d", getpid());
@@ -291,6 +292,7 @@ main(int argc, char *argv[])
 	srv_rpc_finalize();
 
 	dbg("<---%s---", __func__);
+	d_log_fini();
 
 	return 0;
 } /*main*/

--- a/src/test/test_corpc_prefwd.c
+++ b/src/test/test_corpc_prefwd.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2018 Intel Corporation
+/* Copyright (C) 2018-2019 Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -125,6 +125,9 @@ int main(void)
 	excluded_membs.rl_nr = 1;
 	excluded_membs.rl_ranks = &excluded_ranks;
 
+	rc = d_log_init();
+	assert(rc == 0);
+
 	rc = crt_init(NULL, CRT_FLAG_BIT_SERVER);
 	assert(rc == 0);
 
@@ -171,6 +174,8 @@ int main(void)
 
 	rc = crt_finalize();
 	assert(rc == 0);
+
+	d_log_fini();
 
 	return 0;
 }

--- a/src/test/test_corpc_version.c
+++ b/src/test/test_corpc_version.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2017-2018 Intel Corporation
+/* Copyright (C) 2017-2019 Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -574,6 +574,9 @@ test_init(void)
 	int		rc = 0;
 	uint32_t	flag;
 
+	rc = d_log_init();
+	assert(rc == 0);
+
 	D_DEBUG(DB_TEST, "local group: %s, target group: %s\n",
 		test.t_local_group_name,
 		test.t_target_group_name ? test.t_target_group_name : "NULL\n");
@@ -658,6 +661,8 @@ test_fini()
 	D_ASSERTF(rc == 0, "crt_context_destroy() failed. rc: %d\n", rc);
 	rc = crt_finalize();
 	D_ASSERTF(rc == 0, "crt_finalize() failed. rc: %d\n", rc);
+
+	d_log_fini();
 }
 
 int main(int argc, char **argv)

--- a/src/test/test_crt_barrier.c
+++ b/src/test/test_crt_barrier.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2017 Intel Corporation
+/* Copyright (C) 2017-2019 Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -127,6 +127,9 @@ int main(int argc, char **argv)
 	int			i;
 	pthread_t		tid;
 
+	rc = d_log_init();
+	assert(rc == 0);
+
 	printf("Calling crt_init()\n");
 	rc = crt_init("crt_barrier_group", CRT_FLAG_BIT_SERVER);
 	D_ASSERTF(rc == 0, "Failed in crt_init, rc = %d\n", rc);
@@ -174,6 +177,8 @@ int main(int argc, char **argv)
 	crt_context_destroy(crt_ctx, 0);
 	rc = crt_finalize();
 	D_ASSERTF(rc == 0, "Failed in crt_finalize, rc = %d\n", rc);
+
+	d_log_fini();
 
 	free(info);
 

--- a/src/test/test_group.c
+++ b/src/test/test_group.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2016-2018 Intel Corporation
+/* Copyright (C) 2016-2019 Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -278,6 +278,12 @@ test_init(void)
 	fprintf(stderr, "local group: %s remote group: %s\n",
 		test_g.t_local_group_name, test_g.t_remote_group_name);
 
+	/* In order to use things like D_ASSERTF, logging needs to be active
+	 * even if cart is not
+	 */
+	rc = d_log_init();
+	D_ASSERT(rc == 0);
+
 	rc = sem_init(&test_g.t_token_to_proceed, 0, 0);
 	D_ASSERTF(rc == 0, "sem_init() failed.\n");
 
@@ -497,6 +503,9 @@ test_fini()
 
 	rc = crt_finalize();
 	D_ASSERTF(rc == 0, "crt_finalize() failed. rc: %d\n", rc);
+
+	d_log_fini();
+
 	D_DEBUG(DB_TEST, "exiting.\n");
 }
 

--- a/src/test/test_no_pmix.c
+++ b/src/test/test_no_pmix.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2018 Intel Corporation
+/* Copyright (C) 2018-2019 Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -758,6 +758,9 @@ int main(int argc, char **argv)
 		return -1;
 	}
 
+	rc = d_log_init();
+	assert(rc == 0);
+
 	DBG_PRINT("Self rank = %d\n", opts.self_rank);
 
 	rc = sem_init(&token_to_proceed, 0, 0);
@@ -1124,6 +1127,8 @@ int main(int argc, char **argv)
 		D_ERROR("sem_destroy() failed; rc=%d\n", rc);
 		assert(0);
 	}
+
+	d_log_fini();
 
 	DBG_PRINT("Destroyed semaphore. Exiting\n");
 	DBG_PRINT("---------------------------------\n");

--- a/src/test/test_no_timeout.c
+++ b/src/test/test_no_timeout.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2018 Intel Corporation
+/* Copyright (C) 2018-2019 Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -192,6 +192,9 @@ test_init(void)
 	fprintf(stderr, "local group: %s remote group: %s\n",
 		test_g.t_local_group_name, test_g.t_remote_group_name);
 
+	rc = d_log_init();
+	assert(rc == 0);
+
 	rc = sem_init(&test_g.t_token_to_proceed, 0, 0);
 	D_ASSERTF(rc == 0, "sem_init() failed.\n");
 
@@ -365,6 +368,7 @@ test_fini()
 	D_ASSERTF(rc == 0, "crt_finalize() failed. rc: %d\n", rc);
 	D_DEBUG(DB_TEST, "exiting.\n");
 
+	d_log_fini();
 }
 
 int

--- a/src/test/test_proto_client.c
+++ b/src/test/test_proto_client.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2018 Intel Corporation
+/* Copyright (C) 2018-2019 Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -79,6 +79,9 @@ test_init()
 
 	fprintf(stderr, "local group: %s remote group: %s\n",
 		test.tg_local_group_name, test.tg_remote_group_name);
+
+	rc = d_log_init();
+	assert(rc == 0);
 
 	rc = sem_init(&test.tg_token_to_proceed, 0, 0);
 	D_ASSERTF(rc == 0, "sem_init() failed.\n");
@@ -240,6 +243,8 @@ test_fini()
 	rc = crt_finalize();
 	D_ASSERTF(rc == 0, "crt_finalize() failed. rc: %d\n", rc);
 	D_DEBUG(DB_TRACE, "exiting.\n");
+
+	d_log_fini();
 }
 
 int

--- a/src/test/test_rpc_error.c
+++ b/src/test/test_rpc_error.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2017-2018 Intel Corporation
+/* Copyright (C) 2017-2019 Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -195,6 +195,9 @@ rpc_err_init(void)
 		rpc_err.re_local_group_name,
 		rpc_err.re_target_group_name);
 
+	rc = d_log_init();
+	assert(rc == 0);
+
 	flag = rpc_err.re_is_service ? CRT_FLAG_BIT_SERVER : 0;
 	rc = crt_init(rpc_err.re_local_group_name, flag);
 	D_ASSERTF(rc == 0, "crt_init() failed, rc: %d\n", rc);
@@ -238,6 +241,8 @@ rpc_err_fini()
 	D_ASSERTF(rc == 0, "crt_context_destroy() failed. rc: %d\n", rc);
 	rc = crt_finalize();
 	D_ASSERTF(rc == 0, "crt_finalize() failed. rc: %d\n", rc);
+
+	d_log_fini();
 }
 
 static void

--- a/src/test/test_swim_net.c
+++ b/src/test/test_swim_net.c
@@ -436,6 +436,8 @@ int main(int argc, char *argv[])
 	enum swim_member_status s;
 	int t, j;
 
+	assert(d_log_init() == 0);
+
 	dbg("---%s--->", __func__);
 
 	/* default value */
@@ -464,5 +466,6 @@ int main(int argc, char *argv[])
 	srv_fini();
 
 	dbg("<---%s---", __func__);
+	d_log_fini();
 	return 0;
 }

--- a/src/test/threaded_client.c
+++ b/src/test/threaded_client.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2017 Intel Corporation
+/* Copyright (C) 2017-2019 Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -198,6 +198,9 @@ int main(int argc, char **argv)
 	int			 status = RESET;
 	int			 i;
 
+	saved_rc = d_log_init();
+	assert(saved_rc == 0);
+
 	saved_rc = crt_init(NULL, 0);
 	if (saved_rc != 0) {
 		printf("Could not start server, rc = %d", saved_rc);
@@ -268,6 +271,8 @@ int main(int argc, char **argv)
 	check_return(crt_group_detach(grp), saved_rc);
 	check_return(crt_context_destroy(crt_ctx, false), saved_rc);
 	check_return(crt_finalize(), saved_rc);
+
+	d_log_fini();
 
 	return saved_rc;
 }

--- a/src/test/threaded_server.c
+++ b/src/test/threaded_server.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2017-2018 Intel Corporation
+/* Copyright (C) 2017-2019 Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -122,6 +122,9 @@ int main(int argc, char **argv)
 	int			rc;
 	int			i;
 
+	rc = d_log_init();
+	assert(rc == 0);
+
 	rc = crt_init("manyserver", CRT_FLAG_BIT_SERVER);
 	if (rc != 0) {
 		printf("Could not start server, rc = %d", rc);
@@ -161,6 +164,8 @@ int main(int argc, char **argv)
 
 	crt_context_destroy(crt_ctx, false);
 	crt_finalize();
+
+	d_log_fini();
 
 	return 0;
 }

--- a/utils/run_test.sh
+++ b/utils/run_test.sh
@@ -68,19 +68,26 @@ JENKINS_TEST_LIST=(scripts/cart_echo_test.yml                   \
 # Check for symbol names in the library.
 if [ -d "utils" ]; then
   utils/test_cart_lib.sh
+  build_vars="./.build_vars-Linux.sh"
 else
   ./test_cart_lib.sh
+  build_vars="../.build_vars-Linux.sh"
 fi
 # Run the tests from the install TESTING directory
 if [ -z "$CART_TEST_MODE"  ]; then
   CART_TEST_MODE="native"
 fi
 
-if [ -n "$COMP_PREFIX"  ]; then
-  TESTDIR=${COMP_PREFIX}/TESTING
-else
-  TESTDIR="install/Linux/TESTING"
+if [ -z "$COMP_PREFIX"  ]; then
+  COMP_PREFIX="install/Linux"
+  if [ -f "${build_vars}" ]; then
+    source "${build_vars}"
+    COMP_PREFIX="$SL_PREFIX"
+  fi
 fi
+
+TESTDIR=${COMP_PREFIX}/TESTING
+
 if [[ "$CART_TEST_MODE" =~ (native|all) ]]; then
   echo "Nothing to do yet, wish we could fail some tests"
   if ${RUN_UTEST:-true}; then


### PR DESCRIPTION
1. Consolidate D_DEBUG and D_TRACE, utilizing common macros.
2. typedef the erroneous 64-bit debug mask (masks can only be
   32-bits in the logger but to maintain backwards
   compatibility, we add a typedef which can be made 32-bit
   once libraries are using it.
3. Avoid using D_ERROR in code that may be executed prior
   to logging being active

Change-Id: Ib6129a29ca75c9bafb2e94679f93b537f9f68a52
Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>