### PR TITLE
CART-565 hlc: Initial Hybrid Logical Clocks implementation

### DIFF
--- a/src/cart/SConscript
+++ b/src/cart/SConscript
@@ -50,7 +50,7 @@ SRC = ['crt_barrier.c', 'crt_bulk.c', 'crt_context.c', 'crt_corpc.c',
        'crt_init.c', 'crt_iv.c', 'crt_lm.c', 'crt_pmix.c', 'crt_register.c',
        'crt_rpc.c', 'crt_self_test_client.c', 'crt_self_test_service.c',
        'crt_swim.c', 'crt_tree.c', 'crt_tree_flat.c', 'crt_tree_kary.c',
-       'crt_tree_knomial.c']
+       'crt_tree_knomial.c', 'crt_hlc.c']
 
 # pylint: disable=unused-argument
 def macro_expand(target, source, env):

--- a/src/cart/crt_hlc.c
+++ b/src/cart/crt_hlc.c
@@ -1,0 +1,98 @@
+/* Copyright (C) 2019 Intel Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted for any purpose (including commercial purposes)
+ * provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions, and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions, and the following disclaimer in the
+ *    documentation and/or materials provided with the distribution.
+ *
+ * 3. In addition, redistributions of modified forms of the source or binary
+ *    code must carry prominent notices stating that the original code was
+ *    changed and the date of the change.
+ *
+ * 4. All publications or advertising materials mentioning features or use of
+ *    this software are asked, but not required, to acknowledge that it was
+ *    developed by Intel Corporation and credit the contributors.
+ *
+ * 5. Neither the name of Intel Corporation, nor the name of any Contributor
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/**
+ * This file is part of CaRT. Hybrid Logical Clock (HLC) implementation.
+ */
+#include "crt_internal.h"
+#include <gurt/common.h>	/* for NSEC_PER_SEC */
+#include <gurt/atomic.h>
+#include <time.h>
+
+#define CRT_HLC_MASK 0xFFFFULL
+
+static ATOMIC uint64_t crt_hlc;
+
+/** Get local physical time */
+static inline uint64_t crt_hlc_localtime_get(void)
+{
+	struct timespec now;
+	uint64_t	pt;
+	int		rc;
+
+	rc = clock_gettime(CLOCK_REALTIME_COARSE, &now);
+	pt = rc ? crt_hlc : (now.tv_sec * NSEC_PER_SEC + now.tv_nsec);
+
+	/**
+	 * Return the most significant 48 bits of time.
+	 * In case of error of retrieving a system time use previous time.
+	 */
+	return pt & ~CRT_HLC_MASK;
+}
+
+uint64_t crt_hlc_get(void)
+{
+	uint64_t pt = crt_hlc_localtime_get();
+	uint64_t hlc, ret;
+
+	do {
+		hlc = crt_hlc;
+		ret = (hlc & ~CRT_HLC_MASK) < pt ? pt : (hlc + 1);
+	} while (!atomic_compare_exchange(&crt_hlc, hlc, ret));
+
+	return ret;
+}
+
+uint64_t crt_hlc_get_msg(uint64_t msg)
+{
+	uint64_t pt = crt_hlc_localtime_get();
+	uint64_t hlc, ret, ml = msg & ~CRT_HLC_MASK;
+
+	do {
+		hlc = crt_hlc;
+		if ((hlc & ~CRT_HLC_MASK) < ml)
+			ret = ml < pt ? pt : (msg + 1);
+		else if ((hlc & ~CRT_HLC_MASK) < pt)
+			ret = pt;
+		else if (pt <= ml)
+			ret = (hlc < msg ? msg : hlc) + 1;
+		else
+			ret = hlc + 1;
+	} while (!atomic_compare_exchange(&crt_hlc, hlc, ret));
+
+	return ret;
+}

