### PR TITLE
CORCI-607 Cancel previous jobs in progress

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,7 +38,7 @@
  */
 // To use a test branch (i.e. PR) until it lands to master
 // I.e. for testing library changes
-//@Library(value="pipeline-lib@debug") _
+//@Library(value="pipeline-lib@your_branch") _
 
 def arch="-Linux"
 def sanitized_JOB_NAME = JOB_NAME.toLowerCase().replaceAll('/', '-').replaceAll('%2f', '-')
@@ -94,6 +94,12 @@ pipeline {
     }
 
     stages {
+        stage('Cancel Previous Builds') {
+            when { changeRequest() }
+            steps {
+                cancelPreviousBuilds()
+            }
+        }
         stage('Pre-build') {
             parallel {
                 stage('checkpatch') {


### PR DESCRIPTION
When a new patch is pushed to a PR, cancel any in-progress build/test
jobs.