### PR TITLE
CART-594 group: Fix types of dead events

### DIFF
--- a/src/cart/crt_swim.c
+++ b/src/cart/crt_swim.c
@@ -247,7 +247,7 @@ crt_swim_notify_rank_state(d_rank_t rank, struct swim_member_state *state)
 		cb_type = CRT_EVT_ALIVE;
 		break;
 	case SWIM_MEMBER_DEAD:
-		cb_type = CRT_EVT_ALIVE;
+		cb_type = CRT_EVT_DEAD;
 		break;
 	default:
 		return;


### PR DESCRIPTION
crt_swim_notify_rank_state delivers an incorrect event type, likely due
to a copy-paste error.

Change-Id: I4c7113808d0bdd784f3b72549f12abc7457f9dcf
Signed-off-by: Li Wei <wei.g.li@intel.com>