### PR TITLE
CART-587 dlog: change in stack buf to be thread local data

### DIFF
--- a/src/gurt/dlog.c
+++ b/src/gurt/dlog.c
@@ -356,7 +356,8 @@ void d_vlog(int flags, const char *fmt, va_list ap)
 {
 #define DLOG_TBSIZ    1024	/* bigger than any line should be */
 	int fac, lvl;
-	char b[DLOG_TBSIZ], *b_nopt1hdr;
+	static __thread char b[DLOG_TBSIZ];
+	char *b_nopt1hdr;
 	char facstore[16], *facstr;
 	struct timeval tv;
 	struct tm *tm;
@@ -398,6 +399,7 @@ void d_vlog(int flags, const char *fmt, va_list ap)
 	tm = localtime(&tv.tv_sec);
 	if (tm == NULL) {
 		fprintf(stderr, "clog: localtime returned NULL\n");
+		clog_unlock();
 		return;
 	}
 


### PR DESCRIPTION
The original code d_vlog() uses an in stack 1K buffer as the output
buffer, it is dangerous in some cases that with deep calling depth
that almost consumed all the stack space (ULT stack space for daos is
small by default, for example a segfault in D_DEBUG in DAOS-1542) then
the last calling of d_log() possibly cause stack overflow.

This patch refines it by using static thread local data that not in
stack space.

Change-Id: I1ca17ce079228f53756601a826ebd4bc6925a8a3
Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>