### PR TITLE
CORCI-89 Checkout submodules before RPM build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -170,6 +170,7 @@ pipeline {
                         }
                     }
                     steps {
+                        checkoutScm withSubmodules: true
                         sh '''rm -rf artifacts/
                               mkdir -p artifacts/
                               if make srpm; then


### PR DESCRIPTION
To create an scons_local archive, the submodules need to be explicitly
checked out as that is not done during the implicit per-stage checkout.