### PR TITLE
CART-0000 hlc: fails RPC if nodes time is out of sync

### DIFF
--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -837,7 +837,7 @@ crt_rpc_handler_common(hg_handle_t hg_hdl)
 	rc = crt_hg_unpack_header(hg_hdl, &rpc_tmp, &proc);
 	if (rc != 0) {
 		D_ERROR("crt_hg_unpack_header failed, rc: %d.\n", rc);
-		crt_hg_reply_error_send(&rpc_tmp, -DER_MISC);
+		crt_hg_reply_error_send(&rpc_tmp, rc);
 		/** safe to return here because relevant portion of rpc_tmp is
 		 * already serialized by Mercury. Same for below.
 		 */
@@ -1134,7 +1134,7 @@ crt_hg_req_send_cb(const struct hg_cb_info *hg_cbinfo)
 				RPC_ERROR(rpc_priv,
 					  "HG_Get_output failed, hg_ret: %d\n",
 					  hg_ret);
-				rc = -DER_HG;
+				rc = (hg_ret == -DER_TIME_SYNC) ? hg_ret : -DER_HG;
 			}
 		}
 	}

--- a/src/include/gurt/errno.h
+++ b/src/include/gurt/errno.h
@@ -121,7 +121,9 @@
 	/** user-provided RPC handler didn't send reply back */		\
 	ACTION(DER_NOREPLY,		(DER_ERR_GURT_BASE + 33))	\
 	/** denial-of-service */					\
-	ACTION(DER_DOS,			(DER_ERR_GURT_BASE + 34))
+	ACTION(DER_DOS,			(DER_ERR_GURT_BASE + 34))	\
+	/** time is out of sync */					\
+	ACTION(DER_TIME_SYNC,		(DER_ERR_GURT_BASE + 35))
 	/** TODO: add more error numbers */
 
 #define D_FOREACH_DAOS_ERR(ACTION)					\

--- a/src/test/test_hlc_net.c
+++ b/src/test/test_hlc_net.c
@@ -163,6 +163,8 @@ static void test_cli_cb(const struct crt_cb_info *cb_info)
 
 		D_ASSERT(rpc_input->hlc < rpc_output->hlc);
 		D_ASSERT(rpc_output->hlc < hlc);
+	} else if (cb_info->cci_rc == -DER_TIME_SYNC) {
+		D_ERROR("HLC is out of sync\n");
 	}
 }
 


### PR DESCRIPTION
In this patch implemented example of tracking the case when
node's time is significantly out of sync. A incoming RPC is rejected
if incoming node's time is far in future. With this approach makes
no significant meaning of the time of RPC in flight. The HLC is not
synchronized with out of sync node.

Signed-off-by: Dmitry Eremin <dmitry.eremin@intel.com>