### PR TITLE
CART-701 Remove test_runner from CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -939,6 +939,7 @@ pipeline {
                                 unstableThresholdInvalidReadWrite: '',
                                 unstableThresholdTotal: ''
                                 )
+                            junit env.STAGE_NAME + '/*/results.xml'
                             archiveArtifacts artifacts: env.STAGE_NAME + '/**'
                         }
                         /* temporarily moved into runTest->stepResult due to JENKINS-39203

--- a/SConstruct
+++ b/SConstruct
@@ -124,7 +124,6 @@ def scons():
     VariantDir(arch_dir, '.', duplicate=0)
     SConscript('%s/src/SConscript' % arch_dir)
     SConscript('%s/test/SConscript' % arch_dir)
-    SConscript('%s/scons_local/test_runner/SConscript' % arch_dir)
 
     env.Install('$PREFIX/etc', ['utils/memcheck-cart.supp',
                                 'utils/fault-inject-cart.yaml'])

--- a/multi-node-test.sh
+++ b/multi-node-test.sh
@@ -192,9 +192,6 @@ sed -i.dist -e \"s/- boro-A/- ${nodes[0]}/g\" \
 rm -rf \"$TESTDIR/avocado\" \"./*_results.xml\"
 mkdir -p \"$LOGDIR\"
 
-# remove test_runner dir until scons_local is updated
-rm -rf \"$TESTDIR/test_runner\"
-
 # shellcheck disable=SC2154
 trap 'set +e restore_dist_files \"\${yaml_files[@]}\"' EXIT
 

--- a/test/launch.py
+++ b/test/launch.py
@@ -106,10 +106,6 @@ if __name__ == "__main__":
     else:
         printhelp()
 
-    # remove test_runner in install dir
-    # need patch in scons_local to exclude test_runner install
-    os.system("rm -rf test_runner")
-
     # make it easy to specify a directory as a parameter later
     test_directory = os.getcwd()
 


### PR DESCRIPTION
CaRT tests are migrated to run with Avocado.
Removing test_runner from CI.