### PR TITLE
yulujia/fix build

### DIFF
--- a/src/cart/SConscript
+++ b/src/cart/SConscript
@@ -97,8 +97,7 @@ def scons():
     prereqs.require(denv, 'mercury', 'pmix')
     denv.AppendUnique(RPATH=['$PREFIX/lib'])
 
-    pp_env = Environment(TOOLS=['default', 'extra'])
-    pp_env.Replace(CC=env['CC'])
+    pp_env = env.Clone(TOOLS=['default', 'extra'])
     pp_env.AppendUnique(CPPPATH=['src/include', 'src/cart'])
     prereqs.require(pp_env, 'mercury', 'pmix', headers_only=True)
 

--- a/src/cart/SConscript
+++ b/src/cart/SConscript
@@ -97,7 +97,7 @@ def scons():
     prereqs.require(denv, 'mercury', 'pmix')
     denv.AppendUnique(RPATH=['$PREFIX/lib'])
 
-    pp_env = env.Clone(TOOLS=['default', 'extra'])
+    pp_env = env.Clone(tools=['extra'])
     pp_env.AppendUnique(CPPPATH=['src/include', 'src/cart'])
     prereqs.require(pp_env, 'mercury', 'pmix', headers_only=True)
 

--- a/src/cart/SConscript
+++ b/src/cart/SConscript
@@ -98,6 +98,7 @@ def scons():
     denv.AppendUnique(RPATH=['$PREFIX/lib'])
 
     pp_env = Environment(TOOLS=['default', 'extra'])
+    pp_env.Replace(CC=env['CC'])
     pp_env.AppendUnique(CPPPATH=['src/include', 'src/cart'])
     prereqs.require(pp_env, 'mercury', 'pmix', headers_only=True)
 


### PR DESCRIPTION
CART-89 build: change preprocessor

change the preprocessor used for preprocessing to the same one used for
compiling. Previously gcc is used for preprocessing no matter what 
compiler is supplied uisng
            scons COMPILER=xxx

Note: this is just for the auto-generated header files to help developers, not 
for the preprocessor used to build the code.