### PR TITLE
CART-595 proto: Prevent double registration

### DIFF
--- a/src/cart/crt_register.c
+++ b/src/cart/crt_register.c
@@ -44,6 +44,9 @@
 #include <semaphore.h>
 #include "crt_internal.h"
 
+static int
+crt_proto_query_local(crt_opcode_t base_opc, uint32_t ver);
+
 /* init L2, alloc 32 entries by default */
 static int
 crt_opc_map_L2_create(struct crt_opc_map_L2 *L2_entry)
@@ -362,40 +365,14 @@ crt_opc_reg(struct crt_opc_info *opc_info, crt_opcode_t opc, uint32_t flags,
 	    size_t output_size, crt_rpc_cb_t rpc_cb,
 	    struct crt_corpc_ops *co_ops)
 {
-	bool		     disable_reply;
-	bool		     enable_reset_timer;
+	bool	disable_reply;
+	bool	enable_reset_timer;
+	int	rc = 0;
 
 	if (opc_info->coi_inited == 1) {
-		if (opc_info->coi_input_size != input_size) {
-			D_DEBUG(DB_TRACE, "opc %#x, update input_size "
-					"from "DF_U64" to "DF_U64".\n", opc,
-					opc_info->coi_input_size, input_size);
-			opc_info->coi_input_size = input_size;
-		}
-		if (opc_info->coi_output_size != output_size) {
-			D_DEBUG(DB_TRACE, "opc %#x, update output_size "
-					"from "DF_U64" to "DF_U64".\n", opc,
-					opc_info->coi_output_size, output_size);
-			opc_info->coi_output_size = output_size;
-		}
-		opc_info->coi_crf = crf;
-		if (rpc_cb != NULL) {
-			if (opc_info->coi_rpc_cb != NULL)
-				D_DEBUG(DB_TRACE, "re-reg rpc callback, "
-						"opc %#x.\n", opc);
-			else
-				opc_info->coi_rpccb_init = 1;
-			opc_info->coi_rpc_cb = rpc_cb;
-		}
-		if (co_ops != NULL) {
-			if (opc_info->coi_co_ops != NULL)
-				D_DEBUG(DB_TRACE, "re-reg co_ops, "
-						"opc %#x.\n", opc);
-			else
-				opc_info->coi_coops_init = 1;
-			opc_info->coi_co_ops = co_ops;
-		}
-		D_GOTO(set, 0);
+		D_ERROR("RPC with opcode 0x%x already registered\n",
+			opc_info->coi_opc);
+		D_GOTO(out, rc = -DER_EXIST);
 	};
 
 	opc_info->coi_opc = opc;
@@ -414,7 +391,6 @@ crt_opc_reg(struct crt_opc_info *opc_info, crt_opcode_t opc, uint32_t flags,
 
 	opc_info->coi_inited = 1;
 
-set:
 	/* Calculate the size required for the RPC.
 	 *
 	 * If crp_forward is enabled memory is only allocated for output buffer,
@@ -445,8 +421,8 @@ set:
 	else
 		D_DEBUG(DB_TRACE, "opc %#x, reset_timer disabled.\n", opc);
 
-
-	return DER_SUCCESS;
+out:
+	return rc;
 }
 
 static int
@@ -906,6 +882,35 @@ crt_proto_register(struct crt_proto_format *cpf)
 	}
 
 	return crt_proto_register_common(cpf);
+}
+
+int
+crt_proto_unregister(crt_opcode_t base_opc, uint32_t ver)
+{
+	int rc;
+	unsigned int	L1_idx;
+	unsigned int	L2_idx;
+	struct crt_opc_map	*map;
+	crt_opcode_t	opc;
+
+	rc = crt_proto_query_local(base_opc, ver);
+	if (rc != 0) {
+		D_ERROR("Protocol %#x:%#x not registered, rc:%d\n",
+			base_opc, ver, rc);
+		D_GOTO(out, rc = -DER_NONEXIST);
+	}
+
+	opc = CRT_PROTO_OPC(base_opc, ver, 0);
+
+	L1_idx = opc >> 24;
+	L2_idx = (opc & CRT_PROTO_VER_MASK) >> 16;
+
+	map = crt_gdata.cg_opc_map;
+
+	crt_opc_map_L3_destroy(&map->com_map[L1_idx].L2_map[L2_idx]);
+
+out:
+	return rc;
 }
 
 int

--- a/src/cart/crt_register.c
+++ b/src/cart/crt_register.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2016-2018 Intel Corporation
+/* Copyright (C) 2016-2019 Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/cart/crt_register.c
+++ b/src/cart/crt_register.c
@@ -885,35 +885,6 @@ crt_proto_register(struct crt_proto_format *cpf)
 }
 
 int
-crt_proto_unregister(crt_opcode_t base_opc, uint32_t ver)
-{
-	int rc;
-	unsigned int	L1_idx;
-	unsigned int	L2_idx;
-	struct crt_opc_map	*map;
-	crt_opcode_t	opc;
-
-	rc = crt_proto_query_local(base_opc, ver);
-	if (rc != 0) {
-		D_ERROR("Protocol %#x:%#x not registered, rc:%d\n",
-			base_opc, ver, rc);
-		D_GOTO(out, rc = -DER_NONEXIST);
-	}
-
-	opc = CRT_PROTO_OPC(base_opc, ver, 0);
-
-	L1_idx = opc >> 24;
-	L2_idx = (opc & CRT_PROTO_VER_MASK) >> 16;
-
-	map = crt_gdata.cg_opc_map;
-
-	crt_opc_map_L3_destroy(&map->com_map[L1_idx].L2_map[L2_idx]);
-
-out:
-	return rc;
-}
-
-int
 crt_proto_register_internal(struct crt_proto_format *cpf)
 {
 	if (cpf == NULL) {

--- a/src/include/cart/api.h
+++ b/src/include/cart/api.h
@@ -1644,7 +1644,9 @@ crt_lm_attach(crt_group_t *tgt_grp, crt_lm_attach_cb_t completion_cb,
  */
 
 /**
- * Register a protocol. Can be called on a server or a client.
+ * Register a protocol. Can be called on a server or a client. Re-registering
+ * existing base_opc + version combination will result in -DER_EXIST error
+ * being returned to the caller.
  *
  * \param[in] cpf              protocol format description. (See \ref
  *                             crt_proto_format)
@@ -1654,6 +1656,18 @@ crt_lm_attach(crt_group_t *tgt_grp, crt_lm_attach_cb_t completion_cb,
  */
 int
 crt_proto_register(struct crt_proto_format *cpf);
+
+/**
+ * Unregister rpcs specified by base_opc and ver pairs.
+ *
+ * \param[in] base_opc         base_opc to unregister
+ * \param[in] ver              version to unregister
+ *
+ * \return                     DER_SPUCCESS on success, negative value
+ *                             on failure.
+ */
+int
+crt_proto_unregister(crt_opcode_t base_opc, uint32_t ver);
 
 /**
  * query tgt_ep if it has registered base_opc with version.

--- a/src/include/cart/api.h
+++ b/src/include/cart/api.h
@@ -1658,18 +1658,6 @@ int
 crt_proto_register(struct crt_proto_format *cpf);
 
 /**
- * Unregister rpcs specified by base_opc and ver pairs.
- *
- * \param[in] base_opc         base_opc to unregister
- * \param[in] ver              version to unregister
- *
- * \return                     DER_SPUCCESS on success, negative value
- *                             on failure.
- */
-int
-crt_proto_unregister(crt_opcode_t base_opc, uint32_t ver);
-
-/**
  * query tgt_ep if it has registered base_opc with version.
  *
  * \param[in] tgt_ep           the service rank to query

--- a/src/test/test_proto_client.c
+++ b/src/test/test_proto_client.c
@@ -93,24 +93,12 @@ test_init()
 	rc = crt_group_rank(NULL, &test.tg_my_rank);
 	D_ASSERTF(rc == 0, "crt_group_rank() failed. rc: %d\n", rc);
 
-	/* Attempt to register and unregister OPC_MY_PROTO:0 */
-	rc = crt_proto_register(&my_proto_fmt_0_duplicate);
-	D_ASSERTF(rc == 0, "registration failed with rc: %d\n", rc);
-
-	rc = crt_proto_unregister(OPC_MY_PROTO, 0);
-	D_ASSERTF(rc == 0, "unregistration failed with rc: %d\n", rc);
-
 	/* Attempt to register actual fmt_0 and fmt_1 */
 	rc = crt_proto_register(&my_proto_fmt_0);
 	D_ASSERTF(rc == 0, "registration failed with rc: %d\n", rc);
 
 	rc = crt_proto_register(&my_proto_fmt_1);
 	D_ASSERTF(rc == 0, "registration failed with rc: %d\n", rc);
-
-	/* Attempt to unregister non-existing version */
-	rc = crt_proto_unregister(OPC_MY_PROTO, 2);
-	D_ASSERTF(rc == -DER_NONEXIST,
-		"deregistration returned unexpected rc: %d\n", rc);
 
 	/* Attempt to re-register duplicate proto */
 	rc = crt_proto_register(&my_proto_fmt_0_duplicate);

--- a/src/test/test_proto_client.c
+++ b/src/test/test_proto_client.c
@@ -93,10 +93,30 @@ test_init()
 	rc = crt_group_rank(NULL, &test.tg_my_rank);
 	D_ASSERTF(rc == 0, "crt_group_rank() failed. rc: %d\n", rc);
 
+	/* Attempt to register and unregister OPC_MY_PROTO:0 */
+	rc = crt_proto_register(&my_proto_fmt_0_duplicate);
+	D_ASSERTF(rc == 0, "registration failed with rc: %d\n", rc);
+
+	rc = crt_proto_unregister(OPC_MY_PROTO, 0);
+	D_ASSERTF(rc == 0, "unregistration failed with rc: %d\n", rc);
+
+	/* Attempt to register actual fmt_0 and fmt_1 */
 	rc = crt_proto_register(&my_proto_fmt_0);
-	D_ASSERT(rc == 0);
+	D_ASSERTF(rc == 0, "registration failed with rc: %d\n", rc);
+
 	rc = crt_proto_register(&my_proto_fmt_1);
-	D_ASSERT(rc == 0);
+	D_ASSERTF(rc == 0, "registration failed with rc: %d\n", rc);
+
+	/* Attempt to unregister non-existing version */
+	rc = crt_proto_unregister(OPC_MY_PROTO, 2);
+	D_ASSERTF(rc == -DER_NONEXIST,
+		"deregistration returned unexpected rc: %d\n", rc);
+
+	/* Attempt to re-register duplicate proto */
+	rc = crt_proto_register(&my_proto_fmt_0_duplicate);
+	D_ASSERTF(rc == -DER_EXIST,
+		"re-registration returned unexpected rc: %d\n", rc);
+
 	rc = crt_context_create(&test.tg_crt_ctx);
 	D_ASSERTF(rc == 0, "crt_context_create() failed. rc: %d\n", rc);
 

--- a/src/test/test_proto_common.h
+++ b/src/test/test_proto_common.h
@@ -180,6 +180,22 @@ struct crt_proto_format my_proto_fmt_0 = {
 	.cpf_base = OPC_MY_PROTO,
 };
 
+/* Format with the same .cpf_ver and .cpf_base as my_proto_fmt_0.
+ * Used for testing crt_proto_register() returning error on
+ * re-registration of the same base+version
+ */
+struct crt_proto_format my_proto_fmt_0_duplicate = {
+	.cpf_name = "my-proto-re-reg",
+	.cpf_ver = 0,
+	.cpf_base = OPC_MY_PROTO,
+
+	/* Chose different count from my_proto_fmt_0 */
+	.cpf_count = 1,
+	.cpf_prf = &my_proto_rpc_fmt_0[1],
+
+};
+
+
 struct crt_proto_format my_proto_fmt_1 = {
 	.cpf_name = "my-proto",
 	.cpf_ver = 1,

--- a/src/test/test_proto_common.h
+++ b/src/test/test_proto_common.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2018 Intel Corporation
+/* Copyright (C) 2018-2019 Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/test_proto_common.h
+++ b/src/test/test_proto_common.h
@@ -192,9 +192,7 @@ struct crt_proto_format my_proto_fmt_0_duplicate = {
 	/* Chose different count from my_proto_fmt_0 */
 	.cpf_count = 1,
 	.cpf_prf = &my_proto_rpc_fmt_0[1],
-
 };
-
 
 struct crt_proto_format my_proto_fmt_1 = {
 	.cpf_name = "my-proto",


### PR DESCRIPTION
- crt_proto_register() will now return -DER_EXIST if base_opc:version
tuple is already registered.
- crt_proto_unregister(base_opc, ver) API added to allow
unregistration of existing base_opc:version tuple.
- test_proto_client test modified to check for new behavior of
crt_proto_register and crt_proto_unregister.