### PR TITLE
CART-629 log: add function to set DD_MASK

### DIFF
--- a/src/gurt/debug.c
+++ b/src/gurt/debug.c
@@ -297,6 +297,54 @@ d_log_dbg_grp_dealloc(char *name)
 	return -1;
 }
 
+static void
+debug_mask_load(const char *mask_name)
+{
+	char			*mask_str;
+	char			*cur;
+	int			 i;
+	struct d_debug_bit	*d;
+	struct d_debug_grp	*g;
+
+	D_STRNDUP(mask_str, mask_name, DBG_ENV_MAX_LEN);
+	if (mask_str == NULL) {
+		D_PRINT_ERR("D_STRNDUP of debug mask failed");
+		return;
+	}
+
+	cur = strtok(mask_str, DD_SEP);
+	d_dbglog_data.dd_mask = 0;
+	while (cur != NULL) {
+		for (i = 0; i < NUM_DBG_BIT_ENTRIES; i++) {
+			d = &d_dbg_bit_dict[i];
+			if (d->db_name != NULL &&
+			    strncasecmp(cur, d->db_name,
+					d->db_name_size) == 0) {
+				d_dbglog_data.dd_mask |= *(d->db_bit);
+				break;
+			}
+			if (d->db_lname != NULL &&
+			    strncasecmp(cur, d->db_lname,
+					d->db_lname_size) == 0) {
+				d_dbglog_data.dd_mask |= *(d->db_bit);
+				break;
+			}
+		}
+		/* check if DD_MASK entry is a group name */
+		for (i = 0; i < NUM_DBG_GRP_ENTRIES; i++) {
+			g = &d_dbg_grp_dict[i];
+			if (g->dg_name != NULL &&
+			    strncasecmp(cur, g->dg_name,
+					g->dg_name_size) == 0) {
+				d_dbglog_data.dd_mask |= g->dg_mask;
+				break;
+			}
+		}
+		cur = strtok(NULL, DD_SEP);
+	}
+	D_FREE(mask_str);
+}
+
 /**
  * Create an identifier/group name for muliple debug bits
  *
@@ -306,16 +354,18 @@ d_log_dbg_grp_dealloc(char *name)
  * \return			0 on success, -1 on error
  */
 int
-d_log_dbg_grp_alloc(d_dbug_t dbgmask, char *grpname)
+d_log_dbg_grp_alloc(d_dbug_t dbgmask, char *grpname, uint32_t flags)
 {
-	int		   i;
-	size_t		   name_sz;
-	struct d_debug_grp *g;
+	int			 i;
+	size_t			 name_sz;
+	struct d_debug_grp	*g;
+	bool			 set_as_default;
 
 	if (grpname == NULL || dbgmask == 0)
 		return -1;
 
 	name_sz = strlen(grpname) + 1;
+	set_as_default = flags & D_LOG_SET_AS_DEFAULT;
 
 	/**
 	 * Allocate debug group in gurt for given debug mask name.
@@ -334,6 +384,9 @@ d_log_dbg_grp_alloc(d_dbug_t dbgmask, char *grpname)
 			g->dg_name = grpname;
 			g->dg_name_size = name_sz;
 			g->dg_mask = dbgmask;
+			if (set_as_default)
+				debug_mask_load(grpname);
+
 			return 0;
 		}
 	}
@@ -371,53 +424,12 @@ static void
 debug_mask_load_env(void)
 {
 	char		    *mask_env;
-	char		    *mask_str;
-	char		    *cur;
-	int		    i;
-	struct d_debug_bit *d;
-	struct d_debug_grp *g;
 
 	mask_env = getenv(DD_MASK_ENV);
 	if (mask_env == NULL)
 		return;
 
-	D_STRNDUP(mask_str, mask_env, DBG_ENV_MAX_LEN);
-	if (mask_str == NULL) {
-		D_PRINT_ERR("D_STRNDUP of debug mask failed");
-		return;
-	}
-
-	cur = strtok(mask_str, DD_SEP);
-	d_dbglog_data.dd_mask = 0;
-	while (cur != NULL) {
-		for (i = 0; i < NUM_DBG_BIT_ENTRIES; i++) {
-			d = &d_dbg_bit_dict[i];
-			if (d->db_name != NULL &&
-			    strncasecmp(cur, d->db_name,
-					d->db_name_size) == 0) {
-				d_dbglog_data.dd_mask |= *(d->db_bit);
-				break;
-			}
-			if (d->db_lname != NULL &&
-			    strncasecmp(cur, d->db_lname,
-					d->db_lname_size) == 0) {
-				d_dbglog_data.dd_mask |= *(d->db_bit);
-				break;
-			}
-		}
-		/* check if DD_MASK entry is a group name */
-		for (i = 0; i < NUM_DBG_GRP_ENTRIES; i++) {
-			g = &d_dbg_grp_dict[i];
-			if (g->dg_name != NULL &&
-			    strncasecmp(cur, g->dg_name,
-					g->dg_name_size) == 0) {
-				d_dbglog_data.dd_mask |= g->dg_mask;
-				break;
-			}
-		}
-		cur = strtok(NULL, DD_SEP);
-	}
-	D_FREE(mask_str);
+	debug_mask_load(mask_env);
 }
 
 void

