### PR TITLE
CART-603 launcher: New crt_launch utility added

### DIFF
--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -337,6 +337,7 @@ static int check_ep(crt_endpoint_t *tgt_ep)
 	} else {
 		grp_priv = container_of(tgt_ep->ep_grp, struct crt_grp_priv,
 					gp_pub);
+
 		if (grp_priv->gp_service == 0) {
 			D_ERROR("bad parameter tgt_ep->ep_grp: %p (gp_primary: "
 				"%d, gp_service: %d, gp_local: %d.\n",
@@ -1361,8 +1362,12 @@ crt_common_hdr_init(struct crt_rpc_priv *rpc_priv, crt_opcode_t opc)
 	uint32_t	xid;
 	int		rc;
 
-	rc = crt_group_rank(0, &rank);
-	D_ASSERT(rc == 0);
+	if (crt_is_service()) {
+		rc = crt_group_rank(0, &rank);
+		D_ASSERT(rc == 0);
+	} else {
+		rank = 0; /* Client rank */
+	}
 
 	xid = atomic_fetch_add(&crt_gdata.cg_xid, 1);
 

--- a/src/crt_launch/SConscript
+++ b/src/crt_launch/SConscript
@@ -35,66 +35,29 @@
 # ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
 # THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-"""Build cart src"""
+"""Build crt_launch"""
+
 import os
 
-HEADERS = ['api.h', 'iv.h', 'types.h', 'swim.h']
-HEADERS_GURT = ['dlog.h', 'debug.h', 'common.h', 'hash.h', 'list.h',
-                'heap.h', 'errno.h', 'fault_inject.h', 'debug_setup.h',
-                'types.h', 'atomic.h']
+CRT_LAUNCH = 'crt_launch.c'
 
 def scons():
-    """Scons function"""
+    """scons function"""
 
-    Import('env')
+    Import('env', 'prereqs', 'cart_lib', 'gurt_lib')
 
-    env.Append(CPPPATH=['#src/include'])
-    for header in HEADERS:
-        env.Install(os.path.join('$PREFIX', 'include', 'cart'),
-                    os.path.join('include', 'cart', header))
-    for header in HEADERS_GURT:
-        env.Install(os.path.join('$PREFIX', 'include', 'gurt'),
-                    os.path.join('include', 'gurt', header))
+    tenv = env.Clone()
 
-    # Generate the common libraries used by everyone
-    SConscript('gurt/SConscript')
-    SConscript('swim/SConscript')
-    SConscript('cart/SConscript')
+    tenv.AppendUnique(CPPPATH=['#/src/cart'])
+    tenv.AppendUnique(LIBS=['cart', 'gurt', 'pthread', 'm', 'mpi'])
+    prereqs.require(tenv, 'mercury')
+    tenv.AppendUnique(LIBPATH=['#/src/cart'])
+    tenv.AppendUnique(RPATH="$PREFIX/lib")
+    tenv.AppendUnique(FLAGS='-pthread')
 
-    # Builders
-    SConscript('test/SConscript')
-
-    # Build self test
-    SConscript('self_test/SConscript')
-
-    # Build crt_launch
-    SConscript('crt_launch/SConscript')
-
-    # Build cart_ctl
-    SConscript('ctl/SConscript')
-
-    # Build the unit tests
-    SConscript('utest/SConscript')
-
-    if not env.GetOption('clean'):
-
-        print("Checking local headers can be included")
-        broken_includes = False
-        config_env = env.Clone()
-        config = Configure(config_env)
-        for header in HEADERS_GURT:
-            if not config.CheckHeader(os.path.join('gurt', header)):
-                broken_includes = True
-        for header in HEADERS:
-            if not config.CheckHeader(os.path.join('cart', header)):
-                broken_includes = True
-        config.Finish()
-
-        if broken_includes:
-            print("Broken local header files, cannot continue")
-            Exit(2)
-
-    Default('gurt', 'swim', 'cart', 'test', 'self_test')
+    crt_launch = tenv.Program(CRT_LAUNCH)
+    tenv.Requires(crt_launch, [cart_lib, gurt_lib])
+    tenv.Install(os.path.join("$PREFIX", 'bin'), crt_launch)
 
 if __name__ == "SCons.Script":
     scons()

--- a/src/crt_launch/crt_launch.c
+++ b/src/crt_launch/crt_launch.c
@@ -1,0 +1,348 @@
+/* Copyright (C) 2019 Intel Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted for any purpose (including commercial purposes)
+ * provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions, and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions, and the following disclaimer in the
+ *    documentation and/or materials provided with the distribution.
+ *
+ * 3. In addition, redistributions of modified forms of the source or binary
+ *    code must carry prominent notices stating that the original code was
+ *    changed and the date of the change.
+ *
+ *  4. All publications or advertising materials mentioning features or use of
+ *     this software are asked, but not required, to acknowledge that it was
+ *     developed by Intel Corporation and credit the contributors.
+ *
+ * 5. Neither the name of Intel Corporation, nor the name of any Contributor
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/**
+ * MPI-based and cart-based crt_launch application that facilitates launching
+ * cart-based clients and servers when no pmix is used.
+ *
+ * Usage is mpirun -x OFI_INTERFACE=eth0 -H <hosts> crt_launch <app to run>
+ *
+ * crt_launch wil prepare environment for app and exec provided <app to run>
+ * The enviornment consists of envariables:
+ *
+ * CRT_L_RANK - rank for <app to run> to use. Rank is negotiated across all
+ * instances of crt_launch so that each exec-ed app is passed a unique rank.
+ *
+ * CRT_L_GRP_CFG - Path to group configuration file generated in /tmp/ having
+ * form of crt_launch-info-XXXXXX where X's are replaced by random string.
+ *
+ * OFI_PORT - port to use for
+ *
+ */
+#include <unistd.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <mpi.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <errno.h>
+#include <cart/api.h>
+#include <cart/types.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <assert.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <semaphore.h>
+#include <getopt.h>
+
+#include <gurt/common.h>
+
+
+#define URI_MAX 4096
+
+struct host {
+	int	my_rank;
+	char	self_uri[URI_MAX];
+	int	ofi_port;
+	int	is_client;
+};
+
+static int	my_rank;
+
+struct options_t {
+	int	is_client;
+	int	show_help;
+	char	*app_to_exec;
+	int	app_args_indx;
+};
+
+struct options_t g_opt;
+
+static void
+show_usage(const char *msg)
+{
+	printf("----------------------------------------------\n");
+	printf("%s\n", msg);
+	printf("Usage: crt_launch [-ch] <-e app_to_exec app_args>\n");
+	printf("Options:\n");
+	printf("-c	: Indicate app is a client\n");
+	printf("-h	: Print this help and exit\n");
+	printf("----------------------------------------------\n");
+}
+
+static int
+parse_args(int argc, char **argv)
+{
+	int				option_index = 0;
+	int				rc = 0;
+	struct option			long_options[] = {
+		{"client",	no_argument,		0, 'c'},
+		{"help",	no_argument,		0, 'h'},
+		{"exec",	required_argument,	0, 'e'},
+		{0, 0, 0, 0}
+	};
+
+	while (1) {
+		rc = getopt_long(argc, argv, "e:ch", long_options,
+				 &option_index);
+		if (rc == -1)
+			break;
+		switch (rc) {
+		case 'c':
+			g_opt.is_client = true;
+			break;
+		case 'h':
+			g_opt.show_help = true;
+			break;
+		case 'e':
+			g_opt.app_to_exec = optarg;
+			g_opt.app_args_indx = optind;
+			break;
+		default:
+			g_opt.show_help = true;
+			return 1;
+		}
+	}
+
+	return 0;
+}
+
+/* Retrieve self uri via CART */
+static int
+get_self_uri(struct host *h)
+{
+	char		*uri;
+	crt_context_t	ctx;
+	char		*p;
+	int		len;
+	int		rc;
+
+	rc = crt_init(0, CRT_FLAG_BIT_SERVER | CRT_FLAG_BIT_PMIX_DISABLE |
+			CRT_FLAG_BIT_LM_DISABLE);
+	if (rc != 0) {
+		D_ERROR("crt_init() failed; rc=%d\n", rc);
+		D_GOTO(out, rc);
+	}
+
+	rc = crt_context_create(&ctx);
+	if (rc != 0) {
+		D_ERROR("crt_context_create() failed; rc=%d\n", rc);
+		D_GOTO(out, rc);
+	}
+
+	rc = crt_self_uri_get(0, &uri);
+	if (rc != 0) {
+		D_ERROR("crt_self_uri_get() failed; rc=%d\n", rc);
+		D_GOTO(out, rc);
+	}
+
+	len = strlen(uri);
+
+	/* Find port number - first from the end number separated by :*/
+	/* URIs have a form of: ofi+sockets://10.8.1.55:48259 */
+	p = uri+len;
+	while (*p != ':') {
+		p--;
+		if (p == uri)
+			break;
+	}
+
+	/* Replace : with space */
+	*p = ' ';
+
+	p++;
+	h->ofi_port = atoi(p);
+	strncpy(h->self_uri, uri, URI_MAX-1);
+
+	D_FREE(uri);
+
+	rc = crt_context_destroy(ctx, 1);
+	if (rc != 0) {
+		D_ERROR("ctx_context_destroy() failed; rc=%d\n", rc);
+		D_GOTO(out, rc);
+	}
+
+	rc = crt_finalize();
+	if (rc != 0) {
+		D_ERROR("crt_finalize() failed; rc=%d\n", rc);
+		D_GOTO(out, rc);
+	}
+
+out:
+	return rc;
+}
+
+/*
+ * Generate group configuration file. Each entry consists of
+ * rank<space>uri lines.
+ *
+ * At the end point CRT_L_GRP_CFG envariable to a generated file
+ */
+static int
+generate_group_file(int world_size, struct host *h)
+{
+	FILE	*f;
+	char	grp_info_template[] = "/tmp/crt_launch-info-XXXXXXX";
+	int	tmp_fd;
+	int	i;
+
+	tmp_fd = mkstemp(grp_info_template);
+
+	if (tmp_fd == -1) {
+		D_ERROR("mkstemp() failed on %s, error: %s\n",
+			grp_info_template, strerror(errno));
+		return -1;
+	}
+
+	f = fdopen(tmp_fd, "w");
+	if (f == NULL) {
+		printf("fopen failed on %s, error: %s\n",
+			grp_info_template, strerror(errno));
+		return -1;
+	}
+
+	for (i = 0; i < world_size; i++) {
+		if (h[i].is_client == false)
+			fprintf(f, "%d %s\n", h[i].my_rank, h[i].self_uri);
+	}
+
+	fclose(f);
+	setenv("CRT_L_GRP_CFG", grp_info_template, true);
+
+	return 0;
+}
+
+
+int main(int argc, char **argv)
+{
+	int		world_size;
+	struct host	*hostbuf = NULL;
+	struct host	*recv_buf = NULL;
+	int		rc = 0;
+	char		str_rank[255];
+	char		str_port[255];
+
+	if (argc < 2) {
+		show_usage("Insufficient number of arguments");
+		return -1;
+	}
+
+	rc = parse_args(argc, argv);
+	if (rc != 0) {
+		show_usage("Failed to parse arguments");
+		return -1;
+	}
+
+	if (g_opt.show_help) {
+		show_usage("Help");
+		return -1;
+	}
+
+	if (g_opt.app_to_exec == NULL) {
+		show_usage("-e option is required\n");
+		return -1;
+	}
+
+	/*
+	 * Using MPI negotiate ranks between each process and retrieve
+	 * URI.
+	 */
+	MPI_Init(&argc, &argv);
+
+	MPI_Comm_rank(MPI_COMM_WORLD, &my_rank);
+	MPI_Comm_size(MPI_COMM_WORLD, &world_size);
+
+	hostbuf = calloc(sizeof(*hostbuf), 1);
+	if (!hostbuf) {
+		D_ERROR("Failed to allocate hostbuf\n");
+		D_GOTO(exit, rc = -1);
+	}
+
+	recv_buf = calloc(sizeof(struct host), world_size);
+	if (!recv_buf) {
+		D_ERROR("Failed to allocate recv_buf\n");
+		D_GOTO(exit, rc = -1);
+	}
+
+	hostbuf->is_client = g_opt.is_client;
+	hostbuf->my_rank = my_rank;
+	rc = get_self_uri(hostbuf);
+	if (rc != 0) {
+		D_ERROR("Failed to retrieve self uri\n");
+		D_GOTO(exit, rc);
+	}
+
+	MPI_Allgather(hostbuf, sizeof(struct host), MPI_CHAR,
+		recv_buf, sizeof(struct host), MPI_CHAR,
+		   MPI_COMM_WORLD);
+
+	/* Generate group configuration file */
+	rc = generate_group_file(world_size, recv_buf);
+	if (rc != 0) {
+		D_ERROR("generate_group_file() failed\n");
+		D_GOTO(exit, rc);
+	}
+
+	MPI_Barrier(MPI_COMM_WORLD);
+
+	sprintf(str_rank, "%d", hostbuf->my_rank);
+	sprintf(str_port, "%d", hostbuf->ofi_port);
+exit:
+	if (hostbuf)
+		free(hostbuf);
+
+	if (recv_buf)
+		free(recv_buf);
+
+	MPI_Finalize();
+
+	/* Set CRT_L_RANK and OFI_PORT */
+	setenv("CRT_L_RANK", str_rank, true);
+	setenv("OFI_PORT", str_port, true);
+
+	if (rc == 0) {
+		/* Exec passed application with rest of arguments */
+		execve(g_opt.app_to_exec, &argv[g_opt.app_args_indx], environ);
+	}
+
+	return 0;
+
+
+}

--- a/src/include/cart/api.h
+++ b/src/include/cart/api.h
@@ -1875,6 +1875,40 @@ int crt_group_info_set(d_iov_t *grp_info);
  */
 int crt_group_ranks_get(crt_group_t *group, d_rank_list_t **list);
 
+/**
+ * Create local group view and return a handle to a group.
+ * This call is only supported for cliens.
+ *
+ * \param[in] grp_id            Group id to create
+ * \param[out] ret_grp          Returned group handle
+ *
+ * \return                      DER_SUCCESS on success, negative value
+ *                              on failure
+ */
+int crt_group_view_create(crt_group_id_t grpid, crt_group_t **ret_grp);
+
+/**
+ * Destroy group handle previously created by \a crt_Group_view_create
+ * This call is only suppoted for clients
+ *
+ * \param[in] grp               Group handle to destroy
+ *
+ * \return                      DER_SUCCESS on success, negative value
+ *                              on failure.
+ */
+int crt_group_view_destroy(crt_group_t *grp);
+
+/**
+ * Specify rank to be a PSR for the provided group
+ *
+ * \param[in] grp               Group handle
+ * \param[in] rank              Rank to set as PSR
+ *
+ * \return                      DER_SUCCESS on success, negative value
+ *                              on failure.
+ */
+int crt_group_psr_set(crt_group_t *grp, d_rank_t rank);
+
 #define crt_proc__Bool			crt_proc_bool
 #define crt_proc_d_rank_t		crt_proc_uint32_t
 #define crt_proc_int			crt_proc_int32_t

--- a/src/test/SConscript
+++ b/src/test/SConscript
@@ -44,7 +44,8 @@ SIMPLE_TEST_SRC = ['test_no_pmix.c', 'test_crt_barrier.c', 'threaded_client.c',
                    'test_corpc_version.c', 'test_corpc_prefwd.c',
                    'test_proto_server.c', 'test_proto_client.c',
                    'test_no_timeout.c', 'test_ep_cred_server.c',
-                   'test_ep_cred_client.c']
+                   'test_ep_cred_client.c', 'no_pmix_launcher_server.c',
+                   'no_pmix_launcher_client.c']
 ECHO_TEST_SRC = ['crt_echo_cli.c', 'crt_echo_srv.c', 'crt_echo_srv2.c']
 BASIC_SRC = ['crt_basic.c']
 TEST_GROUP_SRC = 'test_group.c'

--- a/src/test/no_pmix_launcher_client.c
+++ b/src/test/no_pmix_launcher_client.c
@@ -1,0 +1,254 @@
+/* Copyright (C) 2018-2019 Intel Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted for any purpose (including commercial purposes)
+ * provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions, and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions, and the following disclaimer in the
+ *    documentation and/or materials provided with the distribution.
+ *
+ * 3. In addition, redistributions of modified forms of the source or binary
+ *    code must carry prominent notices stating that the original code was
+ *    changed and the date of the change.
+ *
+ *  4. All publications or advertising materials mentioning features or use of
+ *     this software are asked, but not required, to acknowledge that it was
+ *     developed by Intel Corporation and credit the contributors.
+ *
+ * 5. Neither the name of Intel Corporation, nor the name of any Contributor
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/**
+ * Client utilizing crt_launch generated environment for NO-PMIX mode
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <assert.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <semaphore.h>
+#include <gurt/common.h>
+#include <cart/api.h>
+
+#include "no_pmix_launcher_common.h"
+#include "tests_common.h"
+
+static void *
+progress_function(void *data)
+{
+	crt_context_t *p_ctx = (crt_context_t *)data;
+
+	while (g_do_shutdown == 0)
+		crt_progress(*p_ctx, 1000, NULL, NULL);
+
+	crt_context_destroy(*p_ctx, 1);
+
+	return NULL;
+}
+
+static void
+rpc_handle_reply(const struct crt_cb_info *info)
+{
+	sem_t	*sem;
+
+	D_ASSERTF(info->cci_rc == 0, "rpc response failed. rc: %d\n",
+		info->cci_rc);
+
+	sem = (sem_t *)info->cci_arg;
+	sem_post(sem);
+}
+
+
+int main(int argc, char **argv)
+{
+	crt_context_t		crt_ctx;
+	crt_group_t		*grp;
+	char			*grp_cfg_file;
+	int			rc;
+	sem_t			sem;
+	pthread_t		progress_thread;
+	crt_rpc_t		*rpc = NULL;
+	struct RPC_PING_in	*input;
+	crt_endpoint_t		server_ep;
+	int			i;
+	uint32_t		grp_size;
+	d_rank_list_t		*rank_list;
+	d_rank_t		rank;
+	int			tag;
+
+	/* Set up for DBG_PRINT */
+	opts.self_rank = 0;
+	opts.mypid = getpid();
+	opts.is_server = 0;
+
+	rc = d_log_init();
+	assert(rc == 0);
+
+	DBG_PRINT("Client starting up\n");
+
+	rc = sem_init(&sem, 0, 0);
+	if (rc != 0) {
+		D_ERROR("sem_init() failed; rc=%d\n", rc);
+		assert(0);
+	}
+
+	rc = crt_init(NULL, CRT_FLAG_BIT_SINGLETON | CRT_FLAG_BIT_PMIX_DISABLE |
+			CRT_FLAG_BIT_LM_DISABLE);
+	if (rc != 0) {
+		D_ERROR("crt_init() failed; rc=%d\n", rc);
+		assert(0);
+	}
+
+	rc = crt_proto_register(&my_proto_fmt);
+	if (rc != 0) {
+		D_ERROR("crt_proto_register() failed; rc=%d\n", rc);
+		assert(0);
+	}
+
+	rc = crt_group_view_create("server_grp", &grp);
+	if (!grp || rc != 0) {
+		D_ERROR("Failed to create group view; rc=%d\n", rc);
+		assert(0);
+	}
+
+	rc = crt_context_create(&crt_ctx);
+	if (rc != 0) {
+		D_ERROR("crt_context_create() failed; rc=%d\n", rc);
+		assert(0);
+	}
+
+	rc = pthread_create(&progress_thread, 0,
+				progress_function, &crt_ctx);
+	assert(rc == 0);
+
+	grp_cfg_file = getenv("CRT_L_GRP_CFG");
+	DBG_PRINT("Client starting with cfg_file=%s\n", grp_cfg_file);
+
+	/* load group info from a config file and delete file upon return */
+	rc = tc_load_group_from_file(grp_cfg_file, grp, NUM_SERVER_CTX,
+				-1, true);
+	if (rc != 0) {
+		D_ERROR("tc_load_group_from_file() failed; rc=%d\n", rc);
+		assert(0);
+	}
+
+	/* Give time for servers to start; need better way later on */
+	sleep(2);
+
+	rc = crt_group_size(grp, &grp_size);
+	if (rc != 0) {
+		D_ERROR("crt_group_size() failed; rc=%d\n", rc);
+		assert(0);
+	}
+
+	rc = crt_group_ranks_get(grp, &rank_list);
+	if (rc != 0) {
+		D_ERROR("crt_group_ranks_get() failed; rc=%d\n", rc);
+		assert(0);
+	}
+
+	if (rank_list->rl_nr != grp_size) {
+		D_ERROR("rank_list differs in size. expected %d got %d\n",
+			grp_size, rank_list->rl_nr);
+		assert(0);
+	}
+
+	rc = crt_group_psr_set(grp, rank_list->rl_ranks[0]);
+	if (rc != 0) {
+		D_ERROR("crt_group_psr_set() failed; rc=%d\n", rc);
+		assert(0);
+	}
+
+	/* Cycle through all ranks and 8 tags and send rpc to each */
+	for (i = 0; i < rank_list->rl_nr; i++) {
+
+		rank = rank_list->rl_ranks[i];
+
+		for (tag = 0; tag < NUM_SERVER_CTX; tag++) {
+			DBG_PRINT("Sending ping to %d:%d\n", rank, tag);
+
+			server_ep.ep_rank = rank;
+			server_ep.ep_tag = tag;
+			server_ep.ep_grp = grp;
+
+			rc = crt_req_create(crt_ctx, &server_ep,
+					RPC_PING, &rpc);
+			if (rc != 0) {
+				D_ERROR("crt_req_create() failed; rc=%d\n",
+					rc);
+				assert(0);
+			}
+
+			input = crt_req_get(rpc);
+			input->tag = tag;
+
+			rc = crt_req_send(rpc, rpc_handle_reply, &sem);
+			tc_sem_timedwait(&sem, 10, __LINE__);
+			DBG_PRINT("Ping response from %d:%d\n", rank, tag);
+		}
+	}
+
+	/* Send shutdown RPC to each server */
+	for (i = 0; i < rank_list->rl_nr; i++) {
+
+		rank = rank_list->rl_ranks[i];
+		DBG_PRINT("Sending shutdown to rank=%d\n", rank);
+
+		server_ep.ep_rank = rank;
+		server_ep.ep_tag = 0;
+		server_ep.ep_grp = grp;
+
+		rc = crt_req_create(crt_ctx, &server_ep, RPC_SHUTDOWN,
+				&rpc);
+		if (rc != 0) {
+			D_ERROR("crt_req_create() failed; rc=%d\n", rc);
+			assert(0);
+		}
+
+		rc = crt_req_send(rpc, rpc_handle_reply, &sem);
+		tc_sem_timedwait(&sem, 10, __LINE__);
+		DBG_PRINT("RPC response received from rank=%d\n", rank);
+	}
+
+	D_FREE(rank_list->rl_ranks);
+	D_FREE(rank_list);
+
+	rc = crt_group_view_destroy(grp);
+	if (rc != 0) {
+		D_ERROR("crt_group_view_destroy() failed; rc=%d\n", rc);
+		assert(0);
+	}
+
+	g_do_shutdown = true;
+	pthread_join(progress_thread, NULL);
+
+	sem_destroy(&sem);
+
+	rc = crt_finalize();
+	if (rc != 0) {
+		D_ERROR("crt_finalize() failed with rc=%d\n", rc);
+		assert(0);
+	}
+
+	DBG_PRINT("Client successfully finished\n");
+	d_log_fini();
+}

--- a/src/test/no_pmix_launcher_common.h
+++ b/src/test/no_pmix_launcher_common.h
@@ -1,0 +1,165 @@
+/* Copyright (C) 2019 Intel Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted for any purpose (including commercial purposes)
+ * provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions, and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions, and the following disclaimer in the
+ *    documentation and/or materials provided with the distribution.
+ *
+ * 3. In addition, redistributions of modified forms of the source or binary
+ *    code must carry prominent notices stating that the original code was
+ *    changed and the date of the change.
+ *
+ *  4. All publications or advertising materials mentioning features or use of
+ *     this software are asked, but not required, to acknowledge that it was
+ *     developed by Intel Corporation and credit the contributors.
+ *
+ * 5. Neither the name of Intel Corporation, nor the name of any Contributor
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef __NO_PMIX_LAUNCHER_COMMON_H__
+#define __NO_PMIX_LAUNCHER_COMMON_H__
+
+struct test_options {
+	int		self_rank;
+	int		mypid;
+	int		is_server;
+};
+
+static struct test_options opts;
+
+#define DBG_PRINT(x...)							\
+	do {								\
+		if (opts.is_server)					\
+			fprintf(stderr, "SRV [rank=%d pid=%d]\t",	\
+			opts.self_rank,					\
+			opts.mypid);					\
+		else							\
+			fprintf(stderr, "CLI [rank=%d pid=%d]\t",	\
+			opts.self_rank,					\
+			opts.mypid);					\
+		fprintf(stderr, x);					\
+	} while (0)
+
+#define MY_BASE 0x010000000
+#define MY_VER  0
+
+#define NUM_SERVER_CTX 8
+
+#define RPC_DECLARE(name)						\
+	CRT_RPC_DECLARE(name, CRT_ISEQ_##name, CRT_OSEQ_##name)		\
+	CRT_RPC_DEFINE(name, CRT_ISEQ_##name, CRT_OSEQ_##name)
+
+enum {
+	RPC_PING = CRT_PROTO_OPC(MY_BASE, MY_VER, 0),
+	RPC_SET_GRP_INFO,
+	RPC_SHUTDOWN
+} rpc_id_t;
+
+
+#define CRT_ISEQ_RPC_PING	/* input fields */		 \
+	((uint64_t)		(tag)			CRT_VAR)
+
+#define CRT_OSEQ_RPC_PING	/* output fields */		 \
+	((uint64_t)		(field)			CRT_VAR)
+
+#define CRT_ISEQ_RPC_SET_GRP_INFO /* input fields */		 \
+	((d_iov_t)		(grp_info)		CRT_VAR)
+
+#define CRT_OSEQ_RPC_SET_GRP_INFO /* output fields */		 \
+	((uint64_t)		(rc)			CRT_VAR)
+
+#define CRT_ISEQ_RPC_SHUTDOWN	/* input fields */		 \
+	((uint64_t)		(field)			CRT_VAR)
+
+#define CRT_OSEQ_RPC_SHUTDOWN	/* output fields */		 \
+	((uint64_t)		(field)			CRT_VAR)
+
+int handler_ping(crt_rpc_t *rpc);
+int handler_set_group_info(crt_rpc_t *rpc);
+int handler_shutdown(crt_rpc_t *rpc);
+
+RPC_DECLARE(RPC_PING);
+RPC_DECLARE(RPC_SET_GRP_INFO);
+RPC_DECLARE(RPC_SHUTDOWN);
+
+struct crt_proto_rpc_format my_proto_rpc_fmt[] = {
+	{
+		.prf_flags	= 0,
+		.prf_req_fmt	= &CQF_RPC_PING,
+		.prf_hdlr	= (void *)handler_ping,
+		.prf_co_ops	= NULL,
+	}, {
+		.prf_flags	= 0,
+		.prf_req_fmt	= &CQF_RPC_SET_GRP_INFO,
+		.prf_hdlr	= (void *)handler_set_group_info,
+		.prf_co_ops	= NULL,
+	}, {
+		.prf_flags	= 0,
+		.prf_req_fmt	= &CQF_RPC_SHUTDOWN,
+		.prf_hdlr	= (void *)handler_shutdown,
+		.prf_co_ops	= NULL,
+	}
+};
+
+struct crt_proto_format my_proto_fmt = {
+	.cpf_name = "my-proto",
+	.cpf_ver = MY_VER,
+	.cpf_count = ARRAY_SIZE(my_proto_rpc_fmt),
+	.cpf_prf = &my_proto_rpc_fmt[0],
+	.cpf_base = MY_BASE,
+};
+
+int handler_ping(crt_rpc_t *rpc)
+{
+	struct RPC_PING_in	*input;
+	int			my_tag;
+
+	input = crt_req_get(rpc);
+
+	crt_context_idx(rpc->cr_ctx, &my_tag);
+
+	DBG_PRINT("Ping handler called on tag: %d\n", my_tag);
+	if (my_tag != input->tag) {
+		D_ERROR("Request was sent to wrong tag. Expected %lu got %d\n",
+			input->tag, my_tag);
+		assert(0);
+	}
+
+	crt_reply_send(rpc);
+	return 0;
+}
+
+int handler_set_group_info(crt_rpc_t *rpc)
+{
+	return 0;
+}
+static int g_do_shutdown;
+
+int handler_shutdown(crt_rpc_t *rpc)
+{
+	DBG_PRINT("Shutdown handler called!\n");
+	crt_reply_send(rpc);
+
+	g_do_shutdown = true;
+	return 0;
+}
+#endif

--- a/src/test/no_pmix_launcher_server.c
+++ b/src/test/no_pmix_launcher_server.c
@@ -1,0 +1,171 @@
+/* Copyright (C) 2018-2019 Intel Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted for any purpose (including commercial purposes)
+ * provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions, and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions, and the following disclaimer in the
+ *    documentation and/or materials provided with the distribution.
+ *
+ * 3. In addition, redistributions of modified forms of the source or binary
+ *    code must carry prominent notices stating that the original code was
+ *    changed and the date of the change.
+ *
+ *  4. All publications or advertising materials mentioning features or use of
+ *     this software are asked, but not required, to acknowledge that it was
+ *     developed by Intel Corporation and credit the contributors.
+ *
+ * 5. Neither the name of Intel Corporation, nor the name of any Contributor
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/**
+ * Server utilizing crt_launch generated environment for NO-PMIX mode
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <assert.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <semaphore.h>
+#include <gurt/common.h>
+#include <cart/api.h>
+
+#include "no_pmix_launcher_common.h"
+#include "tests_common.h"
+
+static void *
+progress_function(void *data)
+{
+	crt_context_t *p_ctx = (crt_context_t *)data;
+
+	while (g_do_shutdown == 0)
+		crt_progress(*p_ctx, 1000, NULL, NULL);
+
+	crt_context_destroy(*p_ctx, 1);
+
+	return NULL;
+}
+
+int main(int argc, char **argv)
+{
+	crt_group_t		*grp;
+	crt_context_t		crt_ctx[NUM_SERVER_CTX];
+	pthread_t		progress_thread[NUM_SERVER_CTX];
+	int			i;
+	char			*my_uri;
+	char			*env_self_rank;
+	d_rank_t		my_rank;
+	char			*grp_cfg_file;
+	uint32_t		grp_size;
+	int			rc;
+
+	env_self_rank = getenv("CRT_L_RANK");
+	my_rank = atoi(env_self_rank);
+
+	/* Set up for DBG_PRINT */
+	opts.self_rank = my_rank;
+	opts.mypid = getpid();
+	opts.is_server = 1;
+
+	rc = d_log_init();
+	assert(rc == 0);
+
+	DBG_PRINT("Server starting up\n");
+	rc = crt_init(NULL, CRT_FLAG_BIT_SERVER |
+		CRT_FLAG_BIT_PMIX_DISABLE | CRT_FLAG_BIT_LM_DISABLE);
+	if (rc != 0) {
+		D_ERROR("crt_init() failed; rc=%d\n", rc);
+		assert(0);
+	}
+
+	rc = crt_proto_register(&my_proto_fmt);
+	if (rc != 0) {
+		D_ERROR("crt_proto_register() failed; rc=%d\n", rc);
+		assert(0);
+	}
+
+	grp = crt_group_lookup(NULL);
+	if (!grp) {
+		D_ERROR("Failed to lookup group\n");
+		assert(0);
+	}
+
+	for (i = 0; i < NUM_SERVER_CTX; i++) {
+		rc = crt_context_create(&crt_ctx[i]);
+		if (rc != 0) {
+			D_ERROR("crt_context_create() failed; rc=%d\n", rc);
+			assert(0);
+		}
+
+		rc = pthread_create(&progress_thread[i], 0,
+				progress_function, &crt_ctx[i]);
+		assert(rc == 0);
+	}
+
+	grp_cfg_file = getenv("CRT_L_GRP_CFG");
+
+	rc = crt_rank_self_set(my_rank);
+	if (rc != 0) {
+		D_ERROR("crt_rank_self_set(%d) failed; rc=%d\n",
+			my_rank, rc);
+		assert(0);
+	}
+
+	rc = crt_rank_uri_get(grp, my_rank, 0, &my_uri);
+	if (rc != 0) {
+		D_ERROR("crt_rank_uri_get() failed; rc=%d\n", rc);
+		assert(0);
+	}
+
+	/* load group info from a config file and delete file upon return */
+	rc = tc_load_group_from_file(grp_cfg_file, grp, NUM_SERVER_CTX,
+				my_rank, true);
+	if (rc != 0) {
+		D_ERROR("tc_load_group_from_file() failed; rc=%d\n", rc);
+		assert(0);
+	}
+
+	DBG_PRINT("self_rank=%d uri=%s grp_cfg_file=%s\n", my_rank,
+			my_uri, grp_cfg_file);
+	D_FREE(my_uri);
+
+	rc = crt_group_size(NULL, &grp_size);
+	if (rc != 0) {
+		D_ERROR("crt_group_size() failed; rc=%d\n", rc);
+		assert(0);
+	}
+
+	/* Wait until shutdown is issued and progress threads exit */
+	for (i = 0; i < NUM_SERVER_CTX; i++)
+		pthread_join(progress_thread[i], NULL);
+
+	rc = crt_finalize();
+	if (rc != 0) {
+		D_ERROR("crt_finalize() failed with rc=%d\n", rc);
+		assert(0);
+	}
+
+	d_log_fini();
+
+	return 0;
+}
+