--- a/src/cart/crt_internal_fns.h
+++ b/src/cart/crt_internal_fns.h
@@ -104,4 +104,7 @@ crt_bulk_desc_dup(struct crt_bulk_desc *bulk_desc_new,
 void
 crt_hdlr_proto_query(crt_rpc_t *rpc_req);
 
+/* Internal API to sync timestamp with remote message */
+uint64_t crt_hlc_get_msg(uint64_t msg);
+
 #endif /* __CRT_INTERNAL_FNS_H__ */

--- a/src/cart/crt_rpc.h
+++ b/src/cart/crt_rpc.h
@@ -90,6 +90,8 @@ struct crt_common_hdr {
 	uint32_t	cch_opc;
 	/* RPC request flag, see enum crt_rpc_flags_internal */
 	uint32_t	cch_flags;
+	/* HLC timestamp */
+	uint64_t	cch_hlc;
 	/* gid and rank identify the rpc request sender */
 	d_rank_t	cch_rank;
 	/* used in crp_reply_hdr to propagate rpc failure back to sender */
@@ -145,11 +147,11 @@ struct crt_corpc_info {
 
 struct crt_rpc_priv {
 	/* link to crt_ep_inflight::epi_req_q/::epi_req_waitq */
-	d_list_t			crp_epi_link;
+	d_list_t		crp_epi_link;
 	/* tmp_link used in crt_context_req_untrack */
-	d_list_t			crp_tmp_link;
+	d_list_t		crp_tmp_link;
 	/* link to parent RPC crp_opc_info->co_child_rpcs/co_replied_rpcs */
-	d_list_t			crp_parent_link;
+	d_list_t		crp_parent_link;
 	/* binheap node for timeout management, in crt_context::cc_bh_timeout */
 	struct d_binheap_node	crp_timeout_bp_node;
 	/* the timeout in seconds set by user */

--- a/src/include/cart/api.h
+++ b/src/include/cart/api.h
@@ -408,6 +408,21 @@ crt_reply_get(crt_rpc_t *rpc)
 }
 
 /**
+ * Return current HLC timestamp
+ *
+ * HLC timestamps are synchronized between nodes. They sends with each RPC for
+ * different nodes and updated when received from different node. The HLC
+ * timestamps synchronization will be called transparently at sending/receiving
+ * RPC into the wire (when Mercury will encode/decode the packet). So, with
+ * each call of this function you will get from it always last HLC timestamp
+ * synchronized across all nodes involved in current communication.
+ *
+ * \return                     HLC timestamp
+ */
+uint64_t
+crt_hlc_get(void);
+
+/**
  * Abort an RPC request.
  *
  * \param[in] req              pointer to RPC request

--- a/src/include/gurt/atomic.h
+++ b/src/include/gurt/atomic.h
@@ -52,7 +52,8 @@
 
 /* stdatomic interface for compare_and_exchange doesn't quite align */
 #define atomic_compare_exchange(ptr, oldvalue, newvalue) \
-	atomic_compare_exchange_weak(ptr, &oldvalue, newvalue)
+	atomic_compare_exchange_weak(ptr, &oldvalue, newvalue, \
+				memory_order_relaxed, memory_order_relaxed)
 #define atomic_store_release(ptr, value) \
 	atomic_store_explicit(ptr, value, memory_order_release)
 

--- a/src/test/SConscript
+++ b/src/test/SConscript
@@ -52,6 +52,7 @@ IV_TESTS = ['iv_client.c', 'iv_server.c']
 TEST_RPC_ERR_SRC = 'test_rpc_error.c'
 CRT_RPC_TESTS = ['rpc_test_cli.c', 'rpc_test_srv.c', 'rpc_test_srv2.c']
 SWIM_TESTS = ['test_swim.c', 'test_swim_net.c']
+HLC_TESTS = ['test_hlc_net.c']
 
 def scons():
     """scons function"""
@@ -86,6 +87,11 @@ def scons():
         tenv.Install(os.path.join("$PREFIX", 'TESTING', 'tests'), target)
 
     for test in SWIM_TESTS:
+        target = tenv.Program(test)
+        tenv.Requires(target, [cart_lib, gurt_lib])
+        tenv.Install(os.path.join("$PREFIX", 'TESTING', 'tests'), target)
+
+    for test in HLC_TESTS:
         target = tenv.Program(test)
         tenv.Requires(target, [cart_lib, gurt_lib])
         tenv.Install(os.path.join("$PREFIX", 'TESTING', 'tests'), target)

--- a/src/test/test_hlc_net.c
+++ b/src/test/test_hlc_net.c
@@ -1,0 +1,310 @@
+/* Copyright (C) 2019 Intel Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted for any purpose (including commercial purposes)
+ * provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions, and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions, and the following disclaimer in the
+ *    documentation and/or materials provided with the distribution.
+ *
+ * 3. In addition, redistributions of modified forms of the source or binary
+ *    code must carry prominent notices stating that the original code was
+ *    changed and the date of the change.
+ *
+ * 4. All publications or advertising materials mentioning features or use of
+ *    this software are asked, but not required, to acknowledge that it was
+ *    developed by Intel Corporation and credit the contributors.
+ *
+ * 5. Neither the name of Intel Corporation, nor the name of any Contributor
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <sched.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <assert.h>
+#include <pthread.h>
+#include <cart/api.h>
+#include <cart/types.h>
+#include <gurt/common.h>
+
+/* CRT internal opcode definitions, must be 0xFF00xxxx.*/
+#define CRT_OPC_TEST_PROTO (0x10000000)
+
+#define DEBUG		1
+#define MAX_SEQ		1000
+
+#define CRT_ISEQ_RPC_TEST	/* input fields */		 \
+	((uint64_t)		(seq)			CRT_VAR) \
+	((uint64_t)		(hlc)			CRT_VAR) \
+	((uint32_t)		(src)			CRT_VAR) \
+	((uint32_t)		(dst)			CRT_VAR)
+
+#define CRT_OSEQ_RPC_TEST	/* output fields */		 \
+	((uint64_t)		(seq)			CRT_VAR) \
+	((uint64_t)		(hlc)			CRT_VAR) \
+	((uint32_t)		(src)			CRT_VAR) \
+	((uint32_t)		(dst)			CRT_VAR)
+
+CRT_RPC_DECLARE(crt_rpc_test, CRT_ISEQ_RPC_TEST, CRT_OSEQ_RPC_TEST)
+CRT_RPC_DEFINE(crt_rpc_test, CRT_ISEQ_RPC_TEST, CRT_OSEQ_RPC_TEST)
+
+static void test_srv_cb(crt_rpc_t *rpc);
+
+static struct crt_proto_rpc_format test_proto_rpc_fmt[] = {
+	{
+		.prf_flags	= 0,
+		.prf_req_fmt	= &CQF_crt_rpc_test,
+		.prf_hdlr	= test_srv_cb,
+		.prf_co_ops	= NULL,
+	}
+};
+
+static struct crt_proto_format test_proto_fmt = {
+	.cpf_name	= "test-proto",
+	.cpf_ver	= 0,
+	.cpf_count	= ARRAY_SIZE(test_proto_rpc_fmt),
+	.cpf_prf	= &test_proto_rpc_fmt[0],
+	.cpf_base	= CRT_OPC_TEST_PROTO,
+};
+
+struct global_srv {
+	crt_context_t		 crt_ctx;
+	pthread_t		 progress_thid;
+	uint64_t		 seq;
+	uint32_t		 my_rank;
+	uint32_t		 grp_size;
+	uint32_t		 shutdown;
+};
+
+#if DEBUG == 1
+#define dbg(fmt, ...)	D_DEBUG(DB_TEST, fmt, ##__VA_ARGS__)
+#else
+#define dbg(fmt, ...)							\
+	printf("%s[%d]\t[%d]\t"fmt"\n",					\
+	(strrchr(__FILE__, '/')+1), __LINE__, getpid(), ##__VA_ARGS__)
+#endif
+
+/*========================== GLOBAL ===========================*/
+
+static struct global_srv global_srv;
+
+/*========================== GLOBAL ===========================*/
+
+static void test_srv_cb(crt_rpc_t *rpc)
+{
+	struct crt_rpc_test_in	*rpc_input;
+	struct crt_rpc_test_out	*rpc_output;
+	uint64_t		 hlc = crt_hlc_get();
+	int			 rc;
+
+	rpc_input = crt_req_get(rpc);
+	D_ASSERT(rpc_input != NULL);
+
+	rpc_output = crt_reply_get(rpc);
+	D_ASSERT(rpc_output != NULL);
+
+	/* send HLC should be early than receive HLC */
+	D_ASSERT(rpc_input->hlc < hlc);
+
+	rpc_output->seq = rpc_input->seq;
+	rpc_output->hlc = hlc;
+	rpc_output->src = rpc_input->src;
+	rpc_output->dst = rpc_input->dst;
+
+	dbg("HLC=0x%lx recv RPC %02u.%03lu %02u send HLC=0x%lx\n", hlc,
+	    rpc_input->src, rpc_input->seq, rpc_input->dst, rpc_input->hlc);
+
+	rc = crt_reply_send(rpc);
+	D_ASSERTF(rc == 0, "crt_reply_send failed %d\n", rc);
+}
+
+static void test_cli_cb(const struct crt_cb_info *cb_info)
+{
+	struct crt_rpc_test_in	*rpc_input;
+	struct crt_rpc_test_out	*rpc_output;
+	crt_rpc_t		*rpc = cb_info->cci_rpc;
+	uint64_t		 hlc = crt_hlc_get();
+
+	dbg("opc: %#x cci_rc: %d", rpc->cr_opc, cb_info->cci_rc);
+
+	if (cb_info->cci_rc == 0) {
+		rpc_input = crt_req_get(rpc);
+		D_ASSERT(rpc_input != NULL);
+
+		rpc_output = crt_reply_get(rpc);
+		D_ASSERT(rpc_output != NULL);
+
+		dbg("HLC=0x%lx send RPC %02u.%03lu %02u repl HLC=0x%lx "
+		    "current HLC=0x%lx\n", rpc_input->hlc,
+		    rpc_input->src, rpc_input->seq, rpc_input->dst,
+		    rpc_output->hlc, hlc);
+
+		D_ASSERT(rpc_output->seq == rpc_input->seq);
+		D_ASSERT(rpc_output->src == rpc_input->src);
+		D_ASSERT(rpc_output->dst == rpc_input->dst);
+
+		D_ASSERT(rpc_input->hlc < rpc_output->hlc);
+		D_ASSERT(rpc_output->hlc < hlc);
+	}
+}
+
+static int test_send_rpc(d_rank_t to)
+{
+	struct crt_rpc_test_in *rpc_input;
+	crt_rpc_t *rpc;
+	crt_endpoint_t ep;
+	crt_opcode_t opc;
+	int rc = 0;
+
+	dbg("---%s--->", __func__);
+
+	if (global_srv.seq >= MAX_SEQ)
+		return -DER_SHUTDOWN;
+
+	ep.ep_grp  = NULL;
+	ep.ep_rank = to;
+	ep.ep_tag  = 0;
+
+	/* get the opcode of the first RPC in version 0 of OPC_SWIM_PROTO */
+	opc = CRT_PROTO_OPC(CRT_OPC_TEST_PROTO, 0, 0);
+	rc = crt_req_create(global_srv.crt_ctx, &ep, opc, &rpc);
+	D_ASSERTF(rc == 0, "crt_req_create() failed rc=%d", rc);
+
+	rpc_input = crt_req_get(rpc);
+	D_ASSERT(rpc_input != NULL);
+	rpc_input->seq = global_srv.seq++;
+	rpc_input->hlc = crt_hlc_get();
+	rpc_input->src = global_srv.my_rank;
+	rpc_input->dst = to;
+
+	rc = crt_req_send(rpc, test_cli_cb, NULL);
+	D_ASSERTF(rc == 0, "crt_req_send() failed rc=%d", rc);
+
+	dbg("<---%s---", __func__);
+	return rc;
+}
+
+static void *srv_progress(void *data)
+{
+	crt_context_t *ctx = (crt_context_t *)data;
+	int rc = 0;
+
+	dbg("---%s--->", __func__);
+
+	D_ASSERTF(ctx != NULL, "ctx=%p\n", ctx);
+
+	while (global_srv.shutdown == 0) {
+		rc = crt_progress(*ctx, 1000, NULL, NULL);
+		if (rc != 0 && rc != -DER_TIMEDOUT) {
+			D_ERROR("crt_progress() failed rc=%d\n", rc);
+			break;
+		}
+	}
+
+	dbg("<---%s---", __func__);
+	return NULL;
+}
+
+static void srv_fini(void)
+{
+	int rc = 0;
+
+	dbg("---%s--->", __func__);
+
+	global_srv.shutdown = 1;
+	dbg("main thread wait progress thread...");
+
+	if (global_srv.progress_thid)
+		pthread_join(global_srv.progress_thid, NULL);
+
+	rc = crt_context_destroy(global_srv.crt_ctx, true);
+	D_ASSERTF(rc == 0, "crt_context_destroy failed rc=%d\n", rc);
+
+	rc = crt_finalize();
+	D_ASSERTF(rc == 0, "crt_finalize failed rc=%d\n", rc);
+
+	dbg("<---%s---", __func__);
+}
+
+static int srv_init(void)
+{
+	int rc = 0;
+
+	dbg("---%s--->", __func__);
+
+	rc = crt_init(CRT_DEFAULT_SRV_GRPID, CRT_FLAG_BIT_SERVER);
+	D_ASSERTF(rc == 0, " crt_init failed %d\n", rc);
+
+	rc = crt_proto_register(&test_proto_fmt);
+	D_ASSERT(rc == 0);
+
+	rc = crt_group_rank(NULL, &global_srv.my_rank);
+	D_ASSERTF(rc == 0, "crt_group_rank failed %d\n", rc);
+
+	rc = crt_group_size(NULL, &global_srv.grp_size);
+	D_ASSERTF(rc == 0, "crt_group_size failed %d\n", rc);
+
+	rc = crt_context_create(&global_srv.crt_ctx);
+	D_ASSERTF(rc == 0, "crt_context_create() failed %d\n", rc);
+
+	/* create progress thread */
+	rc = pthread_create(&global_srv.progress_thid, NULL,
+			    srv_progress, &global_srv.crt_ctx);
+	if (rc != 0)
+		D_ERROR("progress thread creating failed, rc=%d\n", rc);
+
+	dbg("my_rank=%u, group_size=%u srv_pid=%d",
+	    global_srv.my_rank, global_srv.grp_size, getpid());
+
+	dbg("<---%s---", __func__);
+	return rc;
+}
+
+int main(int argc, char *argv[])
+{
+	int i, rc;
+
+	dbg("---%s--->", __func__);
+
+	/* default value */
+
+	srv_init();
+
+	/* print the state of all members from all targets */
+	while (!global_srv.shutdown) {
+		for (i = 0; i < global_srv.grp_size; i++) {
+			if (i != global_srv.my_rank) {
+				rc = test_send_rpc(i);
+				if (rc)
+					break;
+			}
+		}
+		if (rc)
+			break;
+		sched_yield();
+	}
+
+	sleep(5); /* wait until other threads complete */
+	srv_fini();
+
+	dbg("<---%s---", __func__);
+	return 0;
+}

--- a/src/utest/SConscript
+++ b/src/utest/SConscript
@@ -38,12 +38,11 @@
 
 import os
 
-TEST_SRC = ['test_gurt_v1.c', 'test_linkage.cpp', 'test_gurt.c']
+TEST_SRC = ['test_gurt_v1.c', 'test_linkage.cpp', 'test_gurt.c', 'utest_hlc.c']
 WRAPPERS = {'test_linkage.cpp':['PMIx_Init', 'PMIx_Get',
                                 'PMIx_Publish', 'PMIx_Lookup',
                                 'PMIx_Fence', 'PMIx_Unpublish',
                                 'PMIx_Register_event_handler']}
-
 LIBPATH = [Dir('../cart'), Dir('../gurt')]
 
 def scons():

--- a/src/utest/utest_hlc.c
+++ b/src/utest/utest_hlc.c
@@ -1,0 +1,123 @@
+/* Copyright (C) 2019 Intel Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted for any purpose (including commercial purposes)
+ * provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions, and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions, and the following disclaimer in the
+ *    documentation and/or materials provided with the distribution.
+ *
+ * 3. In addition, redistributions of modified forms of the source or binary
+ *    code must carry prominent notices stating that the original code was
+ *    changed and the date of the change.
+ *
+ * 4. All publications or advertising materials mentioning features or use of
+ *    this software are asked, but not required, to acknowledge that it was
+ *    developed by Intel Corporation and credit the contributors.
+ *
+ * 5. Neither the name of Intel Corporation, nor the name of any Contributor
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/**
+ * This file is part of CaRT testing.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <time.h>
+
+#include <cmocka.h>
+
+#include <cart/api.h>
+#include "../cart/crt_internal.h"
+
+#define COUNT 32000
+
+static uint64_t last;
+
+static void
+test_hlc_get(void **state)
+{
+	uint64_t time;
+	int i;
+
+	for (i = 0; i < COUNT; i++) {
+		time = crt_hlc_get();
+		assert_true(last < time);
+		last = time;
+		if (i == 9)
+			sleep(1);
+	}
+}
+
+static void
+test_hlc_get_msg(void **state)
+{
+	uint64_t time = last, time2 = last;
+	int i;
+
+	for (i = 0; i < COUNT; i++) {
+		if (i % 5 == 1)
+			time2 = time + 0x100;
+		else if (i % 5 == 2)
+			time2 = time - 0x100;
+		else
+			time2 = time + (i % 3);
+		time = crt_hlc_get_msg(time2);
+		assert_true(time2 < time);
+		assert_true(last < time);
+		last = time;
+		if (i == 9)
+			sleep(1);
+	}
+}
+
+static int
+init_tests(void **state)
+{
+	unsigned int seed;
+
+	/* Seed the random number generator once per test run */
+	seed = time(NULL);
+	fprintf(stdout, "Seeding this test run with seed=%u\n", seed);
+	srand(seed);
+
+	return 0;
+}
+
+static int
+fini_tests(void **state)
+{
+	return 0;
+}
+
+
+int main(int argc, char **argv)
+{
+	const struct CMUnitTest tests[] = {
+		cmocka_unit_test(test_hlc_get),
+		cmocka_unit_test(test_hlc_get_msg),
+	};
+
+	return cmocka_run_group_tests(tests, init_tests, fini_tests);
+}


### PR DESCRIPTION
Inserted HLC timestamps to all RPCs send and received.
This allow to arrange them according the time across all nodes
involved in communication. Disregard to RPCs you can query for
current timestamp like following:

uint64_t hlc = crt_hlc_get();

This function returns the current HLC timestamp for this moment.