### PR TITLE
CART-584 log: Remove d_ prefixed symbols from cart

### DIFF
--- a/src/cart/crt_debug.h
+++ b/src/cart/crt_debug.h
@@ -38,10 +38,20 @@
 
 #ifndef __CRT_DEBUG_H__
 #define __CRT_DEBUG_H__
+
+#ifndef CRT_USE_GURT_FAC
+#define DD_FAC(name)	crt_##name##_logfac
+#endif
+
+#ifndef D_LOGFAC
+#define D_LOGFAC DD_FAC(crt)
+#endif
+
 #include <gurt/dlog.h>
 #include <gurt/debug_setup.h>
 
 #define CRT_FOREACH_LOG_FAC(ACTION, arg)	\
+	ACTION(crt,   cart,        arg)	\
 	ACTION(rpc,   rpc,         arg)	\
 	ACTION(bulk,  bulk,        arg)	\
 	ACTION(corpc, corpc,       arg)	\
@@ -53,7 +63,9 @@
 	ACTION(iv,    iv,          arg)	\
 	ACTION(ctl,   ctl,         arg)
 
+#ifndef CRT_USE_GURT_FAC
 CRT_FOREACH_LOG_FAC(D_LOG_DECLARE_FAC, D_NOOP)
+#endif
 
 int crt_setup_log_fac(void);
 

--- a/src/cart/crt_swim.c
+++ b/src/cart/crt_swim.c
@@ -39,6 +39,7 @@
  * This file is part of CaRT. It implements the SWIM integration APIs.
  */
 #define D_LOGFAC	DD_FAC(swim)
+#define CRT_USE_GURT_FAC
 
 #include "crt_internal.h"
 

--- a/src/include/gurt/debug.h
+++ b/src/include/gurt/debug.h
@@ -222,7 +222,9 @@ extern void (*d_alt_assert)(const int, const char*, const char*, const int);
 #define D_TRACE_FATAL(ptr, fmt, ...)	\
 	D_TRACE_DEBUG(DLOG_EMERG, ptr, fmt, ## __VA_ARGS__)
 
+#ifdef D_USE_GURT_FAC
 D_FOREACH_GURT_FAC(D_LOG_DECLARE_FAC, D_NOOP)
+#endif /* D_USE_GURT_FAC */
 
 D_FOREACH_GURT_DB(D_LOG_DECLARE_DB, D_NOOP)
 

--- a/src/include/gurt/debug_setup.h
+++ b/src/include/gurt/debug_setup.h
@@ -51,12 +51,17 @@
 /** @addtogroup GURT_DEBUG
  * @{
  */
-#define DD_FAC(name)	d_##name##_logfac
+#define DD_GURT_FAC(name)	d_##name##_logfac
+#ifndef DD_FAC
+/** User definable facility name to variable name macro */
+#define DD_FAC	DD_GURT_FAC
+#define D_USE_GURT_FAC
+#endif /* !DD_FAC */
 
 #define DD_FAC_DECL(name)	DD_FAC(name)
 
 #ifndef D_LOGFAC
-#define D_LOGFAC	DD_FAC(misc)
+#define D_LOGFAC	DD_GURT_FAC(misc)
 #endif
 
 /** Arguments to priority bit macros are

--- a/utils/test_cart_lib.sh
+++ b/utils/test_cart_lib.sh
@@ -58,8 +58,6 @@ else
     nm -g "${SL_PREFIX}/lib/libcart.so" |
         grep -v " U " |  grep -v " w " |  grep -v " crt_" | grep -v " swim_" |
         grep -v "D CMF_" | grep -v "D CQF_" |
-        grep -v "\bd_\w*_logfac\b" |
-        grep -v "\bd_\w*_logfac_cache\b" |
         grep -v " D _edata" | grep -v " T _fini" | grep -v " T _init" |
         grep -v " B __bss_start" | grep -v " B _end";
     if [ $? -ne 1 ]; then RC=1; fi


### PR DESCRIPTION
We need to rework swim a bit but this works to use crt_ prefix for
cart log messages.   I defined a new "misc" for cart (crt) and use
it rather than letting gurt define its own.

Change-Id: I832ecce1d9f2b4dcea521c6abe69b4a0f1b5c56c
Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>