--- a/src/test/tests_common.h
+++ b/src/test/tests_common.h
@@ -1,0 +1,114 @@
+/* Copyright (C) 2019 Intel Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted for any purpose (including commercial purposes)
+ * provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions, and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions, and the following disclaimer in the
+ *    documentation and/or materials provided with the distribution.
+ *
+ * 3. In addition, redistributions of modified forms of the source or binary
+ *    code must carry prominent notices stating that the original code was
+ *    changed and the date of the change.
+ *
+ *  4. All publications or advertising materials mentioning features or use of
+ *     this software are asked, but not required, to acknowledge that it was
+ *     developed by Intel Corporation and credit the contributors.
+ *
+ * 5. Neither the name of Intel Corporation, nor the name of any Contributor
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/**
+ * Common functions to be shared among tests
+ */
+#ifndef __TESTS_COMMON_H__
+#define __TESTS_COMMON_H__
+
+int
+tc_load_group_from_file(const char *grp_cfg_file, crt_group_t *grp,
+		int num_contexts,
+		d_rank_t my_rank, bool delete_file)
+{
+	FILE		*f;
+	int		parsed_rank;
+	char		parsed_addr[255];
+	int		parsed_port;
+	char		full_uri[255];
+	crt_node_info_t node_info;
+	int		i;
+	int		rc = 0;
+
+	f = fopen(grp_cfg_file, "r");
+	if (!f) {
+		D_ERROR("Failed to open %s for reading\n", grp_cfg_file);
+		D_GOTO(out, rc = DER_NONEXIST);
+	}
+
+	while (1) {
+		rc = fscanf(f, "%d %s %d", &parsed_rank,
+			parsed_addr, &parsed_port);
+		if (rc == EOF) {
+			rc = 0;
+			break;
+		}
+
+		if (parsed_rank == my_rank)
+			continue;
+
+		for (i = 0; i < num_contexts; i++) {
+			sprintf(full_uri, "%s:%d", parsed_addr,
+				parsed_port + i);
+
+			node_info.uri = full_uri;
+			rc = crt_group_node_add(grp, parsed_rank, i,
+						node_info);
+			if (rc != 0) {
+				D_ERROR("Failed to add %d %s; rc=%d\n",
+					parsed_rank, full_uri, rc);
+				break;
+			}
+		}
+	}
+
+	fclose(f);
+
+	if (delete_file)
+		unlink(grp_cfg_file);
+
+out:
+	return rc;
+}
+
+static inline void
+tc_sem_timedwait(sem_t *sem, int sec, int line_number)
+{
+	struct timespec	deadline;
+	int		rc;
+
+	rc = clock_gettime(CLOCK_REALTIME, &deadline);
+	D_ASSERTF(rc == 0, "clock_gettime() failed at line %d rc: %d\n",
+		  line_number, rc);
+
+	deadline.tv_sec += sec;
+	rc = sem_timedwait(sem, &deadline);
+	D_ASSERTF(rc == 0, "sem_timedwait() failed at line %d rc: %d\n",
+		  line_number, rc);
+}
+#endif /* __TESTS_COMMON_H__ */

