### PR TITLE
CART-594 group: Provide public API for events

### DIFF
--- a/src/cart/crt_internal_types.h
+++ b/src/cart/crt_internal_types.h
@@ -55,21 +55,6 @@
 struct crt_hg_gdata;
 struct crt_grp_gdata;
 
-enum crt_event_source {
-	CRT_EVS_UNKNOWN,
-	CRT_EVS_PMIX,
-	CRT_EVS_SWIM,
-};
-
-enum crt_event_type {
-	CRT_EVT_ALIVE,
-	CRT_EVT_DEAD,
-};
-
-typedef void
-(*crt_event_cb) (d_rank_t rank, enum crt_event_source src,
-		 enum crt_event_type type, void *arg);
-
 /* CaRT global data */
 struct crt_gdata {
 	crt_phy_addr_t		cg_addr;

--- a/src/cart/crt_pmix.h
+++ b/src/cart/crt_pmix.h
@@ -65,22 +65,8 @@ int crt_pmix_uri_lookup(crt_group_id_t srv_grpid, d_rank_t rank, char **uri);
 int crt_pmix_attach(struct crt_grp_priv *grp_priv);
 void crt_pmix_reg_event_hdlr(struct crt_grp_priv *grp_priv);
 void crt_pmix_dereg_event_hdlr(struct crt_grp_priv *grp_priv);
+int  crt_plugin_pmix_init(void);
 void crt_plugin_pmix_fini(void);
 int crt_pmix_psr_load(struct crt_grp_priv *grp_priv, d_rank_t psr_rank);
-/**
- * This function registers an event handler for process failures. If the calling
- * process has not yet registered a PMIx event handler for the
- * PMIX_ERR_PROC_ABORTED event, this function will do so.  When the external RAS
- * notifies the current process with a process failure event, event_handler()
- * will be executed. Invocation of event_handler() does not mean the rank has
- * been evicted.
- *
- * \param[in] event_handler    event handler to register
- * \param[in] arg              arg to event_handler
- *
- * \return                     DER_SUCCESS on success, negative value on error
- */
-int  crt_register_event_cb(crt_event_cb event_handler, void *arg);
-void crt_unregister_event_cb(crt_event_cb event_handler, void *arg);
 
 #endif /* __CRT_PMIX_H__ */

--- a/src/include/cart/api.h
+++ b/src/include/cart/api.h
@@ -1510,8 +1510,8 @@ int
 crt_register_progress_cb(crt_progress_cb cb, int ctx_idx, void *arg);
 
 /**
- * Unregister a callback function. The par of arguments (ctx_idx and arg)
- * should be equal to remove this callback from the list.
+ * Unregister a callback function. The pair of arguments (ctx_idx and arg)
+ * should be same as the ones provided during registration.
  */
 int
 crt_unregister_progress_cb(crt_progress_cb cb, int ctx_idx, void *arg);
@@ -1531,6 +1531,53 @@ typedef void
  */
 int
 crt_register_eviction_cb(crt_eviction_cb cb, void *arg);
+
+enum crt_event_source {
+	CRT_EVS_UNKNOWN,
+	CRT_EVS_PMIX,
+	CRT_EVS_SWIM,
+};
+
+enum crt_event_type {
+	CRT_EVT_ALIVE,
+	CRT_EVT_DEAD,
+};
+
+typedef void
+(*crt_event_cb) (d_rank_t rank, enum crt_event_source src,
+		 enum crt_event_type type, void *arg);
+
+/**
+ * This function registers an event handler for any changes in rank state.
+ * There is not any modification about the rank in rank list at this point.
+ * The decision about adding or eviction the rank should be made from
+ * an information from this handler.
+ *
+ * Important:
+ * The event should be processed in non-blocking mode because this
+ * handler is called under lock which should not be held for long time.
+ * Sleeping is also prohibited in this handler! Only quick reaction is
+ * expected into this handler before return.
+ *
+ * \param[in] event_handler    event handler to register
+ * \param[in] arg              arg to event_handler
+ *
+ * \return                     DER_SUCCESS on success, negative value on error
+ */
+int
+crt_register_event_cb(crt_event_cb event_handler, void *arg);
+
+/**
+ * Unregister an event handler. The pair of arguments (event_handler and arg)
+ * should be same as the ones provided during registration.
+ *
+ * \param[in] event_handler    event handler to register
+ * \param[in] arg              arg to event_handler
+ *
+ * \return                     DER_SUCCESS on success, negative value on error
+ */
+int
+crt_unregister_event_cb(crt_event_cb event_handler, void *arg);
 
 /**
  * Retrieve the PSR candidate list for \a tgt_grp.  There is guaranteed to be


### PR DESCRIPTION
We have internal API for events related to rank state. This API is used
to provide rank eviction mechanism. With new bootstrapping approach we
should provide ability to subscribe on those events outside of CaRT to
manage groups members outside. So, move this API to public.

Move initialization of PMIx from crt_register_event_cb() into
crt_plugin_init().