### PR TITLE
DAOS-2444 hlc: add crt_hlc2sec

### DIFF
--- a/src/cart/crt_hlc.c
+++ b/src/cart/crt_hlc.c
@@ -96,3 +96,8 @@ uint64_t crt_hlc_get_msg(uint64_t msg)
 
 	return ret;
 }
+
+uint64_t crt_hlc2sec(uint64_t hlc)
+{
+	return (hlc & ~CRT_HLC_MASK) / NSEC_PER_SEC;
+}

--- a/src/include/cart/api.h
+++ b/src/include/cart/api.h
@@ -424,6 +424,16 @@ uint64_t
 crt_hlc_get(void);
 
 /**
+ * Return the second timestamp of hlc.
+ *
+ * \param[in] hlc              HLC timestamp
+ *
+ * \return                     The timestamp in second
+ */
+uint64_t
+crt_hlc2sec(uint64_t hlc);
+
+/**
  * Abort an RPC request.
  *
  * \param[in] req              pointer to RPC request


### PR DESCRIPTION
To allow user can retrieve second timestamp of hlc.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>