### PR TITLE
CART-644 rpc: New transfer id field in rpc header

### DIFF
--- a/src/cart/crt_context.c
+++ b/src/cart/crt_context.c
@@ -680,7 +680,8 @@ crt_req_timeout_reset(struct crt_rpc_priv *rpc_priv)
 	rc = crt_req_timeout_track(rpc_priv);
 	D_MUTEX_UNLOCK(&crt_ctx->cc_mutex);
 	if (rc != 0) {
-		D_ERROR("crt_req_timeout_track(opc: %#x) failed, rc: %d.\n",
+		RPC_ERROR(rpc_priv,
+			"crt_req_timeout_track(opc: %#x) failed, rc: %d.\n",
 			rpc_priv->crp_pub.cr_opc, rc);
 		return false;
 	}
@@ -904,7 +905,8 @@ crt_context_req_track(struct crt_rpc_priv *rpc_priv)
 			epi->epi_req_num++;
 			rc = CRT_REQ_TRACK_IN_INFLIGHQ;
 		} else {
-			D_ERROR("crt_req_timeout_track failed, rc: %d.\n", rc);
+			RPC_ERROR(rpc_priv,
+				"crt_req_timeout_track failed, rc: %d.\n", rc);
 			/* roll back the addref above */
 			RPC_DECREF(rpc_priv);
 		}
@@ -1010,7 +1012,8 @@ crt_context_req_untrack(struct crt_rpc_priv *rpc_priv)
 		rc = crt_req_timeout_track(tmp_rpc);
 		D_MUTEX_UNLOCK(&crt_ctx->cc_mutex);
 		if (rc != 0)
-			D_ERROR("crt_req_timeout_track failed, rc: %d.\n", rc);
+			RPC_ERROR(tmp_rpc,
+				"crt_req_timeout_track failed, rc: %d.\n", rc);
 
 		/* remove from waitq and add to in-flight queue */
 		d_list_move_tail(&tmp_rpc->crp_epi_link, &epi->epi_req_q);

--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -911,6 +911,7 @@ crt_rpc_handler_common(hg_handle_t hg_hdl)
 		if (rc == 0) {
 			rpc_priv->crp_input_got = 1;
 			rpc_pub->cr_ep.ep_rank = rpc_priv->crp_req_hdr.cch_rank;
+			rpc_pub->cr_ep.ep_tag = rpc_priv->crp_req_hdr.cch_tag;
 			rpc_pub->cr_ep.ep_grp = NULL;
 			/* TODO lookup by rpc_priv->crp_req_hdr.cch_grp_id */
 		} else {

--- a/src/cart/crt_hg_proc.c
+++ b/src/cart/crt_hg_proc.c
@@ -489,6 +489,11 @@ crt_proc_common_hdr(crt_proc_t proc, struct crt_common_hdr *hdr)
 		D_ERROR("hg proc error, hg_ret: %d.\n", hg_ret);
 		D_GOTO(out, rc = -DER_HG);
 	}
+	hg_ret = hg_proc_hg_uint32_t(hg_proc, &hdr->cch_xid);
+	if (hg_ret != HG_SUCCESS) {
+		D_ERROR("hg proc error, hg_ret: %d.\n", hg_ret);
+		rc = -DER_HG;
+	}
 	hg_ret = hg_proc_hg_uint32_t(hg_proc, &hdr->cch_rc);
 	if (hg_ret != HG_SUCCESS) {
 		D_ERROR("hg proc error, hg_ret: %d.\n", hg_ret);

--- a/src/cart/crt_hg_proc.c
+++ b/src/cart/crt_hg_proc.c
@@ -489,6 +489,11 @@ crt_proc_common_hdr(crt_proc_t proc, struct crt_common_hdr *hdr)
 		D_ERROR("hg proc error, hg_ret: %d.\n", hg_ret);
 		D_GOTO(out, rc = -DER_HG);
 	}
