### PR TITLE
CART-89 timeout: avoid RPC double cancel

### DIFF
--- a/src/cart/crt_context.c
+++ b/src/cart/crt_context.c
@@ -745,16 +745,7 @@ crt_req_timeout_hdlr(struct crt_rpc_priv *rpc_priv)
 		RPC_DECREF(rpc_priv);
 		break;
 	default:
-		if (rpc_priv->crp_on_wire) {
-			/* At this point, RPC should always be completed by
-			 * Mercury
-			 */
-			RPC_ERROR(rpc_priv,
-				  "aborting to group %s, rank %d, tgt_uri %s\n",
-				  grp_priv->gp_pub.cg_grpid,
-				  tgt_ep->ep_rank, rpc_priv->crp_tgt_uri);
-			crt_req_abort(&rpc_priv->crp_pub);
-		}
+		/* At this point, RPC should always be completed by Mercury */
 		break;
 	}
 }


### PR DESCRIPTION
avoid calling HG_Cancel() on an RPC after success-and-failure HG_Forward() call.

Sometimes HG_Forward() returns success but actually failed to send
inside. In that case mercury already called NA_Cancel() on that RPC and
posted completion callback. Calling HG_Cancel() a second time will lose
the completion callback somehow.