### PR TITLE
Do not relocate the valgrind logs after running the test.

### DIFF
--- a/utils/run_test.sh
+++ b/utils/run_test.sh
@@ -108,11 +108,4 @@ if [[ "$CART_TEST_MODE" =~ (memcheck|all) ]]; then
   python3 test_runner "${JENKINS_TEST_LIST[@]}"
 
   popd
-  RESULTS="valgrind_results"
-  if [[ ! -e ${RESULTS} ]]; then mkdir ${RESULTS}; fi
-
-  # Recursive copy to results, including all directories and matching files,
-  # but pruning empty directories from the tree.
-  rsync -rm --include="*/" --include="valgrind*xml" "--exclude=*" ${TESTDIR} ${RESULTS}
-
 fi


### PR DESCRIPTION
Change-Id: I77e8c4aa39ff859228ca14c11cd0dfc340a9a7e6
Signed-off-by: Parallels <ashley.m.pittman@intel.com>