### PR TITLE
CART-644 rpc: New transfer_id field added to rpc header

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -167,7 +167,8 @@ pipeline {
                             filename 'Dockerfile-mockbuild.centos.7'
                             dir 'utils/docker'
                             label 'docker_runner'
-                            additionalBuildArgs  '--build-arg UID=$(id -u)'
+                            additionalBuildArgs '--build-arg UID=$(id -u) --build-arg JENKINS_URL=' +
+                                                env.JENKINS_URL
                             args  '--group-add mock --cap-add=SYS_ADMIN --privileged=true'
                         }
                     }
@@ -178,16 +179,18 @@ pipeline {
                                       status: "PENDING"
                         checkoutScm withSubmodules: true
                         sh label: env.STAGE_NAME,
-                           script: '''rm -rf artifacts/
-                                      mkdir -p artifacts/
+                           script: '''rm -rf artifacts/centos7/
+                                      mkdir -p artifacts/centos7/
                                       if make srpm; then
                                           if make mockbuild; then
-                                              (cd /var/lib/mock/epel-7-x86_64/result/ && cp -r . $OLDPWD/artifacts/)
-                                              createrepo artifacts/
+                                              (cd /var/lib/mock/epel-7-x86_64/result/ &&
+                                               cp -r . $OLDPWD/artifacts/centos7/)
+                                              createrepo artifacts/centos7/
                                           else
                                               rc=\${PIPESTATUS[0]}
-                                              (cd /var/lib/mock/epel-7-x86_64/result/ && cp -r . $OLDPWD/artifacts/)
-                                              cp -af _topdir/SRPMS artifacts/
+                                              (cd /var/lib/mock/epel-7-x86_64/result/ &&
+                                               cp -r . $OLDPWD/artifacts/centos7/)
+                                              cp -af _topdir/SRPMS artifacts/centos7/
                                               exit \$rc
                                           fi
                                       else
@@ -196,7 +199,57 @@ pipeline {
                     }
                     post {
                         always {
-                            archiveArtifacts artifacts: 'artifacts/**'
+                            archiveArtifacts artifacts: 'artifacts/centos7/**'
+                        }
+                        success {
+                            stepResult name: env.STAGE_NAME, context: "build",
+                                       result: "SUCCESS"
+                        }
+                        unstable {
+                            stepResult name: env.STAGE_NAME, context: "build",
+                                       result: "UNSTABLE"
+                        }
+                        failure {
+                            stepResult name: env.STAGE_NAME, context: "build",
+                                       result: "FAILURE"
+                        }
+                    }
+                }
+                stage('Build RPM on SLES 12.3') {
+                    agent {
+                        dockerfile {
+                            filename 'Dockerfile-rpmbuild.sles.12.3'
+                            dir 'utils/docker'
+                            label 'docker_runner'
+                            additionalBuildArgs  '--build-arg UID=$(id -u) ' +
+                                                 "--build-arg CACHEBUST=${currentBuild.startTimeInMillis}"
+                        }
+                    }
+                    steps {
+                         githubNotify credentialsId: 'daos-jenkins-commit-status',
+                                      description: env.STAGE_NAME,
+                                      context: "build" + "/" + env.STAGE_NAME,
+                                      status: "PENDING"
+                        checkoutScm withSubmodules: true
+                        sh label: env.STAGE_NAME,
+                           script: '''rm -rf artifacts/sles12.3/
+                              mkdir -p artifacts/sles12.3/
+                              rm -rf _topdir/SRPMS
+                              if make srpm; then
+                                  rm -rf _topdir/RPMS
+                                  if make rpms; then
+                                      ln _topdir/{RPMS/*,SRPMS}/*  artifacts/sles12.3/
+                                      createrepo artifacts/sles12.3/
+                                  else
+                                      exit \${PIPESTATUS[0]}
+                                  fi
+                              else
+                                  exit \${PIPESTATUS[0]}
+                              fi'''
+                    }
+                    post {
+                        always {
+                            archiveArtifacts artifacts: 'artifacts/sles12.3/**'
                         }
                         success {
                             stepResult name: env.STAGE_NAME, context: "build",

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,26 @@
-NAME        := cart
-VERSION     := 0.0.1
-RELEASE     := 2
-DIST        := $(shell rpm --eval %{dist})
-SRPM        := _topdir/SRPMS/$(NAME)-$(VERSION)-$(RELEASE)$(DIST).src.rpm
-RPMS        := _topdir/RPMS/x86_64/$(NAME)-$(VERSION)-$(RELEASE)$(DIST).x86_64.rpm           \
-	       _topdir/RPMS/x86_64/$(NAME)-devel-$(VERSION)-$(RELEASE)$(DIST).x86_64.rpm     \
-	       _topdir/RPMS/x86_64/$(NAME)-tests-$(VERSION)-$(RELEASE)$(DIST).x86_64.rpm     \
-	       _topdir/RPMS/x86_64/$(NAME)-debuginfo-$(VERSION)-$(RELEASE)$(DIST).x86_64.rpm
-SPEC        := $(NAME).spec
-SRC_EXT     := gz
-SOURCE0     := $(NAME)-$(VERSION).tar.$(SRC_EXT)
-SOURCE1     := scons_local-$(VERSION).tar.$(SRC_EXT)
-SOURCES     := _topdir/SOURCES/$(NAME)-$(VERSION).tar.$(SRC_EXT) \
-               _topdir/SOURCES/scons_local-$(VERSION).tar.$(SRC_EXT)
+NAME    := cart
+SRC_EXT := gz
+SOURCE   = $(NAME)-$(VERSION).tar.$(SRC_EXT)
+PATCHES  = scons_local-$(VERSION).tar.$(SRC_EXT)
+
+%.$(SRC_EXT): %
+	rm -f $@
+	gzip $<
+
+dist: $(SOURCES)
+
+DIST    := $(shell rpm --eval %{?dist})
+ifeq ($(DIST),)
+SED_EXPR := 1p
+else
+SED_EXPR := 1s/$(DIST)//p
+endif
+SPEC    := $(NAME).spec
+VERSION := $(shell rpm --specfile --qf '%{version}\n' $(SPEC) | sed -n '1p')
+RELEASE := $(shell rpm --specfile --qf '%{release}\n' $(SPEC) | sed -n '$(SED_EXPR)')
+SRPM    := _topdir/SRPMS/$(NAME)-$(VERSION)-$(RELEASE)$(DIST).src.rpm
+RPMS    := $(addsuffix .rpm,$(addprefix _topdir/RPMS/x86_64/,$(shell rpm --specfile $(SPEC))))
+SOURCES := $(addprefix _topdir/SOURCES/,$(notdir $(SOURCE)) $(PATCHES))
 TARGETS     := $(RPMS) $(SRPM)
 
 all: $(TARGETS)
@@ -24,16 +32,18 @@ _topdir/SOURCES/%: % | _topdir/SOURCES/
 	rm -f $@
 	ln $< $@
 
-%.$(SRC_EXT): %
-	rm -f $@
-	gzip $<
-
 scons_local-$(VERSION).tar:
 	cd scons_local && \
 	git archive --format tar --prefix scons_local/ -o ../$@ HEAD
 
 $(NAME)-$(VERSION).tar:
 	git archive --format tar --prefix $(NAME)-$(VERSION)/ -o $@ HEAD
+
+v$(VERSION).tar.$(SRC_EXT):
+	curl -f -L -O '$(SOURCE)'
+
+$(VERSION).tar.$(SRC_EXT):
+	curl -f -L -O '$(SOURCE)'
 
 # see https://stackoverflow.com/questions/2973445/ for why we subst
 # the "rpm" for "%" to effectively turn this into a multiple matching
@@ -59,6 +69,19 @@ mockbuild: $(SRPM) Makefile
 rpmlint: $(SPEC)
 	rpmlint $<
 
-dist: $(SOURCES)
+show_version:
+	@echo $(VERSION)
 
-.PHONY: srpm rpms ls mockbuild rpmlint FORCE dist
+show_release:
+	@echo $(RELEASE)
+
+show_rpms:
+	@echo $(RPMS)
+
+show_source:
+	@echo $(SOURCE)
+
+show_sources:
+	@echo $(SOURCES)
+
+.PHONY: srpm rpms ls mockbuild rpmlint FORCE dist show_version show_release show_rpms show_source show_sources

--- a/cart.spec
+++ b/cart.spec
@@ -2,7 +2,7 @@
 
 Name:          cart
 Version:       0.0.1
-Release:       2%{?dist}
+Release:       3%{?dist}
 Summary:       CaRT
 
 License:       Apache
@@ -29,11 +29,17 @@ Requires: openpa
 Requires: mercury
 Requires: ompi
 Requires: libevent
-Requires: boost
-Requires: libuuid
+%if (0%{?rhel} >= 7)
+Requires:libuuid
+Requires: libyaml
+%else
+%if (0%{?suse_version} >= 1315)
+Requires: libuuid1
+Requires: libyaml-0-2
+%endif
+%endif
 Requires: hwloc
 Requires: openssl
-Requires: libyaml
 
 %description
 Collective and RPC Transport (CaRT)
@@ -73,12 +79,14 @@ CaRT tests
 # remove rpathing from the build
 find . -name SConscript | xargs sed -i -e '/AppendUnique(RPATH=.*)/d'
 
+SL_PREFIX=%{_prefix}                      \
 scons %{?_smp_mflags}                     \
       --config=force                      \
       USE_INSTALLED=all                   \
-      PREFIX=%{?buildroot}
+      PREFIX=%{?buildroot}%{_prefix}
 
 %install
+SL_PREFIX=%{_prefix}                      \
 scons %{?_smp_mflags}                     \
       --config=force                      \
       install                             \
@@ -111,6 +119,13 @@ ln %{?buildroot}%{carthome}/{TESTING/.build_vars,.build_vars-Linux}.sh
 %{carthome}/.build_vars-Linux.sh
 
 %changelog
+* Tue May 07 2019 Brian J. Murrell <brian.murrell@intel.com>
+- update for SLES 12.3:
+  - libuuid -> libuuid1
+
+* Thu May 02 2019 Brian J. Murrell <brian.murrell@intel.com>
+- fix build to use _prefix as install does
+
 * Fri Apr 05 2019 Brian J. Murrell <brian.murrell@intel.com>
 - split out devel and tests subpackages
 - have devel depend on the main package since we only have the

--- a/src/cart/crt_context.c
+++ b/src/cart/crt_context.c
@@ -680,7 +680,8 @@ crt_req_timeout_reset(struct crt_rpc_priv *rpc_priv)
 	rc = crt_req_timeout_track(rpc_priv);
 	D_MUTEX_UNLOCK(&crt_ctx->cc_mutex);
 	if (rc != 0) {
-		D_ERROR("crt_req_timeout_track(opc: %#x) failed, rc: %d.\n",
+		RPC_ERROR(rpc_priv,
+			"crt_req_timeout_track(opc: %#x) failed, rc: %d.\n",
 			rpc_priv->crp_pub.cr_opc, rc);
 		return false;
 	}
@@ -904,7 +905,8 @@ crt_context_req_track(struct crt_rpc_priv *rpc_priv)
 			epi->epi_req_num++;
 			rc = CRT_REQ_TRACK_IN_INFLIGHQ;
 		} else {
-			D_ERROR("crt_req_timeout_track failed, rc: %d.\n", rc);
+			RPC_ERROR(rpc_priv,
+				"crt_req_timeout_track failed, rc: %d.\n", rc);
 			/* roll back the addref above */
 			RPC_DECREF(rpc_priv);
 		}
@@ -1010,7 +1012,8 @@ crt_context_req_untrack(struct crt_rpc_priv *rpc_priv)
 		rc = crt_req_timeout_track(tmp_rpc);
 		D_MUTEX_UNLOCK(&crt_ctx->cc_mutex);
 		if (rc != 0)
-			D_ERROR("crt_req_timeout_track failed, rc: %d.\n", rc);
+			RPC_ERROR(tmp_rpc,
+				"crt_req_timeout_track failed, rc: %d.\n", rc);
 
 		/* remove from waitq and add to in-flight queue */
 		d_list_move_tail(&tmp_rpc->crp_epi_link, &epi->epi_req_q);

--- a/src/cart/crt_hg_proc.c
+++ b/src/cart/crt_hg_proc.c
@@ -489,6 +489,11 @@ crt_proc_common_hdr(crt_proc_t proc, struct crt_common_hdr *hdr)
 		D_ERROR("hg proc error, hg_ret: %d.\n", hg_ret);
 		D_GOTO(out, rc = -DER_HG);
 	}
+	hg_ret = hg_proc_hg_uint32_t(hg_proc, &hdr->cch_xid);
+	if (hg_ret != HG_SUCCESS) {
+		D_ERROR("hg proc error, hg_ret: %d.\n", hg_ret);
+		rc = -DER_HG;
+	}
 	hg_ret = hg_proc_hg_uint32_t(hg_proc, &hdr->cch_rc);
 	if (hg_ret != HG_SUCCESS) {
 		D_ERROR("hg proc error, hg_ret: %d.\n", hg_ret);

--- a/src/cart/crt_internal.h
+++ b/src/cart/crt_internal.h
@@ -68,7 +68,10 @@
 		/* no-op statement that type-checks the rpc pointer */	\
 		if (false && (rpc)->crp_refcount)			\
 			;						\
-		D_TRACE_DEBUG(mask, rpc, fmt,  ## __VA_ARGS__);		\
+		D_TRACE_DEBUG(mask, rpc, " [opc=0x%x xid=%x:%x] " fmt, 	\
+			rpc->crp_pub.cr_opc, rpc->crp_req_hdr.cch_rank, \
+			rpc->crp_req_hdr.cch_xid, 			\
+			## __VA_ARGS__);				\
 	} while (0)
 
 /* Log an error with a RPC descriptor */
@@ -77,7 +80,10 @@
 		/* no-op statement that type-checks the rpc pointer */	\
 		if (false && (rpc)->crp_refcount)			\
 			;						\
-		D_TRACE_ERROR(rpc, fmt,  ## __VA_ARGS__);		\
+		D_TRACE_ERROR(rpc, " [opc=0x%x xid=%x:%x] " fmt, 	\
+			rpc->crp_pub.cr_opc, rpc->crp_req_hdr.cch_rank, \
+			rpc->crp_req_hdr.cch_xid, 			\
+			## __VA_ARGS__);				\
 	} while (0)
 
 #endif /* __CRT_INTERNAL_H__ */

--- a/src/cart/crt_internal.h
+++ b/src/cart/crt_internal.h
@@ -65,24 +65,18 @@
 /* A wrapper around D_TRACE_DEBUG that ensures the ptr option is a RPC */
 #define RPC_TRACE(mask, rpc, fmt, ...)					\
 	do {								\
-		/* no-op statement that type-checks the rpc pointer */	\
-		if (false && (rpc)->crp_refcount)			\
-			;						\
-		D_TRACE_DEBUG(mask, rpc, " [opc=0x%x xid=%x:%x] " fmt, 	\
-			rpc->crp_pub.cr_opc, rpc->crp_req_hdr.cch_rank, \
-			rpc->crp_req_hdr.cch_xid, 			\
+		D_TRACE_DEBUG(mask, rpc, " [opc=0x%x xid=%x:%x] " fmt,	\
+			rpc->crp_pub.cr_opc, rpc->crp_req_hdr.cch_rank,	\
+			rpc->crp_req_hdr.cch_xid,			\
 			## __VA_ARGS__);				\
 	} while (0)
 
 /* Log an error with a RPC descriptor */
 #define RPC_ERROR(rpc, fmt, ...)					\
 	do {								\
-		/* no-op statement that type-checks the rpc pointer */	\
-		if (false && (rpc)->crp_refcount)			\
-			;						\
-		D_TRACE_ERROR(rpc, " [opc=0x%x xid=%x:%x] " fmt, 	\
-			rpc->crp_pub.cr_opc, rpc->crp_req_hdr.cch_rank, \
-			rpc->crp_req_hdr.cch_xid, 			\
+		D_TRACE_ERROR(rpc, " [opc=0x%x xid=%x:%x] " fmt,	\
+			rpc->crp_pub.cr_opc, rpc->crp_req_hdr.cch_rank,	\
+			rpc->crp_req_hdr.cch_xid,			\
 			## __VA_ARGS__);				\
 	} while (0)
 

--- a/src/cart/crt_internal.h
+++ b/src/cart/crt_internal.h
@@ -71,6 +71,7 @@
 			## __VA_ARGS__);				\
 	} while (0)
 
+
 /* Log an error with a RPC descriptor */
 #define RPC_ERROR(rpc, fmt, ...)					\
 	do {								\

--- a/src/cart/crt_internal_types.h
+++ b/src/cart/crt_internal_types.h
@@ -95,6 +95,8 @@ struct crt_gdata {
 				cg_pmix_disabled:1,
 				cg_grp_inited:1; /* group initialized */
 
+	uint32_t		cg_xid; /* transfer id for rpcs */
+
 	/* protects crt_gdata */
 	pthread_rwlock_t	cg_rwlock;
 };

--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -1357,6 +1357,29 @@ crt_rpc_inout_buff_init(struct crt_rpc_priv *rpc_priv)
 	}
 }
 
+static inline void
+crt_common_hdr_init(struct crt_rpc_priv *rpc_priv, crt_opcode_t opc)
+{
+	d_rank_t	rank;
+	uint32_t	xid;
+	int		rc;
+
+	rc = crt_group_rank(0, &rank);
+	D_ASSERT(rc == 0);
+
+	D_RWLOCK_WRLOCK(&crt_gdata.cg_rwlock);
+	xid = crt_gdata.cg_xid++;
+	D_RWLOCK_UNLOCK(&crt_gdata.cg_rwlock);
+
+	rpc_priv->crp_req_hdr.cch_opc = opc;
+	rpc_priv->crp_req_hdr.cch_rank = rank;
+	rpc_priv->crp_req_hdr.cch_xid = xid;
+
+	rpc_priv->crp_reply_hdr.cch_opc = opc;
+	rpc_priv->crp_reply_hdr.cch_rank = rank;
+	rpc_priv->crp_reply_hdr.cch_xid = xid;
+}
+
 int
 crt_rpc_priv_init(struct crt_rpc_priv *rpc_priv, crt_context_t crt_ctx,
 		  bool srv_flag)
@@ -1375,8 +1398,7 @@ crt_rpc_priv_init(struct crt_rpc_priv *rpc_priv, crt_context_t crt_ctx,
 	rpc_priv->crp_complete_cb = NULL;
 	rpc_priv->crp_arg = NULL;
 	if (!srv_flag) {
-		crt_common_hdr_init(&rpc_priv->crp_req_hdr, opc);
-		crt_common_hdr_init(&rpc_priv->crp_reply_hdr, opc);
+		crt_common_hdr_init(rpc_priv, opc);
 	}
 	rpc_priv->crp_state = RPC_STATE_INITED;
 	rpc_priv->crp_hdl_reuse = NULL;
@@ -1391,6 +1413,7 @@ crt_rpc_priv_init(struct crt_rpc_priv *rpc_priv, crt_context_t crt_ctx,
 	crt_rpc_inout_buff_init(rpc_priv);
 
 	rpc_priv->crp_timeout_sec = ctx->cc_timeout_sec;
+
 exit:
 	return rc;
 }

--- a/src/cart/crt_rpc.h
+++ b/src/cart/crt_rpc.h
@@ -94,6 +94,8 @@ struct crt_common_hdr {
 	uint64_t	cch_hlc;
 	/* gid and rank identify the rpc request sender */
 	d_rank_t	cch_rank;
+	/* Transfer id */
+	uint32_t	cch_xid;
 	/* used in crp_reply_hdr to propagate rpc failure back to sender */
 	uint32_t	cch_rc;
 };
@@ -638,16 +640,6 @@ struct crt_internal_rpc {
 
 void crt_req_destroy(struct crt_rpc_priv *rpc_priv);
 
-static inline void
-crt_common_hdr_init(struct crt_common_hdr *hdr, crt_opcode_t opc)
-{
-	int rc;
-
-	D_ASSERT(hdr != NULL);
-	hdr->cch_opc = opc;
-	rc = crt_group_rank(0, &hdr->cch_rank);
-	D_ASSERT(rc == 0);
-}
 
 static inline bool
 crt_rpc_cb_customized(struct crt_context *crt_ctx,

--- a/utils/docker/Dockerfile-mockbuild.centos.7
+++ b/utils/docker/Dockerfile-mockbuild.centos.7
@@ -16,7 +16,8 @@ ARG UID=1000
 
 # Install basic tools
 RUN yum install -y epel-release
-RUN yum install -y mock make rpm-build curl createrepo rpmlint git
+RUN yum install -y mock make rpm-build curl createrepo rpmlint redhat-lsb-core \
+                   git
 
 # Add build user (to keep rpmbuild happy)
 ENV USER build
@@ -27,32 +28,24 @@ RUN echo "$USER:$PASSWD" | chpasswd
 RUN usermod -a -G mock $USER
 
 # mock in Docker needs to use the old-chroot option
-RUN echo "config_opts['use_nspawn'] = False" >> /etc/mock/site-defaults.cfg
+RUN grep use_nspawn || \
+    echo "config_opts['use_nspawn'] = False" >> /etc/mock/site-defaults.cfg
 
-RUN echo -e "config_opts['yum.conf'] += \"\"\"\n\
-[openpa]\n\
-name=openpa\n\
-baseurl=https://build.hpdd.intel.com/job/daos-stack/job/openpa/job/master/lastSuccessfulBuild/artifact/artifacts/\n\
+ARG JENKINS_URL=""
+
+RUN echo -e "config_opts['yum.conf'] += \"\"\"\n" >> /etc/mock/default.cfg;  \
+    for repo in openpa libfabric pmix ompi mercury; do                       \
+        if [[ $repo = *:* ]]; then                                           \
+            branch="${repo#*:}";                                             \
+            repo="${repo%:*}";                                               \
+        else                                                                 \
+            branch="master";                                                 \
+        fi;                                                                  \
+        JENKINS_URL=$JENKINS_URL;                                            \
+        echo -e "[$repo:$branch:lastSuccessful]\n\
+name=$repo:$branch:lastSuccessful\n\
+baseurl=${JENKINS_URL}job/daos-stack/job/$repo/job/$branch/lastSuccessfulBuild/artifact/artifacts/centos7/\n\
 enabled=1\n\
-gpgcheck = False\n\
-\n\
-[libfabric]\n\
-name=libfabric\n\
-baseurl=https://build.hpdd.intel.com/job/daos-stack/job/libfabric/job/master/lastSuccessfulBuild/artifact/artifacts/\n\
-enabled=1\n\
-gpgcheck = False\n\
-[pmix]\n\
-name=pmix\n\
-baseurl=https://build.hpdd.intel.com/job/daos-stack/job/pmix/job/master/lastSuccessfulBuild/artifact/artifacts/\n\
-enabled=1\n\
-gpgcheck = False\n\
-[ompi]\n\
-name=ompi\n\
-baseurl=https://build.hpdd.intel.com/job/daos-stack/job/ompi/job/master/lastSuccessfulBuild/artifact/artifacts/\n\
-enabled=1\n\
-gpgcheck = False\n\
-[mercury]\n\
-name=mercury\n\
-baseurl=https://build.hpdd.intel.com/job/daos-stack/job/mercury/job/master/lastSuccessfulBuild/artifact/artifacts/\n\
-enabled=1\n\
-gpgcheck = False\n\"\"\"" >> /etc/mock/default.cfg
+gpgcheck = False\n" >> /etc/mock/default.cfg;                           \
+    done;                                                               \
+    echo "\"\"\"" >> /etc/mock/default.cfg

--- a/utils/docker/Dockerfile-rpmbuild.sles.12.3
+++ b/utils/docker/Dockerfile-rpmbuild.sles.12.3
@@ -1,0 +1,67 @@
+#
+# Copyright 2019, Intel Corporation
+#
+# 'recipe' for Docker to build an RPM
+#
+
+# Pull base image
+FROM suse/sles:12.3
+MAINTAINER Brian J. Murrell <brian.murrell@intel.com>
+
+# use same UID as host and default value of 1000 if not specified
+ARG UID=1000
+
+# Add build user (to keep rpmbuild happy)
+ENV USER build
+ENV PASSWD build
+RUN useradd -u $UID -ms /bin/bash $USER
+RUN groupadd -g $UID $USER
+RUN echo "$USER:$PASSWD" | chpasswd
+
+# Install basic tools
+RUN zypper --non-interactive update
+# basic building
+RUN zypper --non-interactive install make rpm-build curl createrepo git    \
+                                     lsb-release autoconf automake libtool \
+                                     ca-certificates-mozilla
+# libfabric
+RUN zypper --non-interactive install rdma-core-devel libnl3-devel        \
+                                     infinipath-psm-devel valgrind-devel
+# mercury
+RUN zypper --non-interactive ar --gpgcheck-allow-unsigned -f https://build.hpdd.intel.com/job/daos-stack/job/openpa/job/master/lastSuccessfulBuild/artifact/artifacts/sles12.3/ openpa;       \
+    zypper --non-interactive ar --gpgcheck-allow-unsigned -f https://build.hpdd.intel.com/job/daos-stack/job/libfabric/job/master/lastSuccessfulBuild/artifact/artifacts/sles12.3/ libfabric; \
+    zypper --non-interactive ref openpa libfabric
+# our libfabric conflicts with libfabric1
+# TODO: consider if we should rename ours or replace libfabric1, etc.
+RUN if rpm -q libfabric1; then zypper --non-interactive remove libfabric1; fi
+RUN zypper --non-interactive install gcc-c++
+RUN zypper --non-interactive --no-gpg-check install openpa-devel      \
+                                                    libfabric-devel   \
+                                                    cmake boost-devel
+# pmix
+RUN zypper --non-interactive install libevent-devel
+
+# ompi
+RUN zypper --non-interactive ar -f https://download.opensuse.org/repositories/science:/HPC:/SLE12SP3_Missing/SLE_12_SP3/ hwloc;                                                   \
+    zypper --non-interactive --gpg-auto-import-keys ref hwloc;                                                                                                                    \
+    zypper --non-interactive ar --gpgcheck-allow-unsigned -f https://build.hpdd.intel.com/job/daos-stack/job/pmix/job/master/lastSuccessfulBuild/artifact/artifacts/sles12.3/ pmix; \
+    zypper --non-interactive ref pmix
+RUN zypper --non-interactive install hwloc-devel pmix-devel flex
+
+# scons
+RUN zypper --non-interactive install fdupes
+
+# cart
+RUN zypper --non-interactive ar --gpgcheck-allow-unsigned -f https://build.hpdd.intel.com/job/daos-stack/job/mercury/job/master/lastSuccessfulBuild/artifact/artifacts/sles12.3/ mercury; \
+    zypper --non-interactive ar --gpgcheck-allow-unsigned -f https://build.hpdd.intel.com/job/daos-stack/job/ompi/job/master/lastSuccessfulBuild/artifact/artifacts/sles12.3/ ompi;       \
+    zypper --non-interactive ar --gpgcheck-allow-unsigned -f https://build.hpdd.intel.com/job/daos-stack/job/scons/job/master/lastSuccessfulBuild/artifact/artifacts/sles12.3/ scons;     \
+    zypper --non-interactive --gpg-auto-import-keys ref mercury ompi scons
+RUN zypper --non-interactive install scons libyaml-devel mercury-devel    \
+                                     ompi-devel openssl-devel
+RUN zypper --non-interactive ar https://download.opensuse.org/repositories/devel:libraries:c_c++/SLE_12_SP3/devel:libraries:c_c++.repo; \
+    zypper --non-interactive --gpg-auto-import-keys ref 'A project for basic libraries shared among multiple projects (SLE_12_SP3)'
+RUN zypper --non-interactive install libcmocka-devel
+
+# force an upgrade to get any newly built RPMs
+ARG CACHEBUST=1
+RUN zypper --non-interactive up


### PR DESCRIPTION
- RPCs now contain new cch_xid (transfer id) field
- RPC_TRACE / RPC_ERROR macros print origin_rank:xid along with opc
- Transfer id is incremented on each new rpc creation.

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>