### PR TITLE
CART-617 rpc: Add option to queue rpcs into front of the queue

### DIFF
--- a/src/cart/crt_context.c
+++ b/src/cart/crt_context.c
@@ -878,11 +878,20 @@ crt_context_req_track(struct crt_rpc_priv *rpc_priv)
 	crt_set_timeout(rpc_priv);
 	rpc_priv->crp_epi = epi;
 	RPC_ADDREF(rpc_priv);
+
+
 	if (crt_gdata.cg_credit_ep_ctx != 0 &&
 	    (epi->epi_req_num - epi->epi_reply_num) >=
 	     crt_gdata.cg_credit_ep_ctx) {
-		d_list_add_tail(&rpc_priv->crp_epi_link,
-				&epi->epi_req_waitq);
+
+		if (rpc_priv->crp_opc_info->coi_queue_front) {
+			d_list_add(&rpc_priv->crp_epi_link,
+					&epi->epi_req_waitq);
+		} else {
+			d_list_add_tail(&rpc_priv->crp_epi_link,
+					&epi->epi_req_waitq);
+		}
+
 		epi->epi_req_wait_num++;
 		rpc_priv->crp_state = RPC_STATE_QUEUED;
 		rc = CRT_REQ_TRACK_IN_WAITQ;

--- a/src/cart/crt_context.c
+++ b/src/cart/crt_context.c
@@ -879,7 +879,6 @@ crt_context_req_track(struct crt_rpc_priv *rpc_priv)
 	rpc_priv->crp_epi = epi;
 	RPC_ADDREF(rpc_priv);
 
-
 	if (crt_gdata.cg_credit_ep_ctx != 0 &&
 	    (epi->epi_req_num - epi->epi_reply_num) >=
 	     crt_gdata.cg_credit_ep_ctx) {

--- a/src/cart/crt_internal_types.h
+++ b/src/cart/crt_internal_types.h
@@ -236,6 +236,7 @@ struct crt_opc_info {
 				 coi_rpccb_init:1,
 				 coi_coops_init:1,
 				 coi_no_reply:1, /* flag of one-way RPC */
+				 coi_queue_front:1, /* add to front of queue */
 				 coi_reset_timer:1; /* reset timer on timeout */
 
 	crt_rpc_cb_t		 coi_rpc_cb;

--- a/src/cart/crt_register.c
+++ b/src/cart/crt_register.c
@@ -365,8 +365,6 @@ crt_opc_reg(struct crt_opc_info *opc_info, crt_opcode_t opc, uint32_t flags,
 	    size_t output_size, crt_rpc_cb_t rpc_cb,
 	    struct crt_corpc_ops *co_ops)
 {
-	bool	disable_reply;
-	bool	enable_reset_timer;
 	int	rc = 0;
 
 	if (opc_info->coi_inited == 1) {
@@ -406,20 +404,16 @@ crt_opc_reg(struct crt_opc_info *opc_info, crt_opcode_t opc, uint32_t flags,
 		opc_info->coi_input_size;
 
 	/* set RPC features */
-	disable_reply =  flags & CRT_RPC_FEAT_NO_REPLY;
-	enable_reset_timer = flags & CRT_RPC_FEAT_NO_TIMEOUT;
+	opc_info->coi_no_reply = (flags & CRT_RPC_FEAT_NO_REPLY) ? 1 : 0;
+	opc_info->coi_reset_timer = (flags & CRT_RPC_FEAT_NO_TIMEOUT) ? 1 : 0;
+	opc_info->coi_queue_front = (flags & CRT_RPC_FEAT_QUEUE_FRONT) ? 1 : 0;
 
-	opc_info->coi_no_reply = disable_reply;
-	if (disable_reply)
-		D_DEBUG(DB_TRACE, "opc %#x, reply disabled.\n", opc);
-	else
-		D_DEBUG(DB_TRACE, "opc %#x, reply enabled.\n", opc);
-
-	opc_info->coi_reset_timer = enable_reset_timer;
-	if (enable_reset_timer)
-		D_DEBUG(DB_TRACE, "opc %#x, reset_timer enabled.\n", opc);
-	else
-		D_DEBUG(DB_TRACE, "opc %#x, reset_timer disabled.\n", opc);
+	D_DEBUG(DB_TRACE, "opc %#x, reply %s.\n", opc,
+		opc_info->coi_no_reply ? "enabled" : "disabled");
+	D_DEBUG(DB_TRACE, "opc %#x, reset_timer %s.\n", opc,
+		opc_info->coi_reset_timer ? "enabled" : "disabled");
+	D_DEBUG(DB_TRACE, "opc %#x, queue_front %s\n", opc,
+		opc_info->coi_queue_front ? "enabled" : "disabled");
 
 out:
 	return rc;

--- a/src/cart/crt_register.c
+++ b/src/cart/crt_register.c
@@ -404,15 +404,14 @@ crt_opc_reg(struct crt_opc_info *opc_info, crt_opcode_t opc, uint32_t flags,
 		opc_info->coi_input_size;
 
 	/* set RPC features */
-	opc_info->coi_no_reply = (flags & CRT_RPC_FEAT_NO_REPLY) ? 1 : 0;
-	opc_info->coi_reset_timer = (flags & CRT_RPC_FEAT_NO_TIMEOUT) ? 1 : 0;
-	opc_info->coi_queue_front = (flags & CRT_RPC_FEAT_QUEUE_FRONT) ? 1 : 0;
+	opc_info->coi_no_reply = D_BIT_IS_SET(flags, CRT_RPC_FEAT_NO_REPLY);
+	opc_info->coi_reset_timer = D_BIT_IS_SET(flags, CRT_RPC_FEAT_NO_TIMEOUT);
+	opc_info->coi_queue_front = D_BIT_IS_SET(flags, CRT_RPC_FEAT_QUEUE_FRONT);
 
-	D_DEBUG(DB_TRACE, "opc %#x, reply %s.\n", opc,
-		opc_info->coi_no_reply ? "enabled" : "disabled");
-	D_DEBUG(DB_TRACE, "opc %#x, reset_timer %s.\n", opc,
-		opc_info->coi_reset_timer ? "enabled" : "disabled");
-	D_DEBUG(DB_TRACE, "opc %#x, queue_front %s\n", opc,
+	D_DEBUG(DB_TRACE, "opc %#x, reply %s, reset_timer %s, queue_front %s\n",
+		opc,
+		opc_info->coi_no_reply ? "enabled" : "disabled",
+		opc_info->coi_reset_timer ? "enabled" : "disabled",
 		opc_info->coi_queue_front ? "enabled" : "disabled");
 
 out:

--- a/src/cart/crt_swim.c
+++ b/src/cart/crt_swim.c
@@ -74,7 +74,8 @@ static void crt_swim_srv_cb(crt_rpc_t *rpc_req);
 
 static struct crt_proto_rpc_format crt_swim_proto_rpc_fmt[] = {
 	{
-		.prf_flags	= CRT_RPC_FEAT_NO_REPLY,
+		.prf_flags	= CRT_RPC_FEAT_NO_REPLY |
+				CRT_RPC_FEAT_QUEUE_FRONT,
 		.prf_req_fmt	= &CQF_crt_rpc_swim,
 		.prf_hdlr	= crt_swim_srv_cb,
 		.prf_co_ops	= NULL,

--- a/src/include/cart/types.h
+++ b/src/include/cart/types.h
@@ -416,6 +416,13 @@ typedef enum {
  */
 #define CRT_RPC_FEAT_NO_TIMEOUT		(1U << 2)
 
+/**
+ * If RPC ends up being queued due to exceeding in-flight rpc limit, queue
+ * at the front of the queue. If not set, queues at the end
+ */
+#define CRT_RPC_FEAT_QUEUE_FRONT	(1U << 3)
+
+
 typedef void *crt_bulk_opid_t;
 
 /** Bulk transfer permissions */

--- a/src/include/gurt/common.h
+++ b/src/include/gurt/common.h
@@ -72,6 +72,10 @@
 extern "C" {
 #endif
 
+/* Check if bit is set in passed val */
+#define D_BIT_IS_SET(val, bit) (((val) & bit) ? 1 : 0)
+
+
 /**
  * Get the current time using a monotonic timer
  * param[out] ts A timespec structure for the result

--- a/src/test/test_ep_cred_common.h
+++ b/src/test/test_ep_cred_common.h
@@ -46,7 +46,8 @@
 
 #define OPC_MY_PROTO    (0x01000000)
 #define OPC_PING	(0x01000000)
-#define OPC_SHUTDOWN    (0x01000001)
+#define OPC_PING_FRONT	(0x01000001)
+#define OPC_SHUTDOWN    (0x01000002)
 
 struct test_global_t {
 	crt_group_t		*tg_local_group;
@@ -64,9 +65,11 @@ struct test_global_t {
 	pthread_t		 tg_tid;
 	int			 tg_thread_id;
 	sem_t			 tg_token_to_proceed;
+	sem_t			 tg_front_queue_token;
 	int			 tg_credits;
 	int			 tg_burst_count;
 	int			 tg_send_shutdown;
+	int			 tg_send_queue_front;
 };
 
 struct test_global_t test = {0};
@@ -98,6 +101,16 @@ ping_hdlr_0(crt_rpc_t *rpc_req)
 	D_ASSERTF(rc == 0, "crt_reply_send() failed. rc: %d\n", rc);
 }
 
+static void
+ping_hdlr_1(crt_rpc_t *rpc_req)
+{
+	int rc;
+
+	D_DEBUG(DB_TRACE, "entered %s().\n", __func__);
+	rc = crt_reply_send(rpc_req);
+	D_ASSERTF(rc == 0, "crt_reply_send() failed. rc: %d\n", rc);
+}
+
 
 static void
 shutdown_handler(crt_rpc_t *rpc_req)
@@ -117,6 +130,11 @@ struct crt_proto_rpc_format my_proto_rpc_fmt_0[] = {
 		.prf_flags	= 0,
 		.prf_req_fmt	= &CQF_ping,
 		.prf_hdlr	= ping_hdlr_0,
+		.prf_co_ops	= NULL,
+	}, {
+		.prf_flags	= CRT_RPC_FEAT_QUEUE_FRONT,
+		.prf_req_fmt	= &CQF_ping,
+		.prf_hdlr	= ping_hdlr_1,
 		.prf_co_ops	= NULL,
 	}, {
 		.prf_flags	= CRT_RPC_FEAT_NO_REPLY,
@@ -148,12 +166,13 @@ test_parse_args(int argc, char **argv)
 		{"is_service",	no_argument,		0, 's'},
 		{"credits",	required_argument,	0, 'c'},
 		{"burst",	required_argument,	0, 'b'},
+		{"front_queue",	no_argument,		0, 'f'},
 		{"shutdown",	no_argument,		0, 'q'},
 		{0, 0, 0, 0}
 	};
 
 	while (1) {
-		rc = getopt_long(argc, argv, "n:a:b:c:hsq", long_options,
+		rc = getopt_long(argc, argv, "n:a:b:c:fhsq", long_options,
 				 &option_index);
 		if (rc == -1)
 			break;
@@ -182,6 +201,9 @@ test_parse_args(int argc, char **argv)
 			break;
 		case 'q':
 			test.tg_send_shutdown = 1;
+			break;
+		case 'f':
+			test.tg_send_queue_front = 1;
 			break;
 		case '?':
 			return 1;

--- a/src/test/test_ep_cred_common.h
+++ b/src/test/test_ep_cred_common.h
@@ -65,7 +65,7 @@ struct test_global_t {
 	pthread_t		 tg_tid;
 	int			 tg_thread_id;
 	sem_t			 tg_token_to_proceed;
-	sem_t			 tg_front_queue_token;
+	sem_t			 tg_queue_front_token;
 	int			 tg_credits;
 	int			 tg_burst_count;
 	int			 tg_send_shutdown;
@@ -166,7 +166,7 @@ test_parse_args(int argc, char **argv)
 		{"is_service",	no_argument,		0, 's'},
 		{"credits",	required_argument,	0, 'c'},
 		{"burst",	required_argument,	0, 'b'},
-		{"front_queue",	no_argument,		0, 'f'},
+		{"queue_front",	no_argument,		0, 'f'},
 		{"shutdown",	no_argument,		0, 'q'},
 		{0, 0, 0, 0}
 	};

--- a/test/cart_test_ep_credits.py
+++ b/test/cart_test_ep_credits.py
@@ -108,7 +108,8 @@ class TestEpCredits(commontestsuite.CommonTestSuite):
                        % srv_proc.returncode)
 
         # Important: 0 should be last in tuple, as client shuts down server
-        # for credit=0 case
+        # for credits=0 case
+        # For credits=1 case, we force 'front of queue' rpc via -f flag
         credits_to_test = (1, 5, 10, 20, 255, 0)
 
         for credit in credits_to_test:
@@ -118,6 +119,11 @@ class TestEpCredits(commontestsuite.CommonTestSuite):
 
             if credit == 0:
                 cli_cmd = cli_cmd + " -q"
+
+            # Force special rpc to front of the queue via -f flag. We do
+            # this for credit=1 to make sure enough of rpcs get queued up
+            if credit == 1:
+                cli_cmd = cli_cmd + " -f"
 
             cli_rtn = self.launch_test(testmsg, '1', self.pass_env,
                                        cli=hosts, cli_arg=cli_cmd)


### PR DESCRIPTION
- CRT_RPC_FEAT_QUEUE_FRONT rpc flag added. When set forces rpc to
be put into the front of the queue instead of being added to the
tail of it.

- SWIM rpcs now set new CRT_RPC_FEAT_QUEUE_FRONT flag

- ep_credits test case modified to test new queueing feature

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>