### PR TITLE
CART-89 build: change preprocessor

### DIFF
--- a/src/cart/SConscript
+++ b/src/cart/SConscript
@@ -98,6 +98,7 @@ def scons():
     denv.AppendUnique(RPATH=['$PREFIX/lib'])
 
     pp_env = Environment(TOOLS=['default', 'extra'])
+    pp_env.Replace(CC=env['CC'])
     pp_env.AppendUnique(CPPPATH=['src/include', 'src/cart'])
     prereqs.require(pp_env, 'mercury', 'pmix', headers_only=True)
 


### PR DESCRIPTION
change the preprocessor used for preprocessing to the same one used for
compiling. Previously gcc is used for preprocessing no matter what
compiler is supplied uisng
        scons COMPILER=