### PR TITLE
DAOS-2240: build: cart-devel should R libyaml-devel

### DIFF
--- a/cart.spec
+++ b/cart.spec
@@ -2,7 +2,7 @@
 
 Name:          cart
 Version:       0.0.1
-Release:       4%{?dist}
+Release:       5%{?dist}
 Summary:       CaRT
 
 License:       Apache
@@ -57,6 +57,7 @@ Summary: CaRT devel
 Requires: %{name} = %{version}-%{release}
 
 Requires: libuuid-devel
+Requires: libyaml-devel
 Requires: boost-devel
 
 %description devel
@@ -121,6 +122,9 @@ ln %{?buildroot}%{carthome}/{TESTING/.build_vars,.build_vars-Linux}.sh
 %{carthome}/.build_vars-Linux.sh
 
 %changelog
+* Fri Jun 21 2019 Brian J. Murrell <brian.murrell@intel.com>
+- add Requires: libyaml-devel to the -devel package
+
 * Wed Jun 12 2019 Vikram Chhabra  <vikram.chhabra@intel.com>
 - added versioning for libcart and libgurt
 

--- a/utils/docker/Dockerfile-mockbuild.centos.7
+++ b/utils/docker/Dockerfile-mockbuild.centos.7
@@ -15,9 +15,8 @@ ARG UID=1000
 #Nothing to do for CentOS
 
 # Install basic tools
-RUN yum install -y epel-release
-RUN yum install -y mock make rpm-build curl createrepo rpmlint redhat-lsb-core \
-                   git
+RUN yum -y install epel-release
+RUN yum -y install mock make rpm-build curl createrepo rpmlint git
 
 # Add build user (to keep rpmbuild happy)
 ENV USER build
@@ -28,20 +27,18 @@ RUN echo "$USER:$PASSWD" | chpasswd
 RUN usermod -a -G mock $USER
 
 # mock in Docker needs to use the old-chroot option
-RUN grep use_nspawn || \
-    echo "config_opts['use_nspawn'] = False" >> /etc/mock/site-defaults.cfg
+RUN echo "config_opts['use_nspawn'] = False" >> /etc/mock/site-defaults.cfg
 
 ARG JENKINS_URL=""
 
 RUN echo -e "config_opts['yum.conf'] += \"\"\"\n" >> /etc/mock/default.cfg;  \
     for repo in openpa libfabric pmix ompi mercury; do                       \
-        if [[ $repo = *:* ]]; then                                           \
-            branch="${repo#*:}";                                             \
-            repo="${repo%:*}";                                               \
+        if [[ $repo = *@* ]]; then                                           \
+            branch="${repo#*@}";                                             \
+            repo="${repo%@*}";                                               \
         else                                                                 \
             branch="master";                                                 \
         fi;                                                                  \
-        JENKINS_URL=$JENKINS_URL;                                            \
         echo -e "[$repo:$branch:lastSuccessful]\n\
 name=$repo:$branch:lastSuccessful\n\
 baseurl=${JENKINS_URL}job/daos-stack/job/$repo/job/$branch/lastSuccessfulBuild/artifact/artifacts/centos7/\n\
@@ -49,3 +46,5 @@ enabled=1\n\
 gpgcheck = False\n" >> /etc/mock/default.cfg;                           \
     done;                                                               \
     echo "\"\"\"" >> /etc/mock/default.cfg
+
+RUN yum -y install redhat-lsb-core


### PR DESCRIPTION
Because include/gurt/fault_inject.h includes yaml.h.