+	hg_ret = hg_proc_hg_uint32_t(hg_proc, &hdr->cch_tag);
+	if (hg_ret != HG_SUCCESS) {
+		D_ERROR("hg proc error, hg_ret: %d.\n", hg_ret);
+		D_GOTO(out, rc = -DER_HG);
+	}
 	hg_ret = hg_proc_hg_uint32_t(hg_proc, &hdr->cch_xid);
 	if (hg_ret != HG_SUCCESS) {
 		D_ERROR("hg proc error, hg_ret: %d.\n", hg_ret);
@@ -718,6 +723,7 @@ crt_proc_in_common(crt_proc_t proc, crt_rpc_input_t *data)
 {
 	struct crt_rpc_priv	*rpc_priv;
 	crt_proc_op_t		 proc_op;
+	struct crt_common_hdr	*hdr;
 	int			 rc = 0;
 
 	if (proc == CRT_PROC_NULL)
@@ -735,8 +741,11 @@ crt_proc_in_common(crt_proc_t proc, crt_rpc_input_t *data)
 
 	if (proc_op != CRT_PROC_FREE) {
 		if (proc_op == CRT_PROC_ENCODE) {
-			rpc_priv->crp_req_hdr.cch_flags = rpc_priv->crp_flags;
-			rpc_priv->crp_req_hdr.cch_hlc = crt_hlc_get();
+			hdr = &rpc_priv->crp_req_hdr;
+
+			hdr->cch_flags = rpc_priv->crp_flags;
+			hdr->cch_tag = rpc_priv->crp_pub.cr_ep.ep_tag;
+			hdr->cch_hlc = crt_hlc_get();
 		}
 		rc = crt_proc_common_hdr(proc, &rpc_priv->crp_req_hdr);
 		if (rc != 0) {

--- a/src/cart/crt_internal.h
+++ b/src/cart/crt_internal.h
@@ -65,18 +65,23 @@
 /* A wrapper around D_TRACE_DEBUG that ensures the ptr option is a RPC */
 #define RPC_TRACE(mask, rpc, fmt, ...)					\
 	do {								\
-		D_TRACE_DEBUG(mask, rpc, " [opc=0x%x xid=%x:%x] " fmt,	\
-			rpc->crp_pub.cr_opc, rpc->crp_req_hdr.cch_rank,	\
+		D_TRACE_DEBUG(mask, rpc,				\
+			" [opc=0x%x xid=%x:%x tag=%d] " fmt,		\
+			rpc->crp_pub.cr_opc,				\
+			rpc->crp_pub.cr_ep.ep_rank,			\
 			rpc->crp_req_hdr.cch_xid,			\
+			rpc->crp_pub.cr_ep.ep_tag,			\
 			## __VA_ARGS__);				\
 	} while (0)
 
 /* Log an error with a RPC descriptor */
 #define RPC_ERROR(rpc, fmt, ...)					\
 	do {								\
-		D_TRACE_ERROR(rpc, " [opc=0x%x xid=%x:%x] " fmt,	\
-			rpc->crp_pub.cr_opc, rpc->crp_req_hdr.cch_rank,	\
+		D_TRACE_ERROR(rpc, " [opc=0x%x xid=%x:%x tag=%d] " fmt,	\
+			rpc->crp_pub.cr_opc,				\
+			rpc->crp_pub.cr_ep.ep_rank,			\
 			rpc->crp_req_hdr.cch_xid,			\
+			rpc->crp_pub.cr_ep.ep_tag,			\
 			## __VA_ARGS__);				\
 	} while (0)
 

--- a/src/cart/crt_internal.h
+++ b/src/cart/crt_internal.h
@@ -65,19 +65,19 @@
 /* A wrapper around D_TRACE_DEBUG that ensures the ptr option is a RPC */
 #define RPC_TRACE(mask, rpc, fmt, ...)					\
 	do {								\
-		/* no-op statement that type-checks the rpc pointer */	\
-		if (false && (rpc)->crp_refcount)			\
-			;						\
-		D_TRACE_DEBUG(mask, rpc, fmt,  ## __VA_ARGS__);		\
+		D_TRACE_DEBUG(mask, rpc, " [opc=0x%x xid=%x:%x] " fmt,	\
+			rpc->crp_pub.cr_opc, rpc->crp_req_hdr.cch_rank,	\
+			rpc->crp_req_hdr.cch_xid,			\
+			## __VA_ARGS__);				\
 	} while (0)
 
 /* Log an error with a RPC descriptor */
 #define RPC_ERROR(rpc, fmt, ...)					\
 	do {								\
-		/* no-op statement that type-checks the rpc pointer */	\
-		if (false && (rpc)->crp_refcount)			\
-			;						\
-		D_TRACE_ERROR(rpc, fmt,  ## __VA_ARGS__);		\
+		D_TRACE_ERROR(rpc, " [opc=0x%x xid=%x:%x] " fmt,	\
+			rpc->crp_pub.cr_opc, rpc->crp_req_hdr.cch_rank,	\
+			rpc->crp_req_hdr.cch_xid,			\
+			## __VA_ARGS__);				\
 	} while (0)
 
 #endif /* __CRT_INTERNAL_H__ */

--- a/src/cart/crt_internal_types.h
+++ b/src/cart/crt_internal_types.h
@@ -95,6 +95,8 @@ struct crt_gdata {
 				cg_pmix_disabled:1,
 				cg_grp_inited:1; /* group initialized */
 
+	uint32_t		cg_xid; /* transfer id for rpcs */
+
 	/* protects crt_gdata */
 	pthread_rwlock_t	cg_rwlock;
 };

--- a/src/cart/crt_internal_types.h
+++ b/src/cart/crt_internal_types.h
@@ -51,6 +51,7 @@
 #include <gurt/list.h>
 #include <gurt/hash.h>
 #include <gurt/heap.h>
+#include <gurt/atomic.h>
 
 struct crt_hg_gdata;
 struct crt_grp_gdata;
@@ -95,7 +96,7 @@ struct crt_gdata {
 				cg_pmix_disabled:1,
 				cg_grp_inited:1; /* group initialized */
 
-	uint32_t		cg_xid; /* transfer id for rpcs */
+	ATOMIC uint32_t		cg_xid; /* transfer id for rpcs */
 
 	/* protects crt_gdata */
 	pthread_rwlock_t	cg_rwlock;

--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -1357,6 +1357,29 @@ crt_rpc_inout_buff_init(struct crt_rpc_priv *rpc_priv)
 	}
 }
 
+static inline void
+crt_common_hdr_init(struct crt_rpc_priv *rpc_priv, crt_opcode_t opc)
+{
+	d_rank_t	rank;
+	uint32_t	xid;
+	int		rc;
+
+	rc = crt_group_rank(0, &rank);
+	D_ASSERT(rc == 0);
+
+	D_RWLOCK_WRLOCK(&crt_gdata.cg_rwlock);
+	xid = crt_gdata.cg_xid++;
+	D_RWLOCK_UNLOCK(&crt_gdata.cg_rwlock);
+
+	rpc_priv->crp_req_hdr.cch_opc = opc;
+	rpc_priv->crp_req_hdr.cch_rank = rank;
+	rpc_priv->crp_req_hdr.cch_xid = xid;
+
+	rpc_priv->crp_reply_hdr.cch_opc = opc;
+	rpc_priv->crp_reply_hdr.cch_rank = rank;
+	rpc_priv->crp_reply_hdr.cch_xid = xid;
+}
+
 int
 crt_rpc_priv_init(struct crt_rpc_priv *rpc_priv, crt_context_t crt_ctx,
 		  bool srv_flag)
@@ -1375,8 +1398,7 @@ crt_rpc_priv_init(struct crt_rpc_priv *rpc_priv, crt_context_t crt_ctx,
 	rpc_priv->crp_complete_cb = NULL;
 	rpc_priv->crp_arg = NULL;
 	if (!srv_flag) {
-		crt_common_hdr_init(&rpc_priv->crp_req_hdr, opc);
-		crt_common_hdr_init(&rpc_priv->crp_reply_hdr, opc);
+		crt_common_hdr_init(rpc_priv, opc);
 	}
 	rpc_priv->crp_state = RPC_STATE_INITED;
 	rpc_priv->crp_hdl_reuse = NULL;
@@ -1391,6 +1413,7 @@ crt_rpc_priv_init(struct crt_rpc_priv *rpc_priv, crt_context_t crt_ctx,
 	crt_rpc_inout_buff_init(rpc_priv);
 
 	rpc_priv->crp_timeout_sec = ctx->cc_timeout_sec;
+
 exit:
 	return rc;
 }

--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -1367,9 +1367,7 @@ crt_common_hdr_init(struct crt_rpc_priv *rpc_priv, crt_opcode_t opc)
 	rc = crt_group_rank(0, &rank);
 	D_ASSERT(rc == 0);
 
-	D_RWLOCK_WRLOCK(&crt_gdata.cg_rwlock);
-	xid = crt_gdata.cg_xid++;
-	D_RWLOCK_UNLOCK(&crt_gdata.cg_rwlock);
+	xid = atomic_fetch_add(&crt_gdata.cg_xid, 1);
 
 	rpc_priv->crp_req_hdr.cch_opc = opc;
 	rpc_priv->crp_req_hdr.cch_rank = rank;

--- a/src/cart/crt_rpc.h
+++ b/src/cart/crt_rpc.h
@@ -94,6 +94,8 @@ struct crt_common_hdr {
 	uint64_t	cch_hlc;
 	/* gid and rank identify the rpc request sender */
 	d_rank_t	cch_rank;
+	/* tag to which rpc request was sent to */
+	d_rank_t	cch_tag;
 	/* Transfer id */
 	uint32_t	cch_xid;
 	/* used in crp_reply_hdr to propagate rpc failure back to sender */

--- a/src/cart/crt_rpc.h
+++ b/src/cart/crt_rpc.h
@@ -94,6 +94,8 @@ struct crt_common_hdr {
 	uint64_t	cch_hlc;
 	/* gid and rank identify the rpc request sender */
 	d_rank_t	cch_rank;
+	/* Transfer id */
+	uint32_t	cch_xid;
 	/* used in crp_reply_hdr to propagate rpc failure back to sender */
 	uint32_t	cch_rc;
 };
@@ -638,16 +640,6 @@ struct crt_internal_rpc {
 
 void crt_req_destroy(struct crt_rpc_priv *rpc_priv);
 
-static inline void
-crt_common_hdr_init(struct crt_common_hdr *hdr, crt_opcode_t opc)
-{
-	int rc;
-
-	D_ASSERT(hdr != NULL);
-	hdr->cch_opc = opc;
-	rc = crt_group_rank(0, &hdr->cch_rank);
-	D_ASSERT(rc == 0);
-}
 
 static inline bool
 crt_rpc_cb_customized(struct crt_context *crt_ctx,


### PR DESCRIPTION
- new cch_xid field added to rpc header
- global xid is incremented on each rpc creation
- opc and xid are now printed as part of RPC_TRACE/RPC_ERROR macros

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>