### PR TITLE
CART-702 test: fix format overflow warning

### DIFF
--- a/src/test/tests_common.h
+++ b/src/test/tests_common.h
@@ -50,7 +50,7 @@ tc_load_group_from_file(const char *grp_cfg_file, crt_group_t *grp,
 	int		parsed_rank;
 	char		parsed_addr[255];
 	int		parsed_port;
-	char		full_uri[255];
+	char		full_uri[511];
 	crt_node_info_t node_info;
 	int		i;
 	int		rc = 0;


### PR DESCRIPTION
Provide ample buffer space so that *printf() functions don't cause errors like
this on newer GCC:

= = = =
error: '%d' directive writing between 1 and 11 bytes into a region of
size between 0 and 254 [-Werror=format-overflow=]
= = = =

Signed-off-by: Yulu Jia <yulu.jia@intel.com>