### PR TITLE
CART-89 test: Fix tests to not mess up environment

### DIFF
--- a/test/cart_echo_test.py
+++ b/test/cart_echo_test.py
@@ -85,9 +85,6 @@ class TestEcho(commontestsuite.CommonTestSuite):
     def tearDown(self):
         """tear down the test"""
         self.logger.info("tearDown begin")
-        os.environ.pop("CRT_PHY_ADDR_STR", "")
-        os.environ.pop("OFI_INTERFACE", "")
-        os.environ.pop("D_LOG_MASK", "")
         self.logger.info("tearDown end\n")
 
     def test_echo_one_node(self):

--- a/test/cart_rpc_test.py
+++ b/test/cart_rpc_test.py
@@ -91,9 +91,6 @@ class TestRpc(commontestsuite.CommonTestSuite):
         self.logger.info("tearDown begin")
         self.logger.info("tearDown removing temp directory")
         shutil.rmtree(self.tempdir)
-        os.environ.pop("CRT_PHY_ADDR_STR", "")
-        os.environ.pop("OFI_INTERFACE", "")
-        os.environ.pop("D_LOG_MASK", "")
         self.logger.info("tearDown end\n")
 
     def test_rpc_node(self):

--- a/test/cart_self_test.py
+++ b/test/cart_self_test.py
@@ -63,9 +63,6 @@ class SelfTest(commontestsuite.CommonTestSuite):
     def tearDown(self):
         """tear down the test"""
         self.logger.info("tearDown begin")
-        os.environ.pop("CRT_PHY_ADDR_STR", "")
-        os.environ.pop("OFI_INTERFACE", "")
-        os.environ.pop("D_LOG_MASK", "")
         self.logger.info("tearDown end\n")
 
     def test_self_test(self):

--- a/test/cart_test_barrier.py
+++ b/test/cart_test_barrier.py
@@ -79,10 +79,6 @@ class TestBarrier(commontestsuite.CommonTestSuite):
     def tearDown(self):
         """tear down the test"""
         self.logger.info("tearDown begin")
-        os.environ.pop("CRT_PHY_ADDR_STR", "")
-        os.environ.pop("OFI_INTERFACE", "")
-        os.environ.pop("D_LOG_MASK", "")
-        os.environ.pop("CRT_TEST_SERVER", "")
         self.logger.info("tearDown end\n")
 
     def test_barrier_test(self):

--- a/test/cart_test_cart_ctl.py
+++ b/test/cart_test_cart_ctl.py
@@ -86,10 +86,6 @@ class TestCartCtl(commontestsuite.CommonTestSuite):
     def tearDown(self):
         """tear down the test"""
         self.logger.info("tearDown begin")
-        os.environ.pop("CRT_PHY_ADDR_STR", "")
-        os.environ.pop("OFI_INTERFACE", "")
-        os.environ.pop("D_LOG_MASK", "")
-        os.environ.pop("D_FI_CONFIG", "")
         self.logger.info("tearDown end\n")
 
     def test_cart_ctl_five_nodes(self):

--- a/test/cart_test_corpc_prefwd.py
+++ b/test/cart_test_corpc_prefwd.py
@@ -81,10 +81,6 @@ class TestCorpcPreFwd(commontestsuite.CommonTestSuite):
     def tearDown(self):
         """tear down the test"""
         self.logger.info("tearDown begin")
-        os.environ.pop("CRT_PHY_ADDR_STR", "")
-        os.environ.pop("OFI_INTERFACE", "")
-        os.environ.pop("D_LOG_MASK", "")
-        os.environ.pop("CRT_TEST_SERVER", "")
         self.logger.info("tearDown end\n")
 
     def test_corpc_version(self):

--- a/test/cart_test_corpc_version.py
+++ b/test/cart_test_corpc_version.py
@@ -77,10 +77,6 @@ class TestCorpcVersion(commontestsuite.CommonTestSuite):
     def tearDown(self):
         """tear down the test"""
         self.logger.info("tearDown begin")
-        os.environ.pop("CRT_PHY_ADDR_STR", "")
-        os.environ.pop("OFI_INTERFACE", "")
-        os.environ.pop("D_LOG_MASK", "")
-        os.environ.pop("CRT_TEST_SERVER", "")
         self.logger.info("tearDown end\n")
 
     def test_corpc_version(self):

--- a/test/cart_test_group.py
+++ b/test/cart_test_group.py
@@ -91,10 +91,6 @@ class TestGroup(commontestsuite.CommonTestSuite):
     def tearDown(self):
         """tear down the test"""
         self.logger.info("tearDown begin")
-        os.environ.pop("CRT_PHY_ADDR_STR", "")
-        os.environ.pop("OFI_INTERFACE", "")
-        os.environ.pop("D_LOG_MASK", "")
-        os.environ.pop("D_FI_CONFIG", "")
         self.logger.info("tearDown end\n")
 
     def test_group_one_node(self):

