### PR TITLE
CART-585 self-test: Use the correct RPC defenitions in self-test.

### DIFF
--- a/src/cart/crt_rpc.h
+++ b/src/cart/crt_rpc.h
@@ -339,12 +339,18 @@ CRT_RPC_DECLARE(crt_grp_destroy, CRT_ISEQ_GRP_DESTROY, CRT_OSEQ_GRP_DESTROY)
 
 CRT_RPC_DECLARE(crt_uri_lookup, CRT_ISEQ_URI_LOOKUP, CRT_OSEQ_URI_LOOKUP)
 
+/*
+ * Note that for these non-empty send structures the session_id is always
+ * the first value. This allows the session to be retrieved without knowing
+ * what the rest of the structure contains
+ */
+
 #define CRT_ISEQ_ST_SEND_ID	/* input fields */		 \
 	((uint64_t)		(unused1)		CRT_VAR)
 
 #define CRT_ISEQ_ST_SEND_ID_IOV	/* input fields */		 \
-	((uint64_t)		(unused1)		CRT_VAR) \
-	((d_iov_t)		(unused2)		CRT_VAR)
+	((int64_t)		(session_id)		CRT_VAR) \
+	((d_iov_t)		(buf)			CRT_VAR)
 
 #define CRT_ISEQ_ST_SEND_ID_IOV_BULK /* input fields */		 \
 	((uint64_t)		(unused1)		CRT_VAR) \

--- a/src/cart/crt_self_test.h
+++ b/src/cart/crt_self_test.h
@@ -194,17 +194,6 @@ enum crt_st_status {
 	CRT_ST_STATUS_TEST_COMPLETE_WITH_ERRORS = 1,
 };
 
-/*
- * Note that for these non-empty send structures the session_id is always
- * the first value. This allows the session to be retrieved without knowing
- * what the rest of the structure contains
- */
-
-struct crt_st_send_id_iov {
-	int64_t		session_id;
-	d_iov_t		buf;
-};
-
 struct crt_st_send_id_iov_bulk {
 	int64_t		session_id;
 	d_iov_t		buf;

--- a/src/cart/crt_self_test_client.c
+++ b/src/cart/crt_self_test_client.c
@@ -315,7 +315,7 @@ static void close_sessions(void)
 static void send_next_rpc(struct st_cb_args *cb_args, int skip_inc_complete)
 {
 	crt_rpc_t		*new_rpc;
-	void			*args = NULL;
+	void			*args;
 	crt_endpoint_t		 local_endpt = {0};
 	struct st_test_endpt	*endpt_ptr;
 	crt_opcode_t		 opcode;
@@ -435,8 +435,7 @@ static void send_next_rpc(struct st_cb_args *cb_args, int skip_inc_complete)
 		case CRT_OPC_SELF_TEST_SEND_IOV_REPLY_EMPTY:
 		case CRT_OPC_SELF_TEST_BOTH_IOV:
 			{
-				struct crt_st_send_id_iov *typed_args =
-					(struct crt_st_send_id_iov *)args;
+				struct crt_st_both_iov_in *typed_args = args;
 
 				D_ASSERT(cb_args->buf_len >= g_data->send_size);
 				d_iov_set(&typed_args->buf,
@@ -447,8 +446,7 @@ static void send_next_rpc(struct st_cb_args *cb_args, int skip_inc_complete)
 			break;
 		case CRT_OPC_SELF_TEST_SEND_IOV_REPLY_BULK:
 			{
-				struct crt_st_send_id_iov_bulk *typed_args =
-					(struct crt_st_send_id_iov_bulk *)args;
+				struct crt_st_send_id_iov_bulk *typed_args = args;
 
 				D_ASSERT(cb_args->buf_len >= g_data->send_size);
 				d_iov_set(&typed_args->buf,
@@ -462,8 +460,7 @@ static void send_next_rpc(struct st_cb_args *cb_args, int skip_inc_complete)
 		case CRT_OPC_SELF_TEST_SEND_BULK_REPLY_IOV:
 		case CRT_OPC_SELF_TEST_BOTH_BULK:
 			{
-				struct crt_st_send_id_bulk *typed_args =
-					(struct crt_st_send_id_bulk *)args;
+				struct crt_st_send_id_bulk *typed_args = args;
 
 				typed_args->bulk_hdl = cb_args->bulk_hdl;
 				D_ASSERT(typed_args->bulk_hdl != CRT_BULK_NULL);


### PR DESCRIPTION
The RPC definitions are automaticly created by the RPC macros so use
these rather than redefining them in the header files.

Change-Id: Iaf0a8417901787f56604fb92e29ea0083f11f9b1
Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>