### PR TITLE
CART-644 bug: uri entry destruction asserts

### DIFF
--- a/src/cart/crt_group.c
+++ b/src/cart/crt_group.c
@@ -615,9 +615,6 @@ crt_grp_lc_addr_invalid(d_list_t *rlink, void *arg)
 		li->li_tag_addr[i] = NULL;
 	}
 
-	d_hash_rec_delete(&li->li_grp_priv->gp_uri_lookup_cache,
-			&li->li_rank, sizeof(d_rank_t));
-
 out:
 	D_MUTEX_UNLOCK(&li->li_mutex);
 	return rc;

--- a/src/test/SConscript
+++ b/src/test/SConscript
@@ -40,7 +40,7 @@
 import os
 
 SIMPLE_TEST_SRC = ['test_no_pmix.c', 'test_crt_barrier.c', 'threaded_client.c',
-                   'threaded_server.c', 'test_pmix.c',
+                   'no_pmix_multi_ctx.c', 'threaded_server.c', 'test_pmix.c',
                    'test_corpc_version.c', 'test_corpc_prefwd.c',
                    'test_proto_server.c', 'test_proto_client.c',
                    'test_no_timeout.c', 'test_ep_cred_server.c',

--- a/src/test/no_pmix_multi_ctx.c
+++ b/src/test/no_pmix_multi_ctx.c
@@ -1,0 +1,154 @@
+/* Copyright (C) 2018-2019 Intel Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted for any purpose (including commercial purposes)
+ * provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions, and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions, and the following disclaimer in the
+ *    documentation and/or materials provided with the distribution.
+ *
+ * 3. In addition, redistributions of modified forms of the source or binary
+ *    code must carry prominent notices stating that the original code was
+ *    changed and the date of the change.
+ *
+ *  4. All publications or advertising materials mentioning features or use of
+ *     this software are asked, but not required, to acknowledge that it was
+ *     developed by Intel Corporation and credit the contributors.
+ *
+ * 5. Neither the name of Intel Corporation, nor the name of any Contributor
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/**
+ * This test verifies proper destruction of contexts and of associated internal
+ * lookup and uri caches when done in parallel.
+ *
+ * Test creates 8 contexts with 8 threads, sets self rank to 0, adds 99 ranks
+ * each with the uri of ourself (need to add valid uri address), and issues
+ * shutdown sequence on threads.
+ *
+ * Threads attempt to destroy their respective contexts, triggering internal
+ * lookup cache/uri table destruction.
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <assert.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <semaphore.h>
+#include <gurt/common.h>
+#include <cart/api.h>
+
+
+#define NUM_CTX 8
+#define NUM_RANKS 99
+
+static int g_do_shutdown;
+
+static void *
+progress_function(void *data)
+{
+	crt_context_t *p_ctx = (crt_context_t *)data;
+
+	while (g_do_shutdown == 0)
+		crt_progress(*p_ctx, 1000, NULL, NULL);
+
+	crt_context_destroy(*p_ctx, 1);
+
+	return NULL;
+}
+
+int main(int argc, char **argv)
+{
+	crt_group_t	*grp;
+	crt_context_t	crt_ctx[NUM_CTX];
+	crt_node_info_t	node_info;
+	pthread_t	progress_thread[NUM_CTX];
+	int		i;
+	int		rc;
+	char		*my_uri;
+
+	rc = d_log_init();
+	assert(rc == 0);
+
+	rc = crt_init(0, CRT_FLAG_BIT_SERVER |
+		CRT_FLAG_BIT_PMIX_DISABLE | CRT_FLAG_BIT_LM_DISABLE);
+
+
+	grp = crt_group_lookup(NULL);
+	if (!grp) {
+		D_ERROR("Failed to lookup group\n");
+		assert(0);
+	}
+
+	rc = crt_rank_self_set(0);
+	if (rc != 0) {
+		D_ERROR("crt_rank_self_set(0) failed; rc=%d\n", rc);
+		assert(0);
+	}
+
+
+	for (i = 0; i < NUM_CTX; i++) {
+		rc = crt_context_create(&crt_ctx[i]);
+		if (rc != 0) {
+			D_ERROR("crt_context_create() failed; rc=%d\n", rc);
+			assert(0);
+		}
+
+		rc = pthread_create(&progress_thread[i], 0,
+				progress_function, &crt_ctx[i]);
+		assert(rc == 0);
+	}
+
+	rc = crt_rank_uri_get(grp, 0, 0, &my_uri);
+	if (rc != 0) {
+		D_ERROR("crt_rank_uri_get() failed; rc=%d\n", rc);
+		assert(0);
+	}
+
+	/* NOTE: We have to pass valid uri or else group_node_add fails */
+	node_info.uri = my_uri;
+	for (i = 1; i < (NUM_RANKS + 1); i++) {
+		rc = crt_group_node_add(grp, i, 0, node_info);
+		if (rc != 0) {
+			D_ERROR("crt_group_node_add() failed; rc=%d\n", rc);
+			assert(0);
+		}
+	}
+
+	D_FREE(my_uri);
+	sleep(1);
+	g_do_shutdown = 1;
+
+	for (i = 0; i < NUM_CTX; i++)
+		pthread_join(progress_thread[i], NULL);
+
+	rc = crt_finalize();
+	if (rc != 0) {
+		D_ERROR("crt_finalize() failed with rc=%d\n", rc);
+		assert(0);
+	}
+
+	d_log_fini();
+
+	return 0;
+}
+

