### PR TITLE
CART-594 swim: Provide public API to get rank SWIM state

### DIFF
--- a/src/cart/crt_swim.c
+++ b/src/cart/crt_swim.c
@@ -615,3 +615,39 @@ void crt_swim_rank_del_all(struct crt_grp_priv *grp_priv)
 	}
 	D_RWLOCK_UNLOCK(&csm->csm_rwlock);
 }
+
+int
+crt_rank_state_get(crt_group_t *grp, d_rank_t rank,
+		   struct swim_member_state *state)
+{
+	struct crt_grp_priv	*grp_priv;
+	struct crt_swim_membs	*csm;
+	int			 rc = 0;
+
+	if (grp == NULL) {
+		D_ERROR("Passed group is NULL\n");
+		D_GOTO(out, rc = -DER_INVAL);
+	}
+
+	if (state == NULL) {
+		D_ERROR("Passed state pointer is NULL\n");
+		D_GOTO(out, rc = -DER_INVAL);
+	}
+
+	if (rank == CRT_NO_RANK) {
+		D_ERROR("Rank is invalid\n");
+		D_GOTO(out, rc = -DER_INVAL);
+	}
+
+	grp_priv = crt_grp_pub2priv(grp);
+	if (!grp_priv->gp_primary) {
+		D_ERROR("Only available for primary groups\n");
+		D_GOTO(out, rc = -DER_INVAL);
+	}
+
+	csm = &grp_priv->gp_membs_swim;
+	rc = crt_swim_get_member_state(csm->csm_ctx, (swim_id_t)rank, state);
+
+out:
+	return rc;
+}

--- a/src/include/cart/api.h
+++ b/src/include/cart/api.h
@@ -1781,9 +1781,9 @@ crt_rank_uri_get(crt_group_t *grp, d_rank_t rank, int tag, char **uri);
 /**
  * Get rank SWIM state.
  *
- * \param[in] grp               Group identifier
- * \param[in] rank              Rank to get SWIM state for
- * \param[in] state             The pointer to store SWIM state
+ * \param[in]  grp              Group identifier
+ * \param[in]  rank             Rank to get SWIM state for
+ * \param[out] state            The pointer to store SWIM state
  *
  * \return                      DER_SUCCESS on success, negative value on
  *                              failure.

--- a/src/include/cart/api.h
+++ b/src/include/cart/api.h
@@ -54,6 +54,7 @@
 #include <cart/types.h>
 #include <gurt/errno.h>
 #include <cart/iv.h>
+#include <cart/swim.h>
 
 #if defined(__cplusplus)
 extern "C" {
@@ -1776,6 +1777,20 @@ crt_rank_self_set(d_rank_t rank);
  */
 int
 crt_rank_uri_get(crt_group_t *grp, d_rank_t rank, int tag, char **uri);
+
+/**
+ * Get rank SWIM state.
+ *
+ * \param[in] grp               Group identifier
+ * \param[in] rank              Rank to get SWIM state for
+ * \param[in] state             The pointer to store SWIM state
+ *
+ * \return                      DER_SUCCESS on success, negative value on
+ *                              failure.
+ */
+int
+crt_rank_state_get(crt_group_t *grp, d_rank_t rank,
+		   struct swim_member_state *state);
 
 /**
  * Remove specified rank from the group.


### PR DESCRIPTION
This API provide ability to check current SWIM state of any rank.