--- a/test/cart_test_no_pmix_launcher.py
+++ b/test/cart_test_no_pmix_launcher.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+# Copyright (C) 2018-2019 Intel Corporation
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted for any purpose (including commercial purposes)
+# provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions, and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions, and the following disclaimer in the
+#    documentation and/or materials provided with the distribution.
+#
+# 3. In addition, redistributions of modified forms of the source or binary
+#    code must carry prominent notices stating that the original code was
+#    changed and the date of the change.
+#
+#  4. All publications or advertising materials mentioning features or use of
+#     this software are asked, but not required, to acknowledge that it was
+#     developed by Intel Corporation and credit the contributors.
+#
+# 5. Neither the name of Intel Corporation, nor the name of any Contributor
+#    may be used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+# THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# -*- coding: utf-8 -*-
+
+"""
+
+cart test when running with no pmix
+
+Usage:
+
+Execute from the install/$arch/TESTING directory.
+
+python3 test_runner scripts/cart_test_no_pmix_launcher.yml
+
+To use valgrind memory checking
+set TR_USE_VALGRIND in cart_test_no_pmix_launcher.yml to memcheck
+
+To use valgrind call (callgrind) profiling
+set TR_USE_VALGRIND in cart_test_no_pmix_launcher.yml to callgrind
+
+"""
+# pylint: disable=fixme
+import os
+import subprocess
+import commontestsuite
+from socket import gethostname
+
+class TestNoPmix(commontestsuite.CommonTestSuite):
+    """ Execute non-pmix tests """
+
+    def setUp(self):
+        """setup the test"""
+        self.get_test_info()
+        # TODO: disable log_mask for now, as debug mask produces
+        # too much data during node addition.
+
+        # log_mask = os.getenv("D_LOG_MASK", "INFO")
+        log_file = self.get_cart_long_log_name()
+        print("LOG file is {}".format(log_file))
+        crt_phy_addr = os.getenv("CRT_PHY_ADDR_STR", "ofi+sockets")
+        ofi_interface = os.getenv("OFI_INTERFACE", "eth0")
+        ofi_share_addr = os.getenv("CRT_CTX_SHARE_ADDR", "0")
+        ofi_ctx_num = os.getenv("CRT_CTX_NUM", "8")
+
+        # TODO: Wrong log file name is generated. need to investigate
+        self.pass_env = ' -x CRT_PHY_ADDR_STR={!s}' \
+                        ' -x OFI_INTERFACE={!s} -x D_LOG_MASK=ERR'.format(
+                        crt_phy_addr, ofi_interface)
+
+    def tearDown(self):
+        """tear down the test"""
+        self.logger.info("tearDown begin")
+        self.logger.info("tearDown end")
+
+    def test_no_pmix(self):
+        """test_no_pmix test case"""
+
+        testmsg = self.shortDescription()
+
+        servers = self.get_server_list()
+        #run test even if server list is not provided.
+        if servers:
+            all_servers = ','.join(servers)
+            hosts = ''.join([' -H ', all_servers])
+        else:
+            hosts = ''.join([' -H ', gethostname().split('.')[0]])
+
+        server_bin = 'crt_launch -e tests/no_pmix_launcher_server'
+        client_bin = 'crt_launch -c -e tests/no_pmix_launcher_client'
+
+        (cmd, prefix) = self.add_prefix_logdir()
+
+        cmdstr = "{!s} {!s} -np 5 {} {!s} {!s} : -np 1 {!s} {!s} {!s} ".format(
+            cmd, hosts, self.pass_env, prefix, server_bin,
+            self.pass_env, prefix, client_bin)
+
+
+        cmd_rtn = self.execute_cmd(testmsg, cmdstr)
+
+        if cmd_rtn:
+            self.fail("no_pmix_launcher test fialed. return code %d" % cmd_rn)
+
+
+        return 0