--- a/test/cart_test_no_pmix_multi_ctx.py
+++ b/test/cart_test_no_pmix_multi_ctx.py
@@ -74,7 +74,7 @@ class TestNoPmix(commontestsuite.CommonTestSuite):
         crt_phy_addr = os.getenv("CRT_PHY_ADDR_STR", "ofi+sockets")
         ofi_interface = os.getenv("OFI_INTERFACE", "eth0")
         ofi_share_addr = os.getenv("CRT_CTX_SHARE_ADDR", "0")
-        ofi_ctx_num = os.getenv("CRT_CTX_NUM", "0")
+        ofi_ctx_num = os.getenv("CRT_CTX_NUM", "8")
 
         # TODO: Wrong log file name is generated. need to investigate
         self.pass_env = {"CRT_PHY_ADDR_STR": crt_phy_addr,

--- a/test/cart_test_no_pmix_multi_ctx.py
+++ b/test/cart_test_no_pmix_multi_ctx.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+# Copyright (C) 2018-2019 Intel Corporation
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted for any purpose (including commercial purposes)
+# provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions, and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions, and the following disclaimer in the
+#    documentation and/or materials provided with the distribution.
+#
+# 3. In addition, redistributions of modified forms of the source or binary
+#    code must carry prominent notices stating that the original code was
+#    changed and the date of the change.
+#
+#  4. All publications or advertising materials mentioning features or use of
+#     this software are asked, but not required, to acknowledge that it was
+#     developed by Intel Corporation and credit the contributors.
+#
+# 5. Neither the name of Intel Corporation, nor the name of any Contributor
+#    may be used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+# THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# -*- coding: utf-8 -*-
+
+"""
+
+cart test when running with no pmix
+
+Usage:
+
+Execute from the install/$arch/TESTING directory.
+
+python3 test_runner scripts/cart_test_no_pmix_multi_ctx.yml
+
+To use valgrind memory checking
+set TR_USE_VALGRIND in cart_test_no_pmix_multi_ctx.yml to memcheck
+
+To use valgrind call (callgrind) profiling
+set TR_USE_VALGRIND in cart_test_no_pmix_multi_ctx.yml to callgrind
+
+"""
+# pylint: disable=fixme
+import os
+import subprocess
+import commontestsuite
+
+class TestNoPmix(commontestsuite.CommonTestSuite):
+    """ Execute non-pmix tests """
+
+    def setUp(self):
+        """setup the test"""
+        self.get_test_info()
+        # TODO: disable log_mask for now, as debug mask produces
+        # too much data during node addition.
+
+        # log_mask = os.getenv("D_LOG_MASK", "INFO")
+        log_file = self.get_cart_long_log_name()
+        print("LOG file is {}".format(log_file))
+        crt_phy_addr = os.getenv("CRT_PHY_ADDR_STR", "ofi+sockets")
+        ofi_interface = os.getenv("OFI_INTERFACE", "eth0")
+        ofi_share_addr = os.getenv("CRT_CTX_SHARE_ADDR", "0")
+        ofi_ctx_num = os.getenv("CRT_CTX_NUM", "0")
+
+        # TODO: Wrong log file name is generated. need to investigate
+        self.pass_env = {"CRT_PHY_ADDR_STR": crt_phy_addr,
+                         "OFI_INTERFACE": ofi_interface,
+                         "CRT_CTX_SHARE_ADDR": ofi_share_addr,
+                         "CRT_CTX_NUM": ofi_ctx_num}
+
+    def tearDown(self):
+        """tear down the test"""
+        self.logger.info("tearDown begin")
+        self.logger.info("tearDown end")
+
+    def test_no_pmix(self):
+        """test_no_pmix test case"""
+
+        test_bin = 'tests/no_pmix_multi_ctx'
+
+        test_env = self.pass_env
+        p = subprocess.Popen([test_bin], env=test_env,
+                             stdout=subprocess.PIPE)
+
+        rc = p.wait(timeout=10)
+
+
+        if rc != 0:
+            print("Error waiting for process. returning {}".format(rc))
+            return rc
+
+        print("Finished waiting for {}".format(p))
+
+        return 0

--- a/test/cart_test_no_pmix_multi_ctx.yml
+++ b/test/cart_test_no_pmix_multi_ctx.yml
@@ -1,0 +1,24 @@
+description: "cart_test_no_pmix_multi_ctx_module"
+
+defaultENV:
+    D_LOG_MASK: "DEBUG,MEM=ERR"
+    TR_REDIRECT_OUTPUT: "no"
+    CRT_PHY_ADDR_STR: "ofi+sockets"
+    OFI_INTERFACE: "eth0"
+
+module:
+    name: "cart_test_no_pmix_multi_ctx"
+    subLogKey: "CRT_TESTLOG"
+    setKeyFromHost: ["CRT_TEST_SERVER"]
+    hostConfig:
+        numServers: all
+        type: buildList
+    setKeyFromInfo:
+        - [CRT_PREFIX, PREFIX, ""]
+
+directives:
+    loop: "no"
+
+execStrategy:
+    - id: default
+      setEnvVars:

--- a/test/test_list.yml
+++ b/test/test_list.yml
@@ -34,3 +34,4 @@ test_list:
   - "scripts/cart_test_no_timeout.yml"
   - "scripts/cart_test_no_timeout_non_sep.yml"
   - "scripts/cart_test_no_pmix.yml"
+  - "scripts/cart_test_no_pmix_multi_ctx.yml"

--- a/utils/run_test.sh
+++ b/utils/run_test.sh
@@ -64,6 +64,8 @@ JENKINS_TEST_LIST=(scripts/cart_echo_test.yml                   \
                    scripts/cart_test_proto.yml                  \
                    scripts/cart_test_proto_non_sep.yml          \
                    scripts/cart_test_no_timeout.yml             \
+                   scripts/cart_test_no_pmix.yml		\
+                   scripts/cart_test_no_pmix_multi_ctx.yml	\
                    scripts/cart_test_no_timeout_non_sep.yml)
 
 # Check for symbol names in the library.


### PR DESCRIPTION
- URI table was previously incorrectly destroyed during context
invalidation. URI table should only be destroyed during group
destruction.

- no_pmix_multi_ctx test added

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>