### PR TITLE
CART-646 gurt: call d_log_sync_mask in d_log_init

### DIFF
--- a/src/gurt/debug.c
+++ b/src/gurt/debug.c
@@ -574,8 +574,9 @@ out:
 int
 d_log_init(void)
 {
-	char *log_file;
-	int flags = DLOG_FLV_LOGPID | DLOG_FLV_FAC | DLOG_FLV_TAG;
+	char	*log_file;
+	int	 flags = DLOG_FLV_LOGPID | DLOG_FLV_FAC | DLOG_FLV_TAG;
+	int	 rc;
 
 	log_file = getenv(D_LOG_FILE_ENV);
 	if (log_file == NULL || strlen(log_file) == 0) {
@@ -583,7 +584,15 @@ d_log_init(void)
 		log_file = NULL;
 	}
 
-	return d_log_init_adv("CaRT", log_file, flags, DLOG_WARN, DLOG_EMERG);
+	rc = d_log_init_adv("CaRT", log_file, flags, DLOG_WARN, DLOG_EMERG);
+	if (rc != DER_SUCCESS) {
+		D_PRINT_ERR("d_log_init_adv failed, rc: %d.\n", rc);
+		D_GOTO(out, rc);
+	}
+
+	d_log_sync_mask();
+out:
+	return rc;
 }
 
 void d_log_fini(void)


### PR DESCRIPTION
add an implicit call to d_log_sync_mask() in d_log_init()

Signed-off-by: Yulu Jia <yulu.jia@intel.com>