### PR TITLE
CART-89 gurt: fix bug in fault injection

### DIFF
--- a/src/gurt/fault_inject.c
+++ b/src/gurt/fault_inject.c
@@ -559,6 +559,8 @@ d_fault_inject_init(void)
 			config_file);
 		d_fault_config_file = 1;
 		d_fault_inject = 1;
+	} else {
+		D_ERROR("Failed to parse fault config file.\n");
 		D_GOTO(out, rc);
 	}
 


### PR DESCRIPTION
Fix a bug in fault injection. The attribute pointer that controls FI in
memory allocations was not initialized.

Ashley found the bug.