### PR TITLE
client side sep

### DIFF
--- a/src/crt_launch/SConscript
+++ b/src/crt_launch/SConscript
@@ -50,7 +50,7 @@ def scons():
 
     tenv.AppendUnique(CPPPATH=['#/src/cart'])
     tenv.AppendUnique(LIBS=['cart', 'gurt', 'pthread', 'm', 'mpi'])
-    prereqs.require(tenv, 'mercury')
+    prereqs.require(tenv, 'mercury', 'ompi')
     tenv.AppendUnique(LIBPATH=['#/src/cart'])
     tenv.AppendUnique(RPATH="$PREFIX/lib")
     tenv.AppendUnique(FLAGS='-pthread')


### PR DESCRIPTION
mercury disables SEP when max_contexts < 2 even when share_addr is true,
see:

https://github.com/mercury-hpc/mercury/blob/cc0807e8377e129945834d292be21a6667a8cbb3/src/na/na_ofi.c#L2010

Signed-off-by: Yulu Jia <yulu.jia@intel.com>