### PR TITLE
DAOS-1801 gurt: Move DAOS Handle types from GURT to DAOS

### DIFF
--- a/src/gurt/hash.c
+++ b/src/gurt/hash.c
@@ -1027,19 +1027,10 @@ d_uhash_link_empty(struct d_ulink *ulink)
 void
 d_hhash_link_insert(struct d_hhash *hhtab, struct d_hlink *hlink, int type)
 {
-	int	n = 0;
-	int	count = 0;
-
 	D_ASSERT(hlink->hl_link.rl_initialized);
 
 	/* check if handle type fits in allocated bits */
-	n = type;
-	while (n) {
-		count++;
-		n >>= 1;
-	}
-
-	D_ASSERTF(count <= D_HTYPE_BITS,
+	D_ASSERTF(type < (1 << D_HTYPE_BITS),
 		  "Type (%d) does not fit D_HTYPE_BITS (%d)\n",
 		   type, D_HTYPE_BITS);
 

--- a/src/gurt/hash.c
+++ b/src/gurt/hash.c
@@ -1027,7 +1027,21 @@ d_uhash_link_empty(struct d_ulink *ulink)
 void
 d_hhash_link_insert(struct d_hhash *hhtab, struct d_hlink *hlink, int type)
 {
+	int	n = 0;
+	int	count = 0;
+
 	D_ASSERT(hlink->hl_link.rl_initialized);
+
+	/* check if handle type fits in allocated bits */
+	n = type;
+	while (n) {
+		count++;
+		n >>= 1;
+	}
+
+	D_ASSERTF(count <= D_HTYPE_BITS,
+		  "Type (%d) does not fit D_HTYPE_BITS (%d)\n",
+		   type, D_HTYPE_BITS);
 
 	if (d_hhash_is_ptrtype(hhtab)) {
 		uint64_t ptr_key = (uintptr_t)hlink;

--- a/src/gurt/hash.c
+++ b/src/gurt/hash.c
@@ -1031,8 +1031,8 @@ d_hhash_link_insert(struct d_hhash *hhtab, struct d_hlink *hlink, int type)
 
 	/* check if handle type fits in allocated bits */
 	D_ASSERTF(type < (1 << D_HTYPE_BITS),
-		  "Type (%d) does not fit D_HTYPE_BITS (%d)\n",
-		   type, D_HTYPE_BITS);
+		  "Type (%d) does not fit in D_HTYPE_BITS (%d)\n",
+		  type, D_HTYPE_BITS);
 
 	if (d_hhash_is_ptrtype(hhtab)) {
 		uint64_t ptr_key = (uintptr_t)hlink;

--- a/src/include/gurt/hash.h
+++ b/src/include/gurt/hash.h
@@ -496,12 +496,6 @@ void d_hash_table_debug(struct d_hash_table *htable);
  */
 enum {
 	D_HTYPE_PTR		= 0, /**< pointer type handle */
-	D_HTYPE_EQ		= 1, /**< event queue */
-	D_HTYPE_POOL		= 3, /**< pool */
-	D_HTYPE_CO		= 5, /**< container */
-	D_HTYPE_OBJ		= 7, /**< object */
-	D_HTYPE_ARRAY		= 9, /**< object */
-	D_HTYPE_TX		= 11, /**< object */
 	/* Must enlarge D_HTYPE_BITS to add more types */
 };
 


### PR DESCRIPTION
Gurt should only support generic bits in the hash implementation,
and therefore all DAOS custom bits should be removed for handle types.

Signed-off-by: Sydney Vanda <sydney.m.vanda@intel.com>