--- a/src/gurt/debug.c
+++ b/src/gurt/debug.c
@@ -348,8 +348,11 @@ debug_mask_load(const char *mask_name)
 /**
  * Create an identifier/group name for muliple debug bits
  *
- * \param[in]	grpname		debug mask group name
  * \param[in]	dbgmask		group mask
+ * \param[in]	grpname		debug mask group name
+ * \param[in]	flags		bit flags. e.g. D_LOG_SET_AS_DEFAULT sets
+ *				grpname as the default mask. See
+ *				\ref d_log_flag_bits for supported flags.
  *
  * \return			0 on success, -1 on error
  */

--- a/src/include/gurt/dlog.h
+++ b/src/include/gurt/dlog.h
@@ -120,6 +120,10 @@ enum {
 	D_FOREACH_PRIO_MASK(D_PRIO_ENUM, D_NOOP)
 };
 
+enum d_log_flag_bits {
+	D_LOG_SET_AS_DEFAULT	= 1U,
+};
+
 #define DLOG_PRISHIFT   24		/**< to get non-debug level */
 #define DLOG_DPRISHIFT  8		/**< to get debug level */
 #define DLOG_FACMASK    0x000000ff	/**< facility mask */
@@ -250,7 +254,7 @@ int d_log_dbg_grp_dealloc(char *grpname);
  *
  * \return		0 on success, -1 on error
  */
-int d_log_dbg_grp_alloc(d_dbug_t dbgmask, char *grpname);
+int d_log_dbg_grp_alloc(d_dbug_t dbgmask, char *grpname, uint32_t flags);
 
 /**
  * log a message using stdarg list without checking filtering

--- a/src/include/gurt/dlog.h
+++ b/src/include/gurt/dlog.h
@@ -121,6 +121,10 @@ enum {
 };
 
 enum d_log_flag_bits {
+	/**
+	 * To be used in d_log_dbg_grp_alloc(). This bit sets grpname as the
+	 * global default debug mask.
+	 */
 	D_LOG_SET_AS_DEFAULT	= 1U,
 };
 
@@ -240,7 +244,7 @@ int d_log_dbg_bit_alloc(d_dbug_t *dbgbit, char *name, char *lname);
 /**
  * Reset optional debug group
  *
- * \param[in]	grpname	debug mask group name
+ * \param[in] grpname	debug mask group name
  *
  * \return		0 on success, -1 on error
  */
@@ -249,8 +253,11 @@ int d_log_dbg_grp_dealloc(char *grpname);
 /**
  * Create an identifier/group name for muliple debug bits
  *
- * \param[in]	grpname		debug mask group name
  * \param[in]	dbgmask		mask of all bits in group
+ * \param[in]	grpname		debug mask group name
+ * \param[in]	flags		bit flags. e.g. D_LOG_SET_AS_DEFAULT sets
+ *				grpname as the default mask. See
+ *				\ref d_log_flag_bits for supported flags.
  *
  * \return		0 on success, -1 on error
  */


### PR DESCRIPTION
Add a function to set default DD_MASK. Currently the only way to set
DD_MASK is via the shell variable.