--- a/test/cart_test_group_tiers.py
+++ b/test/cart_test_group_tiers.py
@@ -80,9 +80,6 @@ class TestGroup(commontestsuite.CommonTestSuite):
     def tearDown(self):
         """tear down the test"""
         self.logger.info("tearDown begin")
-        os.environ.pop("CRT_PHY_ADDR_STR", "")
-        os.environ.pop("OFI_INTERFACE", "")
-        os.environ.pop("D_LOG_MASK", "")
         self.logger.info("tearDown end\n")
 
     def test_group_three_nodes(self):

--- a/test/cart_test_iv.py
+++ b/test/cart_test_iv.py
@@ -133,9 +133,6 @@ class TestIncastVariables(commontestsuite.CommonTestSuite):
     def tearDown(self):
         """tear down the test"""
         self.logger.info("tearDown begin")
-        os.environ.pop("CRT_PHY_ADDR_STR", "")
-        os.environ.pop("OFI_INTERFACE", "")
-        os.environ.pop("D_LOG_MASK", "")
         self.logger.info("tearDown end\n")
 
     def _verify_action(self, action):

--- a/test/cart_test_no_pmix.py
+++ b/test/cart_test_no_pmix.py
@@ -85,10 +85,6 @@ class TestNoPmix(commontestsuite.CommonTestSuite):
     def tearDown(self):
         """tear down the test"""
         self.logger.info("tearDown begin")
-        os.environ.pop("CRT_PHY_ADDR_STR", "")
-        os.environ.pop("OFI_INTERFACE", "")
-        os.environ.pop("D_LOG_MASK", "")
-        os.environ.pop("CRT_TEST_SERVER", "")
         self.logger.info("tearDown end")
 
     def test_no_pmix(self):

--- a/test/cart_test_no_timeout.py
+++ b/test/cart_test_no_timeout.py
@@ -88,9 +88,6 @@ class TestGroup(commontestsuite.CommonTestSuite):
     def tearDown(self):
         """tear down the test"""
         self.logger.info("tearDown begin")
-        os.environ.pop("CRT_PHY_ADDR_STR", "")
-        os.environ.pop("OFI_INTERFACE", "")
-        os.environ.pop("D_LOG_MASK", "")
         self.logger.info("tearDown end\n")
 
     def test_no_timeout_one_node(self):

--- a/test/cart_test_pmix.py
+++ b/test/cart_test_pmix.py
@@ -69,7 +69,6 @@ class TestPMIx(commontestsuite.CommonTestSuite):
     def tearDown(self):
         """tear down the test"""
         self.logger.info("tearDown begin")
-        os.environ.pop("D_LOG_MASK", "")
         self.logger.info("tearDown end\n")
 
     def test_pmix_one_node(self):

--- a/test/cart_test_proto.py
+++ b/test/cart_test_proto.py
@@ -79,9 +79,6 @@ class TestGroup(commontestsuite.CommonTestSuite):
     def tearDown(self):
         """tear down the test"""
         self.logger.info("tearDown begin")
-        os.environ.pop("CRT_PHY_ADDR_STR", "")
-        os.environ.pop("OFI_INTERFACE", "")
-        os.environ.pop("D_LOG_MASK", "")
         self.logger.info("tearDown end\n")
 
     def test_proto_one_node(self):

--- a/test/cart_test_rpc_error.py
+++ b/test/cart_test_rpc_error.py
@@ -85,9 +85,6 @@ class TestRpcError(commontestsuite.CommonTestSuite):
     def tearDown(self):
         """tear down the test"""
         self.logger.info("tearDown begin")
-        os.environ.pop("CRT_PHY_ADDR_STR", "")
-        os.environ.pop("OFI_INTERFACE", "")
-        os.environ.pop("D_LOG_MASK", "")
         self.logger.info("tearDown end\n")
 
     def test_rpc_error_one_node(self):

--- a/test/cart_threaded_test.py
+++ b/test/cart_threaded_test.py
@@ -83,9 +83,6 @@ class TestThreaded(commontestsuite.CommonTestSuite):
     def tearDown(self):
         """tear down the test"""
         self.logger.info("tearDown begin")
-        os.environ.pop("CRT_PHY_ADDR_STR", "")
-        os.environ.pop("OFI_INTERFACE", "")
-        os.environ.pop("D_LOG_MASK", "")
         self.logger.info("tearDown end\n")
 
     def test_threaded_one_node(self):


### PR DESCRIPTION
tearDown() methods in tests used to unset envrionment variables
that were previously set via yml defaultENV setting.
This caused python tests with multiple test functions to clobber
the enviornment after the first test function finishes execution.