### PR TITLE
CART-89 bug: Fix in realloc array macro

### DIFF
--- a/src/include/gurt/common.h
+++ b/src/include/gurt/common.h
@@ -154,31 +154,31 @@ extern "C" {
 #define D_REALLOC_COMMON(newptr, oldptr, size, cnt)			\
 	do {								\
 		int _esz = (int)(size);					\
-		int _sz = (int)(size) * cnt;				\
+		int _sz = (int)(size) * (cnt);				\
 		/* Compiler check to ensure type match */		\
 		typeof(newptr) optr = oldptr;				\
 		D_ASSERT((void *)&(newptr) != &(oldptr));		\
 		(newptr) =  realloc(optr, (_sz));			\
 		if ((newptr) != NULL) {					\
-			if (cnt <= 1)					\
+			if ((cnt) <= 1)					\
 				D_DEBUG(DB_MEM,				\
 					"realloc '" #newptr "': %i at %p (old '" #oldptr "':%p).\n", \
 					_esz, (newptr), (oldptr));	\
 			else						\
 				D_DEBUG(DB_MEM,				\
 					"realloc '" #newptr "': %i * '" #cnt "':%i at %p (old '" #oldptr "':%p).\n", \
-					_esz, cnt, (newptr), (oldptr));	\
+					_esz, (cnt), (newptr), (oldptr));	\
 			(oldptr) = NULL;				\
 			break;						\
 		}							\
-		if (cnt <= 1)						\
+		if ((cnt) <= 1)						\
 			D_ERROR("out of memory (tried to realloc "	\
 				"'" #newptr "': size=%i)\n",		\
 				_esz);					\
 		else							\
 			D_ERROR("out of memory (tried to realloc "	\
 				"'" #newptr "': size=%i count=%d)\n",	\
-				_esz, cnt);				\
+				_esz, (cnt));				\
 	} while (0)
 
 
@@ -186,7 +186,7 @@ extern "C" {
 	D_REALLOC_COMMON(newptr, oldptr, size, 1)
 
 #define D_REALLOC_ARRAY(newptr, oldptr, count) \
-	D_REALLOC_COMMON(newptr, oldptr, sizeof(*oldptr), count)
+	D_REALLOC_COMMON(newptr, oldptr, sizeof(*(oldptr)), count)
 
 
 #define D_FREE(ptr)							\

--- a/src/utest/test_gurt.c
+++ b/src/utest/test_gurt.c
@@ -1128,9 +1128,12 @@ test_gurt_alloc(void **state)
 	D_ALLOC_ARRAY(ptr1, nr);
 	assert_non_null(ptr1);
 
-	D_REALLOC_ARRAY(ptr2, ptr1, nr*10);
+	D_REALLOC_ARRAY(ptr2, ptr1, nr + 10);
+
 	assert_non_null(ptr2);
 	assert_null(ptr1);
+	/* Fill memory to catch wrong allocation via valgrind */
+	memset(ptr2, 0x0, (nr + 10) * sizeof(*ptr2));
 
 	D_FREE(ptr2);
 	assert_null(ptr2);


### PR DESCRIPTION
D_REALLOC_ARRAY_COMMON macro had a bug in which 'cnt' can be expanded
incorrectly due to missing ()'s.

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>