--- a/test/cart_test_no_pmix_launcher.py
+++ b/test/cart_test_no_pmix_launcher.py
@@ -56,9 +56,8 @@ set TR_USE_VALGRIND in cart_test_no_pmix_launcher.yml to callgrind
 """
 # pylint: disable=fixme
 import os
-import subprocess
-import commontestsuite
 from socket import gethostname
+import commontestsuite
 
 class TestNoPmix(commontestsuite.CommonTestSuite):
     """ Execute non-pmix tests """
@@ -70,17 +69,13 @@ class TestNoPmix(commontestsuite.CommonTestSuite):
         # too much data during node addition.
 
         # log_mask = os.getenv("D_LOG_MASK", "INFO")
-        log_file = self.get_cart_long_log_name()
-        print("LOG file is {}".format(log_file))
         crt_phy_addr = os.getenv("CRT_PHY_ADDR_STR", "ofi+sockets")
         ofi_interface = os.getenv("OFI_INTERFACE", "eth0")
-        ofi_share_addr = os.getenv("CRT_CTX_SHARE_ADDR", "0")
-        ofi_ctx_num = os.getenv("CRT_CTX_NUM", "8")
 
         # TODO: Wrong log file name is generated. need to investigate
         self.pass_env = ' -x CRT_PHY_ADDR_STR={!s}' \
                         ' -x OFI_INTERFACE={!s} -x D_LOG_MASK=ERR'.format(
-                        crt_phy_addr, ofi_interface)
+                            crt_phy_addr, ofi_interface)
 
     def tearDown(self):
         """tear down the test"""
@@ -113,7 +108,7 @@ class TestNoPmix(commontestsuite.CommonTestSuite):
         cmd_rtn = self.execute_cmd(testmsg, cmdstr)
 
         if cmd_rtn:
-            self.fail("no_pmix_launcher test fialed. return code %d" % cmd_rn)
+            self.fail("no_pmix_launcher test fialed. return code %d" % cmd_rtn)
 
 
         return 0

--- a/test/cart_test_no_pmix_launcher.yml
+++ b/test/cart_test_no_pmix_launcher.yml
@@ -1,0 +1,24 @@
+description: "cart_test_no_pmix_launcher"
+
+defaultENV:
+    D_LOG_MASK: "DEBUG,MEM=ERR"
+    TR_REDIRECT_OUTPUT: "no"
+    CRT_PHY_ADDR_STR: "ofi+sockets"
+    OFI_INTERFACE: "eth0"
+
+module:
+    name: "cart_test_no_pmix_launcher"
+    subLogKey: "CRT_TESTLOG"
+    setKeyFromHost: ["CRT_TEST_SERVER"]
+    hostConfig:
+        numServers: all
+        type: buildList
+    setKeyFromInfo:
+        - [CRT_PREFIX, PREFIX, ""]
+
+directives:
+    loop: "no"
+
+execStrategy:
+    - id: default
+      setEnvVars:

--- a/test/test_list.yml
+++ b/test/test_list.yml
@@ -35,3 +35,4 @@ test_list:
   - "scripts/cart_test_no_timeout_non_sep.yml"
   - "scripts/cart_test_no_pmix.yml"
   - "scripts/cart_test_no_pmix_multi_ctx.yml"
+  - "scripts/cart_test_no_pmix_launcher.yml"

--- a/utils/run_test.sh
+++ b/utils/run_test.sh
@@ -58,14 +58,15 @@ JENKINS_TEST_LIST=(scripts/cart_echo_test.yml                   \
                    scripts/cart_test_corpc_version_non_sep.yml  \
                    scripts/cart_test_cart_ctl.yml               \
                    scripts/cart_test_cart_ctl_non_sep.yml       \
-                   scripts/cart_test_ep_credits.yml		\
+                   scripts/cart_test_ep_credits.yml             \
                    scripts/cart_test_iv.yml                     \
                    scripts/cart_test_iv_non_sep.yml             \
                    scripts/cart_test_proto.yml                  \
                    scripts/cart_test_proto_non_sep.yml          \
                    scripts/cart_test_no_timeout.yml             \
-                   scripts/cart_test_no_pmix.yml		\
-                   scripts/cart_test_no_pmix_multi_ctx.yml	\
+                   scripts/cart_test_no_pmix.yml                \
+                   scripts/cart_test_no_pmix_multi_ctx.yml      \
+                   scripts/cart_test_no_pmix_launcher.yml       \
                    scripts/cart_test_no_timeout_non_sep.yml)
 
 # Check for symbol names in the library.


### PR DESCRIPTION
- crt_launch utility added to generate environment for running during
NO_PMIX mode of operation. Launcher generates group configuration
file and executes passed application.

Launcher will specify CRT_L_RANK for self-rank for servers to use
and CRT_L_GRP_CFG for path to group configuration file.

- New no_pmix_launcher test added consisting of client and multiple
servers utilizing new crt_launch utility.

- New APIs added:
    crt_group_view_create()
    crt_group_view_destroy()
    crt_group_psr_set()

These APIs are used by clients during NO_PMIX mode of operation to
create group. Once created server nodes can be added dynamically
to that group using existing crt_group_node_add() API.

The behavior of these APIs is similar to crt_group_attach(), except
groups can be populated dynamically without requiring configuration
file.

- tests_common.h added to contain common routines shared among test

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>