### PR TITLE
Enable really strict stack depth testing.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -168,8 +168,8 @@ pipeline {
                         }
                     }
                     steps {
-                        sconsBuild(clean: "_build.external${arch}"
-                                   scons_args: '--warning-level=warning')			   
+                        sconsBuild(clean: "_build.external${arch}",
+                                   scons_args: '--warning-level=warning')
                         // this really belongs in the test stage CORCI-530
                         sh '''scons utest --utest-mode=memcheck
                               mv build/Linux/src/utest{,_valgrind}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -168,7 +168,8 @@ pipeline {
                         }
                     }
                     steps {
-                        sconsBuild clean: "_build.external${arch}"
+                        sconsBuild(clean: "_build.external${arch}"
+                                   scons_args: '--warning-level=warning')			   
                         // this really belongs in the test stage CORCI-530
                         sh '''scons utest --utest-mode=memcheck
                               mv build/Linux/src/utest{,_valgrind}

--- a/SConstruct
+++ b/SConstruct
@@ -49,6 +49,7 @@ except ImportError:
 # Desired compiler flags that will be used if the compiler supports them.
 DESIRED_FLAGS = ['-Wno-gnu-designator',
                  '-Wno-missing-braces',
+                 '-Wframe-larger-than=128',
                  '-Wno-gnu-zero-variadic-macro-arguments',
                  '-Wno-tautological-constant-out-of-range-compare']
 
@@ -109,7 +110,7 @@ def scons():
         env.Append(SHLIBSUFFIX='.so')
 
     # Compiler options
-    env.Append(CCFLAGS=['-g3', '-Wshadow', '-Wall', '-Werror', '-fpic',
+    env.Append(CCFLAGS=['-g3', '-Wshadow', '-Wall', '-fpic',
                         '-D_GNU_SOURCE', '-DD_LOG_V2'])
     env.Append(CCFLAGS=['-O2', '-pthread'])
     env.Append(CFLAGS=['-std=gnu99'])


### PR DESCRIPTION
Turn compile warnings into warnings.  This should cause the build to
continue, record all errors and then have the warnings plugin fail
the build, so the end result is similar, however with better error
reporting.