### PR TITLE
CART-598 bugfix: client hangs with multiple RPCs in flight

### DIFF
--- a/src/cart/crt_context.c
+++ b/src/cart/crt_context.c
@@ -675,7 +675,7 @@ crt_req_timeout_reset(struct crt_rpc_priv *rpc_priv)
 	}
 	RPC_TRACE(DB_NET, rpc_priv, "reset_timer enabled.\n");
 
-	rpc_priv->crp_timeout_ts = crt_get_timeout(rpc_priv);
+	crt_set_timeout(rpc_priv);
 	D_MUTEX_LOCK(&crt_ctx->cc_mutex);
 	rc = crt_req_timeout_track(rpc_priv);
 	D_MUTEX_UNLOCK(&crt_ctx->cc_mutex);
@@ -875,7 +875,7 @@ crt_context_req_track(struct crt_rpc_priv *rpc_priv)
 	/* add the RPC req to crt_ep_inflight */
 	D_MUTEX_LOCK(&epi->epi_mutex);
 	D_ASSERT(epi->epi_req_num >= epi->epi_reply_num);
-	rpc_priv->crp_timeout_ts = crt_get_timeout(rpc_priv);
+	crt_set_timeout(rpc_priv);
 	rpc_priv->crp_epi = epi;
 	RPC_ADDREF(rpc_priv);
 	if (crt_gdata.cg_credit_ep_ctx != 0 &&
@@ -996,7 +996,7 @@ crt_context_req_untrack(struct crt_rpc_priv *rpc_priv)
 		tmp_rpc = d_list_entry(epi->epi_req_waitq.next,
 					struct crt_rpc_priv, crp_epi_link);
 		tmp_rpc->crp_state = RPC_STATE_INITED;
-		tmp_rpc->crp_timeout_ts = crt_get_timeout(tmp_rpc);
+		crt_set_timeout(tmp_rpc);
 
 		D_MUTEX_LOCK(&crt_ctx->cc_mutex);
 		rc = crt_req_timeout_track(tmp_rpc);
@@ -1028,8 +1028,8 @@ crt_context_req_untrack(struct crt_rpc_priv *rpc_priv)
 			continue;
 
 		RPC_ADDREF(tmp_rpc);
-		D_ERROR("crt_req_send_internal failed, rc: %d, opc: %#x.\n",
-			rc, tmp_rpc->crp_pub.cr_opc);
+		RPC_ERROR(tmp_rpc, "crt_req_send_internal failed, rc: %d\n",
+			rc);
 		tmp_rpc->crp_state = RPC_STATE_INITED;
 		crt_context_req_untrack(tmp_rpc);
 		/* for error case here */

--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -93,8 +93,14 @@ static int data_init(crt_init_options_t *opt)
 	D_DEBUG(DB_ALL, "set the global timeout value as %d second.\n",
 		crt_gdata.cg_timeout);
 
-	credits = CRT_DEFAULT_CREDITS_PER_EP_CTX;
-	d_getenv_int("CRT_CREDIT_EP_CTX", &credits);
+	/* Override defaults and environment if option is set */
+	if (opt && opt->cio_use_credits) {
+		credits = opt->cio_ep_credits;
+	} else {
+		credits = CRT_DEFAULT_CREDITS_PER_EP_CTX;
+		d_getenv_int("CRT_CREDIT_EP_CTX", &credits);
+	}
+
 	if (credits == 0) {
 		D_DEBUG(DB_ALL, "CRT_CREDIT_EP_CTX set as 0, flow control "
 			"disabled.\n");

--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -596,7 +596,7 @@ crt_req_uri_lookup_retry(struct crt_grp_priv *grp_priv,
 	D_MUTEX_LOCK(&crt_ctx->cc_mutex);
 	if (!crt_req_timedout(rpc_priv))
 		crt_req_timeout_untrack(rpc_priv);
-	rpc_priv->crp_timeout_ts = crt_get_timeout(rpc_priv);
+	crt_set_timeout(rpc_priv);
 	rc = crt_req_timeout_track(rpc_priv);
 	D_MUTEX_UNLOCK(&crt_ctx->cc_mutex);
 	if (rc != 0) {

--- a/src/cart/crt_rpc.h
+++ b/src/cart/crt_rpc.h
@@ -666,15 +666,22 @@ crt_req_timedout(struct crt_rpc_priv *rpc_priv)
 }
 
 static inline uint64_t
-crt_get_timeout(struct crt_rpc_priv *rpc_priv)
+crt_set_timeout(struct crt_rpc_priv *rpc_priv)
 {
 	uint32_t	timeout_sec;
+	uint64_t	sec_diff;
+
+	D_ASSERT(rpc_priv != NULL);
 
 	timeout_sec = rpc_priv->crp_timeout_sec > 0 ?
 		      rpc_priv->crp_timeout_sec : crt_gdata.cg_timeout;
 
-	return d_timeus_secdiff(timeout_sec);
+	sec_diff = d_timeus_secdiff(timeout_sec);
+	rpc_priv->crp_timeout_ts = sec_diff;
+
+	return sec_diff;
 }
+
 
 /* crt_corpc.c */
 int crt_corpc_req_hdlr(struct crt_rpc_priv *rpc_priv);

--- a/src/include/cart/types.h
+++ b/src/include/cart/types.h
@@ -72,19 +72,26 @@ typedef struct crt_init_options {
 	/**
 	 * if cio_sep_override is 0, the two fields following it won't be used.
 	 */
-	uint32_t	 cio_sep_override:1,
-			 /**
-			  * overrides the value of the environment variable
-			  * CRT_CTX_SHARE_ADDR
-			  */
-			 cio_use_sep:1,
-			 /** whether or not to inject faults */
-			 cio_fault_inject:1;
-			 /**
-			  * overrides the value of the environment variable
-			  * CRT_CTX_NUM
-			  */
-	int		 cio_ctx_max_num;
+	uint32_t	cio_sep_override:1,
+			/**
+			* overrides the value of the environment variable
+			* CRT_CTX_SHARE_ADDR
+			*/
+			cio_use_sep:1,
+			/** whether or not to inject faults */
+			cio_fault_inject:1,
+			/** whether or not to override credits. When set
+			* overrides CRT_CTX_EP_CREDITS envariable
+			*/
+			cio_use_credits:1;
+			/**
+			* overrides the value of the environment variable
+			* CRT_CTX_NUM
+			*/
+	int		cio_ctx_max_num;
+
+			/** Used with cio_use_credits to set credit limit */
+	int		cio_ep_credits;
 } crt_init_options_t;
 
 typedef int		 crt_status_t;

--- a/src/test/SConscript
+++ b/src/test/SConscript
@@ -43,7 +43,8 @@ SIMPLE_TEST_SRC = ['test_no_pmix.c', 'test_crt_barrier.c', 'threaded_client.c',
                    'threaded_server.c', 'test_pmix.c',
                    'test_corpc_version.c', 'test_corpc_prefwd.c',
                    'test_proto_server.c', 'test_proto_client.c',
-                   'test_no_timeout.c']
+                   'test_no_timeout.c', 'test_ep_cred_server.c',
+                   'test_ep_cred_client.c']
 ECHO_TEST_SRC = ['crt_echo_cli.c', 'crt_echo_srv.c', 'crt_echo_srv2.c']
 BASIC_SRC = ['crt_basic.c']
 TEST_GROUP_SRC = 'test_group.c'

--- a/src/test/test_ep_cred_client.c
+++ b/src/test/test_ep_cred_client.c
@@ -1,0 +1,214 @@
+/* Copyright (C) 2018-2019 Intel Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted for any purpose (including commercial purposes)
+ * provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions, and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions, and the following disclaimer in the
+ *    documentation and/or materials provided with the distribution.
+ *
+ * 3. In addition, redistributions of modified forms of the source or binary
+ *    code must carry prominent notices stating that the original code was
+ *    changed and the date of the change.
+ *
+ *  4. All publications or advertising materials mentioning features or use of
+ *     this software are asked, but not required, to acknowledge that it was
+ *     developed by Intel Corporation and credit the contributors.
+ *
+ * 5. Neither the name of Intel Corporation, nor the name of any Contributor
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <cart/api.h>
+#include <gurt/common.h>
+#include <semaphore.h>
+
+#include "test_ep_cred_common.h"
+
+static void
+attach_to_server()
+{
+	int	num_retries = 120;
+	int	retry;
+	int	rc;
+
+	/* try until success to avoid intermittent failures under valgrind. */
+	D_DEBUG(DB_TRACE, "about attach to server\n");
+	for (retry = 0; retry < num_retries; retry++) {
+		sleep(1);
+		printf("Attaching to group %s\n", test.tg_remote_group_name);
+		rc = crt_group_attach(test.tg_remote_group_name,
+				      &test.tg_remote_group);
+		if (rc == DER_SUCCESS)
+			break;
+	}
+	D_ASSERTF(rc == 0, "crt_group_attach failed, rc: %d\n", rc);
+	D_ASSERTF(test.tg_remote_group != NULL, "NULL attached srv_grp\n");
+}
+
+
+static void
+test_init()
+{
+	int			rc;
+	crt_init_options_t	opt = {0};
+
+	fprintf(stderr, "local group: %s remote group: %s\n",
+		test.tg_local_group_name, test.tg_remote_group_name);
+
+	rc = d_log_init();
+	assert(rc == 0);
+
+	rc = sem_init(&test.tg_token_to_proceed, 0, 0);
+	D_ASSERTF(rc == 0, "sem_init() failed.\n");
+
+	opt.cio_use_credits = 1;
+	opt.cio_ep_credits = test.tg_credits;
+
+	D_DEBUG(DB_TRACE, "Number of credits: %d Number of burst: %d\n",
+		test.tg_credits, test.tg_burst_count);
+
+	rc = crt_init_opt(test.tg_local_group_name,
+			CRT_FLAG_BIT_SINGLETON, &opt);
+	D_ASSERTF(rc == 0, "crt_init() failed, rc: %d\n", rc);
+
+	if (test.tg_should_attach)
+		attach_to_server();
+
+	rc = crt_group_rank(NULL, &test.tg_my_rank);
+	D_ASSERTF(rc == 0, "crt_group_rank() failed. rc: %d\n", rc);
+
+	rc = crt_proto_register(&my_proto_fmt_0);
+	D_ASSERTF(rc == 0, "registration failed with rc: %d\n", rc);
+
+	rc = crt_context_create(&test.tg_crt_ctx);
+	D_ASSERTF(rc == 0, "crt_context_create() failed. rc: %d\n", rc);
+
+	rc = pthread_create(&test.tg_tid, NULL, progress_thread,
+			    &test.tg_thread_id);
+	D_ASSERTF(rc == 0, "pthread_create() failed. rc: %d\n", rc);
+}
+
+static int resp_count;
+static int sent_count;
+
+static void
+rpc_handle_reply(const struct crt_cb_info *info)
+{
+	resp_count++;
+	D_DEBUG(DB_TRACE, "Response count=%d\n", resp_count);
+
+	if (resp_count == sent_count) {
+		D_DEBUG(DB_ALL, "received all expected replies\n");
+		sem_post(&test.tg_token_to_proceed);
+	}
+}
+
+static void
+test_run()
+{
+	crt_endpoint_t	ep;
+	crt_rpc_t	*rpc;
+	int		i;
+	int		rc;
+	struct ping_in	*input;
+
+	ep.ep_grp = NULL;
+	ep.ep_rank = 0;
+	ep.ep_tag = 0;
+
+	D_DEBUG(DB_TRACE, "Sending %d rpcs\n", test.tg_burst_count);
+
+	for (i = 0; i < test.tg_burst_count; i++) {
+		rc = crt_req_create(test.tg_crt_ctx, &ep, OPC_PING, &rpc);
+		assert(rc == 0);
+
+		input = crt_req_get(rpc);
+		if (i == 0)
+			input->pi_delay = 1;
+		else
+			input->pi_delay = 0;
+
+		rc = crt_req_send(rpc, rpc_handle_reply, NULL);
+		assert(rc == 0);
+		sent_count++;
+	}
+
+	D_DEBUG(DB_TRACE, "Waiting for responses to %d rpcs\n",
+		test.tg_burst_count);
+	test_sem_timedwait(&test.tg_token_to_proceed, 21, __LINE__);
+	D_DEBUG(DB_TRACE, "Got all responses\n");
+
+	if (test.tg_send_shutdown) {
+		/* Send shutdown to the server */
+		rc = crt_req_create(test.tg_crt_ctx, &ep, OPC_SHUTDOWN, &rpc);
+		D_ASSERTF(rc == 0, "crt_req_create() failed; rc=%d\n", rc);
+
+		rc = crt_req_send(rpc, NULL, NULL);
+		D_ASSERTF(rc == 0, "crt_req_send() failed; rc=%d\n", rc);
+	}
+}
+
+
+static void
+test_fini()
+{
+	int	rc;
+
+	if (test.tg_should_attach) {
+		rc = crt_group_detach(test.tg_remote_group);
+		D_ASSERTF(rc == 0, "crt_group_detach failed, rc: %d\n", rc);
+	}
+
+	test.tg_shutdown = 1;
+
+	rc = pthread_join(test.tg_tid, NULL);
+	D_ASSERTF(rc == 0, "pthread_join failed. rc: %d\n", rc);
+	D_DEBUG(DB_TRACE, "joined progress thread.\n");
+
+
+	rc = crt_context_destroy(test.tg_crt_ctx, 1);
+	D_ASSERTF(rc == 0, "crt_context_destroy() failed. rc: %d\n", rc);
+
+	rc = sem_destroy(&test.tg_token_to_proceed);
+	D_ASSERTF(rc == 0, "sem_destroy() failed.\n");
+
+	rc = crt_finalize();
+	D_ASSERTF(rc == 0, "crt_finalize() failed. rc: %d\n", rc);
+	D_DEBUG(DB_TRACE, "exiting.\n");
+
+	d_log_fini();
+}
+
+int
+main(int argc, char **argv)
+{
+	int	rc;
+
+	rc = test_parse_args(argc, argv);
+	if (rc != 0) {
+		fprintf(stderr, "test_parse_args() failed, rc: %d.\n", rc);
+		return rc;
+	}
+	test_init();
+	test_run();
+	test_fini();
+
+	return rc;
+}

--- a/src/test/test_ep_cred_client.c
+++ b/src/test/test_ep_cred_client.c
@@ -152,7 +152,7 @@ test_run()
 
 	D_DEBUG(DB_TRACE, "Waiting for responses to %d rpcs\n",
 		test.tg_burst_count);
-	test_sem_timedwait(&test.tg_token_to_proceed, 21, __LINE__);
+	test_sem_timedwait(&test.tg_token_to_proceed, 61, __LINE__);
 	D_DEBUG(DB_TRACE, "Got all responses\n");
 
 	if (test.tg_send_shutdown) {

--- a/src/test/test_ep_cred_common.h
+++ b/src/test/test_ep_cred_common.h
@@ -1,0 +1,248 @@
+/* Copyright (C) 2018-2019 Intel Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted for any purpose (including commercial purposes)
+ * provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions, and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions, and the following disclaimer in the
+ *    documentation and/or materials provided with the distribution.
+ *
+ * 3. In addition, redistributions of modified forms of the source or binary
+ *    code must carry prominent notices stating that the original code was
+ *    changed and the date of the change.
+ *
+ *  4. All publications or advertising materials mentioning features or use of
+ *     this software are asked, but not required, to acknowledge that it was
+ *     developed by Intel Corporation and credit the contributors.
+ *
+ * 5. Neither the name of Intel Corporation, nor the name of any Contributor
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef __TEST_EP_CRED_COMMON_H__
+#define __TEST_EP_CRED_COMMON_H__
+
+#include <getopt.h>
+#include <semaphore.h>
+
+#include <gurt/common.h>
+#include <cart/api.h>
+
+#define OPC_MY_PROTO    (0x01000000)
+#define OPC_PING	(0x01000000)
+#define OPC_SHUTDOWN    (0x01000001)
+
+struct test_global_t {
+	crt_group_t		*tg_local_group;
+	crt_group_t		*tg_remote_group;
+	char			*tg_local_group_name;
+	char			*tg_remote_group_name;
+	uint32_t		 tg_remote_group_size;
+	uint32_t		 tg_is_service:1,
+				 tg_should_attach:1,
+				 /* notify the progress thread to exit */
+				 tg_shutdown:1,
+				 tg_hold:1;
+	uint32_t		 tg_my_rank;
+	crt_context_t		 tg_crt_ctx;
+	pthread_t		 tg_tid;
+	int			 tg_thread_id;
+	sem_t			 tg_token_to_proceed;
+	int			 tg_credits;
+	int			 tg_burst_count;
+	int			 tg_send_shutdown;
+};
+
+struct test_global_t test = {0};
+
+#define CRT_ISEQ_PING		/* input fields */		 \
+	((uint32_t)		(pi_delay)		CRT_VAR)
+
+#define CRT_OSEQ_PING		/* output fields */		 \
+	((uint32_t)		(po_magic)		CRT_VAR)
+
+CRT_RPC_DECLARE(ping, CRT_ISEQ_PING, CRT_OSEQ_PING)
+CRT_RPC_DEFINE(ping, CRT_ISEQ_PING, CRT_OSEQ_PING)
+
+static void
+ping_hdlr_0(crt_rpc_t *rpc_req)
+{
+	int		rc;
+	struct ping_in	*input;
+
+	D_DEBUG(DB_TRACE, "entered %s().\n", __func__);
+
+	input = crt_req_get(rpc_req);
+	if (input->pi_delay != 0) {
+		D_DEBUG(DB_TRACE, "sleep for %d\n", input->pi_delay);
+		sleep(input->pi_delay);
+	}
+
+	rc = crt_reply_send(rpc_req);
+	D_ASSERTF(rc == 0, "crt_reply_send() failed. rc: %d\n", rc);
+}
+
+
+static void
+shutdown_handler(crt_rpc_t *rpc_req)
+{
+	D_DEBUG(DB_TRACE, "received shutdown request, opc: %#x.\n",
+		rpc_req->cr_opc);
+
+	D_ASSERTF(rpc_req->cr_input == NULL, "RPC request has invalid input\n");
+	D_ASSERTF(rpc_req->cr_output == NULL, "RPC request output is NULL\n");
+
+	test.tg_shutdown = 1;
+	D_DEBUG(DB_TRACE, "server set shutdown flag.\n");
+}
+
+struct crt_proto_rpc_format my_proto_rpc_fmt_0[] = {
+	{
+		.prf_flags	= 0,
+		.prf_req_fmt	= &CQF_ping,
+		.prf_hdlr	= ping_hdlr_0,
+		.prf_co_ops	= NULL,
+	}, {
+		.prf_flags	= CRT_RPC_FEAT_NO_REPLY,
+		.prf_req_fmt	= NULL,
+		.prf_hdlr	= shutdown_handler,
+		.prf_co_ops	= NULL,
+	}
+};
+
+
+struct crt_proto_format my_proto_fmt_0 = {
+	.cpf_name = "my-proto",
+	.cpf_ver = 0,
+	.cpf_count = ARRAY_SIZE(my_proto_rpc_fmt_0),
+	.cpf_prf = &my_proto_rpc_fmt_0[0],
+	.cpf_base = OPC_MY_PROTO,
+};
+
+
+int
+test_parse_args(int argc, char **argv)
+{
+	int				option_index = 0;
+	int				rc = 0;
+	struct option			long_options[] = {
+		{"name",	required_argument,	0, 'n'},
+		{"attach_to",	required_argument,	0, 'a'},
+		{"hold",	no_argument,		0, 'h'},
+		{"is_service",	no_argument,		0, 's'},
+		{"credits",	required_argument,	0, 'c'},
+		{"burst",	required_argument,	0, 'b'},
+		{"shutdown",	no_argument,		0, 'q'},
+		{0, 0, 0, 0}
+	};
+
+	while (1) {
+		rc = getopt_long(argc, argv, "n:a:b:c:hsq", long_options,
+				 &option_index);
+		if (rc == -1)
+			break;
+		switch (rc) {
+		case 0:
+			if (long_options[option_index].flag != 0)
+				break;
+		case 'n':
+			test.tg_local_group_name = optarg;
+			break;
+		case 'a':
+			test.tg_remote_group_name = optarg;
+			test.tg_should_attach = 1;
+			break;
+		case 'h':
+			test.tg_hold = 1;
+			break;
+		case 's':
+			test.tg_is_service = 1;
+			break;
+		case 'b':
+			test.tg_burst_count = atoi(optarg);
+			break;
+		case 'c':
+			test.tg_credits = atoi(optarg);
+			break;
+		case 'q':
+			test.tg_send_shutdown = 1;
+			break;
+		case '?':
+			return 1;
+		default:
+			return 1;
+		}
+	}
+	if (optind < argc) {
+		fprintf(stderr, "non-option argv elements encountered");
+		return 1;
+	}
+
+	return 0;
+}
+
+static void *
+progress_thread(void *arg)
+{
+	crt_context_t	ctx;
+	pthread_t	current_thread = pthread_self();
+	int		num_cores = sysconf(_SC_NPROCESSORS_ONLN);
+	cpu_set_t	cpuset;
+	int		t_idx;
+	int		rc;
+
+	t_idx = *(int *)arg;
+	CPU_ZERO(&cpuset);
+	CPU_SET(t_idx % num_cores, &cpuset);
+	pthread_setaffinity_np(current_thread, sizeof(cpu_set_t), &cpuset);
+
+	D_DEBUG(DB_ALL, "progress thread %d running on core %d...\n",
+		t_idx, sched_getcpu());
+
+	ctx = test.tg_crt_ctx;
+	/* progress loop */
+	while (1) {
+		rc = crt_progress(ctx, 0, NULL, NULL);
+		if (rc != 0 && rc != -DER_TIMEDOUT)
+			D_ERROR("crt_progress failed rc: %d.\n", rc);
+		if (test.tg_shutdown == 1)
+			break;
+	};
+
+	D_DEBUG(DB_ALL, "progress_thread: progress thread exit ...\n");
+
+	pthread_exit(NULL);
+}
+
+static inline void
+test_sem_timedwait(sem_t *sem, int sec, int line_number)
+{
+	struct timespec			deadline;
+	int				rc;
+
+	rc = clock_gettime(CLOCK_REALTIME, &deadline);
+	D_ASSERTF(rc == 0, "clock_gettime() failed at line %d rc: %d\n",
+		  line_number, rc);
+	deadline.tv_sec += sec;
+	rc = sem_timedwait(sem, &deadline);
+	D_ASSERTF(rc == 0, "sem_timedwait() failed at line %d rc: %d\n",
+		  line_number, rc);
+}
+
+#endif /* __TEST_EP_CRED_COMMON_H__ */

--- a/src/test/test_ep_cred_server.c
+++ b/src/test/test_ep_cred_server.c
@@ -1,0 +1,133 @@
+/* Copyright (C) 2018-2019 Intel Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted for any purpose (including commercial purposes)
+ * provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions, and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions, and the following disclaimer in the
+ *    documentation and/or materials provided with the distribution.
+ *
+ * 3. In addition, redistributions of modified forms of the source or binary
+ *    code must carry prominent notices stating that the original code was
+ *    changed and the date of the change.
+ *
+ *  4. All publications or advertising materials mentioning features or use of
+ *     this software are asked, but not required, to acknowledge that it was
+ *     developed by Intel Corporation and credit the contributors.
+ *
+ * 5. Neither the name of Intel Corporation, nor the name of any Contributor
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <cart/api.h>
+#include <gurt/common.h>
+#include <semaphore.h>
+#include "test_ep_cred_common.h"
+
+static void
+test_init()
+{
+	uint32_t	flag;
+	int		rc;
+	crt_init_options_t opt = {0};
+
+	fprintf(stderr, "local group: %s remote group: %s\n",
+		test.tg_local_group_name, test.tg_remote_group_name);
+
+	rc = d_log_init();
+	assert(rc == 0);
+
+	rc = sem_init(&test.tg_token_to_proceed, 0, 0);
+	D_ASSERTF(rc == 0, "sem_init() failed.\n");
+
+	opt.cio_use_credits = 1;
+	opt.cio_ep_credits = test.tg_credits;
+
+	flag = test.tg_is_service ? CRT_FLAG_BIT_SERVER : 0;
+	flag |= CRT_FLAG_BIT_LM_DISABLE;
+	rc = crt_init_opt(test.tg_local_group_name, flag, &opt);
+	D_ASSERTF(rc == 0, "crt_init() failed, rc: %d\n", rc);
+
+	rc = crt_group_rank(NULL, &test.tg_my_rank);
+	D_ASSERTF(rc == 0, "crt_group_rank() failed. rc: %d\n", rc);
+
+	rc = crt_proto_register(&my_proto_fmt_0);
+	D_ASSERT(rc == 0);
+
+	rc = crt_context_create(&test.tg_crt_ctx);
+	D_ASSERTF(rc == 0, "crt_context_create() failed. rc: %d\n", rc);
+
+	if (test.tg_is_service) {
+		rc = crt_group_config_save(NULL, true);
+		D_ASSERTF(rc == 0, "crt_group_config_save() failed. rc: %d\n",
+			rc);
+	}
+
+	rc = pthread_create(&test.tg_tid, NULL, progress_thread,
+			    &test.tg_thread_id);
+	D_ASSERTF(rc == 0, "pthread_create() failed. rc: %d\n", rc);
+}
+
+
+static void
+test_run()
+{
+	D_DEBUG(DB_TRACE, "test_run\n");
+}
+
+/************************************************/
+static void
+test_fini()
+{
+	int	rc;
+
+	rc = pthread_join(test.tg_tid, NULL);
+	D_ASSERTF(rc == 0, "pthread_join failed. rc: %d\n", rc);
+	D_DEBUG(DB_TRACE, "joined progress thread.\n");
+
+	rc = crt_context_destroy(test.tg_crt_ctx, false);
+	D_ASSERTF(rc == 0, "crt_context_destroy() failed. rc: %d\n", rc);
+
+	rc = sem_destroy(&test.tg_token_to_proceed);
+	D_ASSERTF(rc == 0, "sem_destroy() failed.\n");
+
+	rc = crt_finalize();
+	D_ASSERTF(rc == 0, "crt_finalize() failed. rc: %d\n", rc);
+	D_DEBUG(DB_TRACE, "exiting.\n");
+
+	d_log_fini();
+}
+
+int
+main(int argc, char **argv)
+{
+	int	rc;
+
+	rc = test_parse_args(argc, argv);
+	if (rc != 0) {
+		fprintf(stderr, "test_parse_args() failed, rc: %d.\n", rc);
+		return rc;
+	}
+
+	test_init();
+	test_run();
+	test_fini();
+
+	return rc;
+}

--- a/test/cart_test_ep_credits.py
+++ b/test/cart_test_ep_credits.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+# Copyright (C) 2018-2019 Intel Corporation
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted for any purpose (including commercial purposes)
+# provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions, and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions, and the following disclaimer in the
+#    documentation and/or materials provided with the distribution.
+#
+# 3. In addition, redistributions of modified forms of the source or binary
+#    code must carry prominent notices stating that the original code was
+#    changed and the date of the change.
+#
+#  4. All publications or advertising materials mentioning features or use of
+#     this software are asked, but not required, to acknowledge that it was
+#     developed by Intel Corporation and credit the contributors.
+#
+# 5. Neither the name of Intel Corporation, nor the name of any Contributor
+#    may be used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+# THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# -*- coding: utf-8 -*-
+
+"""
+
+cart EP credits test
+
+Usage:
+
+Execute from the install/$arch/TESTING directory.
+
+python3 test_runner scripts/cart_test_ep_credits.yml
+
+To use valgrind memory checking
+set TR_USE_VALGRIND in cart_test_ep_credits.yml to memcheck
+
+To use valgrind call (callgrind) profiling
+set TR_USE_VALGRIND in cart_test_ep_credits.yml to callgrind
+
+"""
+
+import os
+from socket import gethostname
+import time
+import commontestsuite
+
+class TestEpCredits(commontestsuite.CommonTestSuite):
+    """ Execute EP credits tests """
+
+    def setUp(self):
+        """setup the test"""
+        self.get_test_info()
+        log_mask = os.getenv("D_LOG_MASK", "INFO")
+        log_file = self.get_cart_long_log_name()
+        crt_phy_addr = os.getenv("CRT_PHY_ADDR_STR", "ofi+sockets")
+        ofi_interface = os.getenv("OFI_INTERFACE", "eth0")
+        ofi_share_addr = os.getenv("CRT_CTX_SHARE_ADDR", "0")
+        ofi_ctx_num = os.getenv("CRT_CTX_NUM", "0")
+        self.pass_env = ' -x D_LOG_MASK={!s} -x D_LOG_FILE={!s}' \
+                        ' -x CRT_PHY_ADDR_STR={!s}' \
+                        ' -x OFI_INTERFACE={!s} -x CRT_CTX_SHARE_ADDR={!s}' \
+                        ' -x CRT_CTX_NUM={!s}'.format(
+                            log_mask, log_file, crt_phy_addr, ofi_interface,
+                            ofi_share_addr, ofi_ctx_num)
+
+    def tearDown(self):
+        """tear down the test"""
+        self.logger.info("tearDown begin")
+        self.logger.info("tearDown end\n")
+
+    def test_ep_credits(self):
+        """ep credits test"""
+        testmsg = self.shortDescription()
+
+        servers = self.get_server_list()
+        #run test even if server list is not provided.
+        if servers:
+            all_servers = ','.join(servers)
+            hosts = ''.join([' -H ', all_servers])
+        else:
+            hosts = ''.join([' -H ', gethostname().split('.')[0]])
+
+        srv_args = 'tests/test_ep_cred_server' + \
+            ' -n cred_group -s'
+
+        srv_proc = self.launch_bg(testmsg, '1', self.pass_env, hosts, srv_args)
+
+        time.sleep(2)
+
+        if srv_proc is None:
+            self.fail("Failed to launch cred server; return code %s" \
+                       % srv_proc.returncode)
+
+
+        # Important: 0 should be last in tuple, as client shuts down server
+        # for credit=0 case
+        credits_to_test = (1, 10, 100, 255, 0)
+
+        for credit in credits_to_test:
+
+            cli_cmd = 'tests/test_ep_cred_client -a cred_group -c %d -b 100' \
+                       % credit
+
+            self.logger.info(cli_cmd)
+
+            if credit == 0:
+                cli_cmd = cli_cmd + " -q"
+
+            cli_rtn = self.launch_test(testmsg, '1', self.pass_env,
+                                       cli=hosts, cli_arg=cli_cmd)
+            if cli_rtn:
+                self.fail("ep credit client filed with %d" % cli_rtn)
+
+        return cli_rtn

--- a/test/cart_test_ep_credits.py
+++ b/test/cart_test_ep_credits.py
@@ -107,16 +107,13 @@ class TestEpCredits(commontestsuite.CommonTestSuite):
             self.fail("Failed to launch cred server; return code %s" \
                        % srv_proc.returncode)
 
-
         # Important: 0 should be last in tuple, as client shuts down server
         # for credit=0 case
-        credits_to_test = (1, 10, 100, 255, 0)
+        credits_to_test = (1, 5, 10, 20, 255, 0)
 
         for credit in credits_to_test:
-
-            cli_cmd = 'tests/test_ep_cred_client -a cred_group -c %d -b 100' \
+            cli_cmd = 'tests/test_ep_cred_client -a cred_group -c %d -b 20' \
                        % credit
-
             self.logger.info(cli_cmd)
 
             if credit == 0:

--- a/test/cart_test_ep_credits.yml
+++ b/test/cart_test_ep_credits.yml
@@ -1,0 +1,26 @@
+description: "ep credits test module"
+
+defaultENV:
+    OMPI_MCA_rmaps_base_oversubscribe: "1"
+    D_LOG_MASK: "DEBUG,MEM=ERR"
+    TR_REDIRECT_OUTPUT: "no"
+    CRT_PHY_ADDR_STR: "ofi+sockets"
+    OFI_INTERFACE: "eth0"
+
+module:
+    name: "cart_test_ep_credits"
+    subLogKey: "CRT_TESTLOG"
+    setKeyFromHost: ["CRT_TEST_SERVER"]
+    hostConfig:
+        numServers: all
+        type: buildList
+    setKeyFromInfo:
+        - [CRT_PREFIX, PREFIX, ""]
+        - [CRT_OMPI_BIN, OMPI_PREFIX, "/bin/"]
+
+directives:
+    loop: "no"
+
+execStrategy:
+    - id: default
+      setEnvVars:

--- a/test/test_list.yml
+++ b/test/test_list.yml
@@ -26,6 +26,7 @@ test_list:
   - "scripts/cart_test_corpc_prefwd_non_sep.yml"
   - "scripts/cart_test_cart_ctl.yml"
   - "scripts/cart_test_cart_ctl_non_sep.yml"
+  - "scripts/cart_test_ep_credits.yml"
   - "scripts/cart_test_iv.yml"
   - "scripts/cart_test_iv_non_sep.yml"
   - "scripts/cart_test_proto.yml"

--- a/utils/run_test.sh
+++ b/utils/run_test.sh
@@ -58,6 +58,7 @@ JENKINS_TEST_LIST=(scripts/cart_echo_test.yml                   \
                    scripts/cart_test_corpc_version_non_sep.yml  \
                    scripts/cart_test_cart_ctl.yml               \
                    scripts/cart_test_cart_ctl_non_sep.yml       \
+                   scripts/cart_test_ep_credits.yml		\
                    scripts/cart_test_iv.yml                     \
                    scripts/cart_test_iv_non_sep.yml             \
                    scripts/cart_test_proto.yml                  \


### PR DESCRIPTION
- Bug: during untrack, wrong rpc_priv's field was being set

- Modified queue process logic to use temp variable

- Added new fields to crt_init_options_t:
        * cio_use_credits
        * cio_ep_credits

These two options allow setting of EP credits value similar to
CRT_CTX_EP_CREDITS environment variable.

- Added new 'cart_test_ep_credits' test with new server/client that
utilize new crt_init_options_t fields.

Test goes through few different ep_credits settings and sends
100 rpcs for each value.

Signed-off-by: Alex Oganezov <alexander.a.oganezov@intel.com>