### PR TITLE
CART-584 log: Add a simple boolean macro for a log mask

### DIFF
--- a/src/include/gurt/debug.h
+++ b/src/include/gurt/debug.h
@@ -160,6 +160,12 @@ extern void (*d_alt_assert)(const int, const char*, const char*, const int);
 			func(DD_FLAG(flag, D_LOGFAC), ##__VA_ARGS__);	   \
 		}							   \
 	} while (0)
+
+#define D_LOG_ENABLED(flag)					\
+	({							\
+		_D_DEBUG_V2(D_NOOP, flag);			\
+		__builtin_expect(DD_FLAG(flag, D_LOGFAC), 0);	\
+	})
 /**
  * New version of D_DEBUG which utilizes the facility cache to optimize
  * both negative and postive debug lookups
@@ -177,6 +183,8 @@ extern void (*d_alt_assert)(const int, const char*, const char*, const int);
 #else /* !D_LOG_USE_V2 */
 #define D_DEBUG D_DEBUG_V1
 #define D_TRACE_DEBUG D_TRACE_DEBUG_V1
+#define D_LOG_ENABLED(flag)			\
+	d_log_check((flag) | D_LOGFAC)
 #ifdef D_LOG_V1_TEST
 /** Define the new macro to a sane value so tests still work.  Otherwise, leave
  * it undefined as users shouldn't be using it without defining D_LOG_V2

--- a/src/utest/test_gurt.c
+++ b/src/utest/test_gurt.c
@@ -706,14 +706,20 @@ test_log(void **state)
 	D_DEBUG_V1(DB_TEST1, "V1: This message should appear\n");
 	D_DEBUG_V2(DB_TEST2, "V2: This message should NOT appear\n");
 	D_DEBUG_V1(DB_TEST2, "V1: This message should NOT appear\n");
+	assert_int_not_equal(D_LOG_ENABLED(DB_TEST1), 0);
+	assert_int_equal(D_LOG_ENABLED(DB_TEST2), 0);
 #undef D_LOGFAC
 #define D_LOGFAC	DD_FAC(foo)
 	D_DEBUG_V2(DB_TEST1, "V2: This message should NOT appear\n");
 	D_DEBUG_V1(DB_TEST1, "V1: This message should NOT appear\n");
+	assert_int_equal(D_LOG_ENABLED(DB_TEST2), 0);
+	assert_int_equal(D_LOG_ENABLED(DB_TEST1), 0);
 	d_log_sync_mask();
 	setenv("D_LOG_MASK", "foobar=DEBUG", 1);
 	setenv("DD_MASK", "test2_long", 1);
 	d_log_sync_mask();
+	assert_int_equal(D_LOG_ENABLED(DB_TEST1), 0);
+	assert_int_not_equal(D_LOG_ENABLED(DB_TEST2), 0);
 	D_DEBUG_V2(DB_TEST2, "V2: This message should appear\n");
 	D_DEBUG_V1(DB_TEST2, "V1: This message should appear\n");
 	D_DEBUG_V2(DB_TEST1, "V2: This message should NOT appear\n");


### PR DESCRIPTION
This can be useful at runtime if we want to disable logging in
large blocks of code at once (e.g. two versioned functions)

Change-Id: Ife139d0c1b17a1ac409d2dc86a1b838d86bedc54
Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>