### PR TITLE
CART-89 fix: hg_addr was not freed during unreachable case

### DIFF
--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -364,7 +364,7 @@ do_init:
 		}
 
 		if (crt_is_service()) {
-			rc = crt_swim_init(CRT_DETAULT_PROGRESS_CTX_IDX);
+			rc = crt_swim_init(CRT_DEFAULT_PROGRESS_CTX_IDX);
 			if (rc) {
 				D_ERROR("crt_swim_init() failed rc: %d.\n", rc);
 				crt_lm_finalize();

--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -508,16 +508,18 @@ crt_req_hg_addr_lookup_cb(hg_addr_t hg_addr, void *arg)
 	rank = rpc_priv->crp_pub.cr_ep.ep_rank;
 	tag = rpc_priv->crp_pub.cr_ep.ep_tag;
 
+	crt_ctx = rpc_priv->crp_pub.cr_ctx;
 	if (rpc_priv->crp_state == RPC_STATE_FWD_UNREACH) {
 		RPC_ERROR(rpc_priv,
 			  "opc: %#x with status of FWD_UNREACH\n",
 			  rpc_priv->crp_pub.cr_opc);
+		/* Valid hg_addr gets passed despite unreachable state */
+		crt_hg_addr_free(&crt_ctx->cc_hg_ctx, hg_addr);
 		D_GOTO(unreach, rc);
 	}
 
 	grp_priv = crt_grp_pub2priv(rpc_priv->crp_pub.cr_ep.ep_grp);
 
-	crt_ctx = rpc_priv->crp_pub.cr_ctx;
 	ctx_idx = crt_ctx->cc_idx;
 
 	rc = crt_grp_lc_addr_insert(grp_priv, crt_ctx, rank, tag, &hg_addr);

--- a/src/cart/crt_swim.h
+++ b/src/cart/crt_swim.h
@@ -48,7 +48,7 @@
 #define CRT_SWIM_RPC_TIMEOUT		1	/* 1 sec */
 #define CRT_SWIM_FLUSH_ATTEMPTS		10
 #define CRT_SWIM_PROGRESS_TIMEOUT	0	/* minimal progressing time */
-#define CRT_DETAULT_PROGRESS_CTX_IDX	0
+#define CRT_DEFAULT_PROGRESS_CTX_IDX	0
 
 struct crt_swim_target {
 	d_circleq_entry(crt_swim_target) cst_link;


### PR DESCRIPTION
- hg_addr was not free-ed during sitaution when rpc was marked as
unreachable. This resulted in leaked addr which prevented hg_ctx
from being destroyed

- fixed typo in macro name

Change-Id: I026ee77e2305975b2b207fa701ae712748211923
Signed-off-by: Alex Oganezov <alexander.a.oganezov@intel.com>