### PR TITLE
CART-589 hg: Fix memory leak in crt_hg_addr_lookup()

### DIFF
--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -316,7 +316,8 @@ crt_hg_addr_lookup(struct crt_hg_context *hg_ctx, const char *name,
 	cb_args->al_arg = arg;
 	rc = HG_Addr_lookup(hg_ctx->chc_hgctx, crt_hg_addr_lookup_cb,
 			    cb_args, name, HG_OP_ID_IGNORE);
-	if (rc != 0) {
+	if (rc != HG_SUCCESS) {
+		D_FREE_PTR(cb_args);
 		D_ERROR("HG_Addr_lookup() failed.\n");
 		rc = -DER_HG;
 	}


### PR DESCRIPTION
The memory allocated for completion callback is not freed
in case of error in low level function call.

Change-Id: I60129ffb320a226bc3e7de7319dd09c934b00e8d
Signed-off-by: Dmitry Eremin <dmitry.eremin@intel.com>