### PR TITLE
CART-89 build: Separate gurt/types.h from gurt/common.h

### DIFF
--- a/src/SConscript
+++ b/src/SConscript
@@ -40,7 +40,8 @@ import os
 
 HEADERS = ['api.h', 'iv.h', 'types.h', 'swim.h']
 HEADERS_GURT = ['dlog.h', 'debug.h', 'common.h', 'hash.h', 'list.h',
-                'heap.h', 'errno.h', 'fault_inject.h', 'debug_setup.h']
+                'heap.h', 'errno.h', 'fault_inject.h', 'debug_setup.h',
+                'types.h']
 
 def scons():
     """Scons function"""

--- a/src/include/cart/types.h
+++ b/src/include/cart/types.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2016-2018 Intel Corporation
+/* Copyright (C) 2016-2019 Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -51,8 +51,7 @@
 #define __CRT_TYPES_H__
 
 #include <stdint.h>
-#include <gurt/common.h>
-#include <gurt/list.h>
+#include <gurt/types.h>
 
 #include <boost/preprocessor.hpp>
 

--- a/src/include/gurt/common.h
+++ b/src/include/gurt/common.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2016-2018 Intel Corporation
+/* Copyright (C) 2016-2019 Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -59,6 +59,7 @@
 #include <pthread.h>
 #include <byteswap.h>
 
+#include <gurt/types.h>
 #include <gurt/errno.h>
 #include <gurt/debug.h>
 #include <gurt/fault_inject.h>
@@ -76,52 +77,6 @@ extern "C" {
  * param[out] ts A timespec structure for the result
  */
 #define _gurt_gettime(ts) clock_gettime(CLOCK_MONOTONIC, ts)
-
-/**
- * hide the dark secret that uuid_t is an array not a structure.
- */
-struct d_uuid {
-	uuid_t		uuid;
-};
-
-/** iovec for memory buffer */
-typedef struct {
-	/** buffer address */
-	void		*iov_buf;
-	/** buffer length */
-	size_t		iov_buf_len;
-	/** data length */
-	size_t		iov_len;
-} d_iov_t;
-
-/** Server identification */
-typedef uint32_t	d_rank_t;
-
-typedef struct {
-	/** list of ranks */
-	d_rank_t	*rl_ranks;
-	/** number of ranks */
-	uint32_t	rl_nr;
-} d_rank_list_t;
-
-typedef d_rank_list_t	*d_rank_list_ptr_t;
-
-typedef char		*d_string_t;
-typedef const char	*d_const_string_t;
-
-/** Scatter/gather list for memory buffers */
-typedef struct {
-	uint32_t	sg_nr;
-	uint32_t	sg_nr_out;
-	d_iov_t		*sg_iovs;
-} d_sg_list_t;
-
-static inline void
-d_iov_set(d_iov_t *iov, void *buf, size_t size)
-{
-	iov->iov_buf = buf;
-	iov->iov_len = iov->iov_buf_len = size;
-}
 
 /* memory allocating macros */
 

--- a/src/include/gurt/hash.h
+++ b/src/include/gurt/hash.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2016-2018 Intel Corporation
+/* Copyright (C) 2016-2019 Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -49,7 +49,7 @@
 #include <stdbool.h>
 
 #include <gurt/list.h>
-#include <gurt/common.h> /* for d_uuid */
+#include <gurt/types.h> /* for d_uuid */
 
 /**
  * Hash table keeps and prints extra debugging information

--- a/src/include/gurt/types.h
+++ b/src/include/gurt/types.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2017-2019 Intel Corporation
+/* Copyright (C) 2016-2019 Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -36,34 +36,87 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 /**
- * Common code for threaded_client/threaded_server testing multiple threads
- * using a single context
+ * \file
+ * GURT types.
  */
-#ifndef __COMMON_H__
-#define __COMMON_H__
 
+/** @defgroup GURT GURT */
+/** @defgroup GURT_LOG Gurt Log */
+/** @defgroup GURT_DEBUG Gurt Debug */
+#ifndef __GURT_TYPES_H__
+#define __GURT_TYPES_H__
+
+#include <uuid/uuid.h>
+#include <unistd.h>
+#include <stdbool.h>
+#include <string.h>
+#include <errno.h>
+#include <inttypes.h>
+#include <time.h>
+#include <limits.h>
+#include <stdlib.h>
 #include <stdio.h>
-#include <gurt/common.h>
+#include <pthread.h>
+#include <byteswap.h>
 
-static inline int drain_queue(crt_context_t ctx)
+/** @addtogroup GURT
+ * @{
+ */
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/**
+ * hide the dark secret that uuid_t is an array not a structure.
+ */
+struct d_uuid {
+	uuid_t		uuid;
+};
+
+/** iovec for memory buffer */
+typedef struct {
+	/** buffer address */
+	void		*iov_buf;
+	/** buffer length */
+	size_t		iov_buf_len;
+	/** data length */
+	size_t		iov_len;
+} d_iov_t;
+
+/** Server identification */
+typedef uint32_t	d_rank_t;
+
+typedef struct {
+	/** list of ranks */
+	d_rank_t	*rl_ranks;
+	/** number of ranks */
+	uint32_t	rl_nr;
+} d_rank_list_t;
+
+typedef d_rank_list_t	*d_rank_list_ptr_t;
+
+typedef char		*d_string_t;
+typedef const char	*d_const_string_t;
+
+/** Scatter/gather list for memory buffers */
+typedef struct {
+	uint32_t	sg_nr;
+	uint32_t	sg_nr_out;
+	d_iov_t		*sg_iovs;
+} d_sg_list_t;
+
+static inline void
+d_iov_set(d_iov_t *iov, void *buf, size_t size)
 {
-	int	rc;
-	/* Drain the queue. Progress until 1 second timeout.  We need
-	 * a more robust method
-	 */
-	do {
-		rc = crt_progress(ctx, 1000000, NULL, NULL);
-		if (rc != 0 && rc != -DER_TIMEDOUT) {
-			printf("crt_progress failed rc: %d.\n", rc);
-			return rc;
-		}
-
-		if (rc == -DER_TIMEDOUT)
-			break;
-	} while (1);
-
-	printf("Done draining queue\n");
-	return 0;
+	iov->iov_buf = buf;
+	iov->iov_len = iov->iov_buf_len = size;
 }
 
-#endif /* __COMMON_H__ */
+#if defined(__cplusplus)
+}
+#endif
+
+/** @}
+ */
+#endif /* __GURT_TYPES_H__ */


### PR DESCRIPTION
It turns out common.h includes debug which makes it tricky in
DAOS to include it and define its own DD_FAC.  This ensures
we don't include debug stuff unless we explicity include it.

Change-Id: I320bd2b05b490af4985cbbd76bcf22a78bb7be14
Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>