### PR TITLE
CART-705 Enable runtime logging of server/client commands

### DIFF
--- a/test/barrier/cart_barrier_five_node.py
+++ b/test/barrier/cart_barrier_five_node.py
@@ -58,7 +58,7 @@ class CartBarrierFiveNodeTest(Test):
 
         cmd = self.utils.build_cmd(self, self.env, "srv")
 
-        print("\nTest cmd : %s\n" % cmd)
+        self.utils.print_cmd("\nTest cmd : %s\n" % cmd)
 
         self.utils.launch_test(self, cmd)
 

--- a/test/barrier/cart_barrier_five_node.py
+++ b/test/barrier/cart_barrier_five_node.py
@@ -58,8 +58,6 @@ class CartBarrierFiveNodeTest(Test):
 
         cmd = self.utils.build_cmd(self, self.env, "srv")
 
-        self.utils.print_cmd("\nTest cmd : %s\n" % cmd)
-
         self.utils.launch_test(self, cmd)
 
 if __name__ == "__main__":

--- a/test/barrier/cart_barrier_one_node.py
+++ b/test/barrier/cart_barrier_one_node.py
@@ -58,7 +58,7 @@ class CartBarrierOneNodeTest(Test):
 
         cmd = self.utils.build_cmd(self, self.env, "srv")
 
-        print("\nTest cmd : %s\n" % cmd)
+        self.utils.print_cmd("\nTest cmd : %s\n" % cmd)
 
         self.utils.launch_test(self, cmd)
 

--- a/test/barrier/cart_barrier_one_node.py
+++ b/test/barrier/cart_barrier_one_node.py
@@ -58,8 +58,6 @@ class CartBarrierOneNodeTest(Test):
 
         cmd = self.utils.build_cmd(self, self.env, "srv")
 
-        self.utils.print_cmd("\nTest cmd : %s\n" % cmd)
-
         self.utils.launch_test(self, cmd)
 
 if __name__ == "__main__":

--- a/test/barrier/cart_barrier_two_node.py
+++ b/test/barrier/cart_barrier_two_node.py
@@ -58,8 +58,6 @@ class CartBarrierTwoNodeTest(Test):
 
         cmd = self.utils.build_cmd(self, self.env, "srv")
 
-        self.utils.print_cmd("\nTest cmd : %s\n" % cmd)
-
         self.utils.launch_test(self, cmd)
 
 if __name__ == "__main__":

--- a/test/barrier/cart_barrier_two_node.py
+++ b/test/barrier/cart_barrier_two_node.py
@@ -58,7 +58,7 @@ class CartBarrierTwoNodeTest(Test):
 
         cmd = self.utils.build_cmd(self, self.env, "srv")
 
-        print("\nTest cmd : %s\n" % cmd)
+        self.utils.print_cmd("\nTest cmd : %s\n" % cmd)
 
         self.utils.launch_test(self, cmd)
 

--- a/test/corpc/cart_corpc_five_node.py
+++ b/test/corpc/cart_corpc_five_node.py
@@ -58,8 +58,6 @@ class CartCoRpcFiveNodeTest(Test):
 
         cmd = self.utils.build_cmd(self, self.env, "srv")
 
-        self.utils.print_cmd("\nTest cmd : %s\n" % cmd)
-
         self.utils.launch_test(self, cmd)
 
 if __name__ == "__main__":

--- a/test/corpc/cart_corpc_five_node.py
+++ b/test/corpc/cart_corpc_five_node.py
@@ -58,7 +58,7 @@ class CartCoRpcFiveNodeTest(Test):
 
         cmd = self.utils.build_cmd(self, self.env, "srv")
 
-        print("\nTest cmd : %s\n" % cmd)
+        self.utils.print_cmd("\nTest cmd : %s\n" % cmd)
 
         self.utils.launch_test(self, cmd)
 

--- a/test/corpc/cart_corpc_one_node.py
+++ b/test/corpc/cart_corpc_one_node.py
@@ -58,8 +58,6 @@ class CartCoRpcOneNodeTest(Test):
 
         cmd = self.utils.build_cmd(self, self.env, "srv")
 
-        self.utils.print_cmd("\nTest cmd : %s\n" % cmd)
-
         self.utils.launch_test(self, cmd)
 
 if __name__ == "__main__":

--- a/test/corpc/cart_corpc_one_node.py
+++ b/test/corpc/cart_corpc_one_node.py
@@ -58,7 +58,7 @@ class CartCoRpcOneNodeTest(Test):
 
         cmd = self.utils.build_cmd(self, self.env, "srv")
 
-        print("\nTest cmd : %s\n" % cmd)
+        self.utils.print_cmd("\nTest cmd : %s\n" % cmd)
 
         self.utils.launch_test(self, cmd)
 

--- a/test/corpc/cart_corpc_two_node.py
+++ b/test/corpc/cart_corpc_two_node.py
@@ -58,7 +58,7 @@ class CartCoRpcTwoNodeTest(Test):
 
         cmd = self.utils.build_cmd(self, self.env, "srv")
 
-        print("\nTest cmd : %s\n" % cmd)
+        self.utils.print_cmd("\nTest cmd : %s\n" % cmd)
 
         self.utils.launch_test(self, cmd)
 

--- a/test/corpc/cart_corpc_two_node.py
+++ b/test/corpc/cart_corpc_two_node.py
@@ -58,8 +58,6 @@ class CartCoRpcTwoNodeTest(Test):
 
         cmd = self.utils.build_cmd(self, self.env, "srv")
 
-        self.utils.print_cmd("\nTest cmd : %s\n" % cmd)
-
         self.utils.launch_test(self, cmd)
 
 if __name__ == "__main__":

--- a/test/ctl/cart_ctl_five_node.py
+++ b/test/ctl/cart_ctl_five_node.py
@@ -64,7 +64,7 @@ class CartCtlFiveNodeTest(Test):
         try:
             srv_rtn = self.utils.launch_cmd_bg(self, srvcmd)
         except Exception as e:
-            self.utils.print_cmd("Exception in launching server : {}".format(e))
+            self.utils.print("Exception in launching server : {}".format(e))
             self.fail("Test failed.\n")
 
         # Verify the server is still running.

--- a/test/ctl/cart_ctl_five_node.py
+++ b/test/ctl/cart_ctl_five_node.py
@@ -61,12 +61,12 @@ class CartCtlFiveNodeTest(Test):
 
         srvcmd = self.utils.build_cmd(self, self.env, "srv", True, urifile)
 
-        print("\nServer cmd : %s\n" % srvcmd)
+        self.utils.print_cmd("\nServer cmd : %s\n" % srvcmd)
 
         try:
             srv_rtn = self.utils.launch_cmd_bg(self, srvcmd)
         except Exception as e:
-            print("Exception in launching server : {}".format(e))
+            self.utils.print_cmd("Exception in launching server : {}".format(e))
             self.fail("Test failed.\n")
 
         # Verify the server is still running.
@@ -78,10 +78,10 @@ class CartCtlFiveNodeTest(Test):
         time.sleep(5)
 
         clicmd = self.utils.build_cmd(self, self.env, "cli1", False, urifile)
-        print("\nClient cmd : %s\n" % clicmd)
+        self.utils.print_cmd("\nClient cmd : %s\n" % clicmd)
         self.utils.launch_test(self, clicmd, srv_rtn)
         clicmd = self.utils.build_cmd(self, self.env, "cli2", False, urifile)
-        print("\nClient cmd : %s\n" % clicmd)
+        self.utils.print_cmd("\nClient cmd : %s\n" % clicmd)
         self.utils.launch_test(self, clicmd, srv_rtn)
 
         self.utils.stop_process(srv_rtn)

--- a/test/ctl/cart_ctl_five_node.py
+++ b/test/ctl/cart_ctl_five_node.py
@@ -61,8 +61,6 @@ class CartCtlFiveNodeTest(Test):
 
         srvcmd = self.utils.build_cmd(self, self.env, "srv", True, urifile)
 
-        self.utils.print_cmd("\nServer cmd : %s\n" % srvcmd)
-
         try:
             srv_rtn = self.utils.launch_cmd_bg(self, srvcmd)
         except Exception as e:
@@ -78,10 +76,8 @@ class CartCtlFiveNodeTest(Test):
         time.sleep(5)
 
         clicmd = self.utils.build_cmd(self, self.env, "cli1", False, urifile)
-        self.utils.print_cmd("\nClient cmd : %s\n" % clicmd)
         self.utils.launch_test(self, clicmd, srv_rtn)
         clicmd = self.utils.build_cmd(self, self.env, "cli2", False, urifile)
-        self.utils.print_cmd("\nClient cmd : %s\n" % clicmd)
         self.utils.launch_test(self, clicmd, srv_rtn)
 
         self.utils.stop_process(srv_rtn)

--- a/test/ctl/cart_ctl_one_node.py
+++ b/test/ctl/cart_ctl_one_node.py
@@ -60,8 +60,6 @@ class CartCtlOneNodeTest(Test):
 
         srvcmd = self.utils.build_cmd(self, self.env, "srv", True, urifile)
 
-        self.utils.print_cmd("\nServer cmd : %s\n" % srvcmd)
-
         try:
             srv_rtn = self.utils.launch_cmd_bg(self, srvcmd)
         except Exception as e:
@@ -75,22 +73,16 @@ class CartCtlOneNodeTest(Test):
                        % procrtn)
 
         clicmd = self.utils.build_cmd(self, self.env, "cli1", False, urifile)
-        self.utils.print_cmd("\nClient cmd : %s\n" % clicmd)
         self.utils.launch_test(self, clicmd, srv_rtn)
         clicmd = self.utils.build_cmd(self, self.env, "cli2", False, urifile)
-        self.utils.print_cmd("\nClient cmd : %s\n" % clicmd)
         self.utils.launch_test(self, clicmd, srv_rtn)
         clicmd = self.utils.build_cmd(self, self.env, "cli3", False, urifile)
-        self.utils.print_cmd("\nClient cmd : %s\n" % clicmd)
         self.utils.launch_test(self, clicmd, srv_rtn)
         clicmd = self.utils.build_cmd(self, self.env, "cli4", False, urifile)
-        self.utils.print_cmd("\nClient cmd : %s\n" % clicmd)
         self.utils.launch_test(self, clicmd, srv_rtn)
         clicmd = self.utils.build_cmd(self, self.env, "cli5", False, urifile)
-        self.utils.print_cmd("\nClient cmd : %s\n" % clicmd)
         self.utils.launch_test(self, clicmd, srv_rtn)
         clicmd = self.utils.build_cmd(self, self.env, "cli6", False, urifile)
-        self.utils.print_cmd("\nClient cmd : %s\n" % clicmd)
         self.utils.launch_test(self, clicmd, srv_rtn)
 
 if __name__ == "__main__":

--- a/test/ctl/cart_ctl_one_node.py
+++ b/test/ctl/cart_ctl_one_node.py
@@ -63,7 +63,7 @@ class CartCtlOneNodeTest(Test):
         try:
             srv_rtn = self.utils.launch_cmd_bg(self, srvcmd)
         except Exception as e:
-            self.utils.print_cmd("Exception in launching server : {}".format(e))
+            self.utils.print("Exception in launching server : {}".format(e))
             self.fail("Test failed.\n")
 
         # Verify the server is still running.

--- a/test/ctl/cart_ctl_one_node.py
+++ b/test/ctl/cart_ctl_one_node.py
@@ -60,12 +60,12 @@ class CartCtlOneNodeTest(Test):
 
         srvcmd = self.utils.build_cmd(self, self.env, "srv", True, urifile)
 
-        print("\nServer cmd : %s\n" % srvcmd)
+        self.utils.print_cmd("\nServer cmd : %s\n" % srvcmd)
 
         try:
             srv_rtn = self.utils.launch_cmd_bg(self, srvcmd)
         except Exception as e:
-            print("Exception in launching server : {}".format(e))
+            self.utils.print_cmd("Exception in launching server : {}".format(e))
             self.fail("Test failed.\n")
 
         # Verify the server is still running.
@@ -75,22 +75,22 @@ class CartCtlOneNodeTest(Test):
                        % procrtn)
 
         clicmd = self.utils.build_cmd(self, self.env, "cli1", False, urifile)
-        print("\nClient cmd : %s\n" % clicmd)
+        self.utils.print_cmd("\nClient cmd : %s\n" % clicmd)
         self.utils.launch_test(self, clicmd, srv_rtn)
         clicmd = self.utils.build_cmd(self, self.env, "cli2", False, urifile)
-        print("\nClient cmd : %s\n" % clicmd)
+        self.utils.print_cmd("\nClient cmd : %s\n" % clicmd)
         self.utils.launch_test(self, clicmd, srv_rtn)
         clicmd = self.utils.build_cmd(self, self.env, "cli3", False, urifile)
-        print("\nClient cmd : %s\n" % clicmd)
+        self.utils.print_cmd("\nClient cmd : %s\n" % clicmd)
         self.utils.launch_test(self, clicmd, srv_rtn)
         clicmd = self.utils.build_cmd(self, self.env, "cli4", False, urifile)
-        print("\nClient cmd : %s\n" % clicmd)
+        self.utils.print_cmd("\nClient cmd : %s\n" % clicmd)
         self.utils.launch_test(self, clicmd, srv_rtn)
         clicmd = self.utils.build_cmd(self, self.env, "cli5", False, urifile)
-        print("\nClient cmd : %s\n" % clicmd)
+        self.utils.print_cmd("\nClient cmd : %s\n" % clicmd)
         self.utils.launch_test(self, clicmd, srv_rtn)
         clicmd = self.utils.build_cmd(self, self.env, "cli6", False, urifile)
-        print("\nClient cmd : %s\n" % clicmd)
+        self.utils.print_cmd("\nClient cmd : %s\n" % clicmd)
         self.utils.launch_test(self, clicmd, srv_rtn)
 
 if __name__ == "__main__":

--- a/test/group_tiers/cart_group_tiers_three_node.py
+++ b/test/group_tiers/cart_group_tiers_three_node.py
@@ -67,8 +67,6 @@ class CartGroupTiersThreeNodeTest(Test):
 
         srv2cmd = self.utils.build_cmd(self, self.env, "srv2", True, urifile2)
 
-        self.utils.print_cmd("\nServer 1 cmd : %s\n" % srv2cmd)
-
         try:
             srv2_rtn = self.utils.launch_cmd_bg(self, srv2cmd)
         except Exception as e:
@@ -76,8 +74,6 @@ class CartGroupTiersThreeNodeTest(Test):
             self.fail("Test failed.\n")
 
         time.sleep(8)
-
-        self.utils.print_cmd("\nServer 2 cmd : %s\n" % srvcmd)
 
         try:
             srv_rtn = self.utils.launch_cmd_bg(self, srvcmd)
@@ -89,13 +85,9 @@ class CartGroupTiersThreeNodeTest(Test):
 
         clicmd = self.utils.build_cmd(self, self.env, "cli1", False, urifile2)
 
-        self.utils.print_cmd("\nClient 1 cmd : %s\n" % clicmd)
-
         self.utils.launch_test(self, clicmd, srv_rtn, srv2_rtn)
 
         clicmd = self.utils.build_cmd(self, self.env, "cli2", False, urifile1)
-
-        self.utils.print_cmd("\nClient 2 cmd : %s\n" % clicmd)
 
         self.utils.launch_test(self, clicmd, srv_rtn, srv2_rtn)
 

--- a/test/group_tiers/cart_group_tiers_three_node.py
+++ b/test/group_tiers/cart_group_tiers_three_node.py
@@ -67,43 +67,43 @@ class CartGroupTiersThreeNodeTest(Test):
 
         srv2cmd = self.utils.build_cmd(self, self.env, "srv2", True, urifile2)
 
-        print("\nServer 1 cmd : %s\n" % srv2cmd)
+        self.utils.print_cmd("\nServer 1 cmd : %s\n" % srv2cmd)
 
         try:
             srv2_rtn = self.utils.launch_cmd_bg(self, srv2cmd)
         except Exception as e:
-            print("Exception in launching server : {}".format(e))
+            self.utils.print_cmd("Exception in launching server : {}".format(e))
             self.fail("Test failed.\n")
 
         time.sleep(8)
 
-        print("\nServer 2 cmd : %s\n" % srvcmd)
+        self.utils.print_cmd("\nServer 2 cmd : %s\n" % srvcmd)
 
         try:
             srv_rtn = self.utils.launch_cmd_bg(self, srvcmd)
         except Exception as e:
-            print("Exception in launching server : {}".format(e))
+            self.utils.print_cmd("Exception in launching server : {}".format(e))
             self.fail("Test failed.\n")
 
         time.sleep(4)
 
         clicmd = self.utils.build_cmd(self, self.env, "cli1", False, urifile2)
 
-        print("\nClient 1 cmd : %s\n" % clicmd)
+        self.utils.print_cmd("\nClient 1 cmd : %s\n" % clicmd)
 
         self.utils.launch_test(self, clicmd, srv_rtn, srv2_rtn)
 
         clicmd = self.utils.build_cmd(self, self.env, "cli2", False, urifile1)
 
-        print("\nClient 2 cmd : %s\n" % clicmd)
+        self.utils.print_cmd("\nClient 2 cmd : %s\n" % clicmd)
 
         self.utils.launch_test(self, clicmd, srv_rtn, srv2_rtn)
 
         # Stop the server
-        print("Stopping server process 2 {}".format(srv2_rtn))
+        self.utils.print_cmd("Stopping server process 2 {}".format(srv2_rtn))
         procrtn2 = self.utils.stop_process(srv2_rtn)
 
-        print("Stopping server process 1 {}".format(srv_rtn))
+        self.utils.print_cmd("Stopping server process 1 {}".format(srv_rtn))
         procrtn1 = self.utils.stop_process(srv_rtn)
 
         if procrtn2 or procrtn1:

--- a/test/group_tiers/cart_group_tiers_three_node.py
+++ b/test/group_tiers/cart_group_tiers_three_node.py
@@ -70,7 +70,7 @@ class CartGroupTiersThreeNodeTest(Test):
         try:
             srv2_rtn = self.utils.launch_cmd_bg(self, srv2cmd)
         except Exception as e:
-            self.utils.print_cmd("Exception in launching server : {}".format(e))
+            self.utils.print("Exception in launching server : {}".format(e))
             self.fail("Test failed.\n")
 
         time.sleep(8)
@@ -78,7 +78,7 @@ class CartGroupTiersThreeNodeTest(Test):
         try:
             srv_rtn = self.utils.launch_cmd_bg(self, srvcmd)
         except Exception as e:
-            self.utils.print_cmd("Exception in launching server : {}".format(e))
+            self.utils.print("Exception in launching server : {}".format(e))
             self.fail("Test failed.\n")
 
         time.sleep(4)
@@ -92,10 +92,10 @@ class CartGroupTiersThreeNodeTest(Test):
         self.utils.launch_test(self, clicmd, srv_rtn, srv2_rtn)
 
         # Stop the server
-        self.utils.print_cmd("Stopping server process 2 {}".format(srv2_rtn))
+        self.utils.print("Stopping server process 2 {}".format(srv2_rtn))
         procrtn2 = self.utils.stop_process(srv2_rtn)
 
-        self.utils.print_cmd("Stopping server process 1 {}".format(srv_rtn))
+        self.utils.print("Stopping server process 1 {}".format(srv_rtn))
         procrtn1 = self.utils.stop_process(srv_rtn)
 
         if procrtn2 or procrtn1:

--- a/test/iv/cart_iv_one_node.py
+++ b/test/iv/cart_iv_one_node.py
@@ -110,19 +110,19 @@ class CartIvOneNodeTest(Test):
         if (('operation' not in action) or
                 ('rank' not in action) or
                 ('key' not in action)):
-            self.utils.print_cmd("Error happened during action check")
+            self.utils.print("Error happened during action check")
             raise ValueError("Each action must contain an operation," \
                              " rank, and key")
 
         if len(action['key']) != 2:
-            self.utils.print_cmd("Error key should be tuple of (rank, idx)")
+            self.utils.print("Error key should be tuple of (rank, idx)")
             raise ValueError("key should be a tuple of (rank, idx)")
 
     def _verify_fetch_operation(self, action):
         """verify fetch operation"""
         if (('return_code' not in action) or
                 ('expected_value' not in action)):
-            self.utils.print_cmd("Error: fetch operation was malformed")
+            self.utils.print("Error: fetch operation was malformed")
             raise ValueError("Fetch operation malformed")
 
     def _iv_test_actions(self, cmd, actions):
@@ -151,7 +151,7 @@ class CartIvOneNodeTest(Test):
                             log_path)
                 clicmd += command
 
-                self.utils.print_cmd("\nClient cmd : %s\n" % clicmd)
+                self.utils.print("\nClient cmd : %s\n" % clicmd)
                 cli_rtn = subprocess.call(shlex.split(clicmd))
 
                 if cli_rtn != 0:
@@ -194,7 +194,7 @@ class CartIvOneNodeTest(Test):
                                 action['value'])
                 clicmd += command
 
-                self.utils.print_cmd("\nClient cmd : %s\n" % clicmd)
+                self.utils.print("\nClient cmd : %s\n" % clicmd)
                 cli_rtn = subprocess.call(shlex.split(clicmd))
 
                 if cli_rtn != 0:
@@ -206,7 +206,7 @@ class CartIvOneNodeTest(Test):
                     command, operation, rank, key_rank, key_idx)
                 clicmd += command
 
-                self.utils.print_cmd("\nClient cmd : %s\n" % clicmd)
+                self.utils.print("\nClient cmd : %s\n" % clicmd)
                 cli_rtn = subprocess.call(shlex.split(clicmd))
 
                 if cli_rtn != 0:
@@ -225,7 +225,7 @@ class CartIvOneNodeTest(Test):
         try:
             srv_rtn = self.utils.launch_cmd_bg(self, srvcmd)
         except Exception as e:
-            self.utils.print_cmd("Exception in launching server : {}".format(e))
+            self.utils.print("Exception in launching server : {}".format(e))
             self.fail("Test failed.\n")
 
         # Verify the server is still running.
@@ -262,7 +262,7 @@ class CartIvOneNodeTest(Test):
             self._iv_test_actions(clicmd, actions)
         except ValueError as exception:
             failed = True
-            self.utils.print_cmd("TEST FAILED: %s", str(exception))
+            self.utils.print("TEST FAILED: %s", str(exception))
 
         ########## Shutdown Servers ##########
 
@@ -274,23 +274,23 @@ class CartIvOneNodeTest(Test):
         # Request each server shut down gracefully
         for rank in reversed(range(1, int(srv_ppn) * num_servers)):
             clicmd += " -o shutdown -r " + str(rank)
-            self.utils.print_cmd("\nClient cmd : %s\n" % clicmd)
+            self.utils.print("\nClient cmd : %s\n" % clicmd)
             try:
                 subprocess.call(shlex.split(clicmd))
             except Exception as e:
                 failed = True
-                self.utils.print_cmd("Exception in launching client : {}".format(e))
+                self.utils.print("Exception in launching client : {}".format(e))
 
         time.sleep(1)
 
         # Shutdown rank 0 separately
         clicmd += " -o shutdown -r 0"
-        self.utils.print_cmd("\nClient cmd : %s\n" % clicmd)
+        self.utils.print("\nClient cmd : %s\n" % clicmd)
         try:
             subprocess.call(shlex.split(clicmd))
         except Exception as e:
             failed = True
-            self.utils.print_cmd("Exception in launching client : {}".format(e))
+            self.utils.print("Exception in launching client : {}".format(e))
 
         time.sleep(2)
 

--- a/test/iv/cart_iv_one_node.py
+++ b/test/iv/cart_iv_one_node.py
@@ -110,19 +110,19 @@ class CartIvOneNodeTest(Test):
         if (('operation' not in action) or
                 ('rank' not in action) or
                 ('key' not in action)):
-            print("Error happened during action check")
+            self.utils.print_cmd("Error happened during action check")
             raise ValueError("Each action must contain an operation," \
                              " rank, and key")
 
         if len(action['key']) != 2:
-            print("Error key should be tuple of (rank, idx)")
+            self.utils.print_cmd("Error key should be tuple of (rank, idx)")
             raise ValueError("key should be a tuple of (rank, idx)")
 
     def _verify_fetch_operation(self, action):
         """verify fetch operation"""
         if (('return_code' not in action) or
                 ('expected_value' not in action)):
-            print("Error: fetch operation was malformed")
+            self.utils.print_cmd("Error: fetch operation was malformed")
             raise ValueError("Fetch operation malformed")
 
     def _iv_test_actions(self, cmd, actions):
@@ -151,7 +151,7 @@ class CartIvOneNodeTest(Test):
                             log_path)
                 clicmd += command
 
-                print("\nClient cmd : %s\n" % clicmd)
+                self.utils.print_cmd("\nClient cmd : %s\n" % clicmd)
                 cli_rtn = subprocess.call(shlex.split(clicmd))
 
                 if cli_rtn != 0:
@@ -194,7 +194,7 @@ class CartIvOneNodeTest(Test):
                                 action['value'])
                 clicmd += command
 
-                print("\nClient cmd : %s\n" % clicmd)
+                self.utils.print_cmd("\nClient cmd : %s\n" % clicmd)
                 cli_rtn = subprocess.call(shlex.split(clicmd))
 
                 if cli_rtn != 0:
@@ -206,7 +206,7 @@ class CartIvOneNodeTest(Test):
                     command, operation, rank, key_rank, key_idx)
                 clicmd += command
 
-                print("\nClient cmd : %s\n" % clicmd)
+                self.utils.print_cmd("\nClient cmd : %s\n" % clicmd)
                 cli_rtn = subprocess.call(shlex.split(clicmd))
 
                 if cli_rtn != 0:
@@ -222,12 +222,12 @@ class CartIvOneNodeTest(Test):
 
         srvcmd = self.utils.build_cmd(self, self.env, "srv")
 
-        print("\nServer cmd : %s\n" % srvcmd)
+        self.utils.print_cmd("\nServer cmd : %s\n" % srvcmd)
 
         try:
             srv_rtn = self.utils.launch_cmd_bg(self, srvcmd)
         except Exception as e:
-            print("Exception in launching server : {}".format(e))
+            self.utils.print_cmd("Exception in launching server : {}".format(e))
             self.fail("Test failed.\n")
 
         # Verify the server is still running.
@@ -264,7 +264,7 @@ class CartIvOneNodeTest(Test):
             self._iv_test_actions(clicmd, actions)
         except ValueError as exception:
             failed = True
-            print("TEST FAILED: %s", str(exception))
+            self.utils.print_cmd("TEST FAILED: %s", str(exception))
 
         ########## Shutdown Servers ##########
 
@@ -276,23 +276,23 @@ class CartIvOneNodeTest(Test):
         # Request each server shut down gracefully
         for rank in reversed(range(1, int(srv_ppn) * num_servers)):
             clicmd += " -o shutdown -r " + str(rank)
-            print("\nClient cmd : %s\n" % clicmd)
+            self.utils.print_cmd("\nClient cmd : %s\n" % clicmd)
             try:
                 subprocess.call(shlex.split(clicmd))
             except Exception as e:
                 failed = True
-                print("Exception in launching client : {}".format(e))
+                self.utils.print_cmd("Exception in launching client : {}".format(e))
 
         time.sleep(1)
 
         # Shutdown rank 0 separately
         clicmd += " -o shutdown -r 0"
-        print("\nClient cmd : %s\n" % clicmd)
+        self.utils.print_cmd("\nClient cmd : %s\n" % clicmd)
         try:
             subprocess.call(shlex.split(clicmd))
         except Exception as e:
             failed = True
-            print("Exception in launching client : {}".format(e))
+            self.utils.print_cmd("Exception in launching client : {}".format(e))
 
         time.sleep(2)
 

--- a/test/iv/cart_iv_one_node.py
+++ b/test/iv/cart_iv_one_node.py
@@ -222,8 +222,6 @@ class CartIvOneNodeTest(Test):
 
         srvcmd = self.utils.build_cmd(self, self.env, "srv")
 
-        self.utils.print_cmd("\nServer cmd : %s\n" % srvcmd)
-
         try:
             srv_rtn = self.utils.launch_cmd_bg(self, srvcmd)
         except Exception as e:

--- a/test/iv/cart_iv_two_node.py
+++ b/test/iv/cart_iv_two_node.py
@@ -110,19 +110,19 @@ class CartIvTwoNodeTest(Test):
         if (('operation' not in action) or
                 ('rank' not in action) or
                 ('key' not in action)):
-            self.utils.print_cmd("Error happened during action check")
+            self.utils.print("Error happened during action check")
             raise ValueError("Each action must contain an operation," \
                              " rank, and key")
 
         if len(action['key']) != 2:
-            self.utils.print_cmd("Error key should be tuple of (rank, idx)")
+            self.utils.print("Error key should be tuple of (rank, idx)")
             raise ValueError("key should be a tuple of (rank, idx)")
 
     def _verify_fetch_operation(self, action):
         """verify fetch operation"""
         if (('return_code' not in action) or
                 ('expected_value' not in action)):
-            self.utils.print_cmd("Error: fetch operation was malformed")
+            self.utils.print("Error: fetch operation was malformed")
             raise ValueError("Fetch operation malformed")
 
     def _iv_test_actions(self, cmd, actions):
@@ -151,7 +151,7 @@ class CartIvTwoNodeTest(Test):
                             log_path)
                 clicmd += command
 
-                self.utils.print_cmd("\nClient cmd : %s\n" % clicmd)
+                self.utils.print("\nClient cmd : %s\n" % clicmd)
                 cli_rtn = subprocess.call(shlex.split(clicmd))
 
                 if cli_rtn != 0:
@@ -194,7 +194,7 @@ class CartIvTwoNodeTest(Test):
                                 action['value'])
                 clicmd += command
 
-                self.utils.print_cmd("\nClient cmd : %s\n" % clicmd)
+                self.utils.print("\nClient cmd : %s\n" % clicmd)
                 cli_rtn = subprocess.call(shlex.split(clicmd))
 
                 if cli_rtn != 0:
@@ -206,7 +206,7 @@ class CartIvTwoNodeTest(Test):
                     command, operation, rank, key_rank, key_idx)
                 clicmd += command
 
-                self.utils.print_cmd("\nClient cmd : %s\n" % clicmd)
+                self.utils.print("\nClient cmd : %s\n" % clicmd)
                 cli_rtn = subprocess.call(shlex.split(clicmd))
 
                 if cli_rtn != 0:
@@ -225,7 +225,7 @@ class CartIvTwoNodeTest(Test):
         try:
             srv_rtn = self.utils.launch_cmd_bg(self, srvcmd)
         except Exception as e:
-            self.utils.print_cmd("Exception in launching server : {}".format(e))
+            self.utils.print("Exception in launching server : {}".format(e))
             self.fail("Test failed.\n")
 
         # Verify the server is still running.
@@ -262,7 +262,7 @@ class CartIvTwoNodeTest(Test):
             self._iv_test_actions(clicmd, actions)
         except ValueError as exception:
             failed = True
-            self.utils.print_cmd("TEST FAILED: %s", str(exception))
+            self.utils.print("TEST FAILED: %s", str(exception))
 
         ########## Shutdown Servers ##########
 
@@ -274,23 +274,23 @@ class CartIvTwoNodeTest(Test):
         # Request each server shut down gracefully
         for rank in reversed(range(1, int(srv_ppn) * num_servers)):
             clicmd += " -o shutdown -r " + str(rank)
-            self.utils.print_cmd("\nClient cmd : %s\n" % clicmd)
+            self.utils.print("\nClient cmd : %s\n" % clicmd)
             try:
                 subprocess.call(shlex.split(clicmd))
             except Exception as e:
                 failed = True
-                self.utils.print_cmd("Exception in launching client : {}".format(e))
+                self.utils.print("Exception in launching client : {}".format(e))
 
         time.sleep(1)
 
         # Shutdown rank 0 separately
         clicmd += " -o shutdown -r 0"
-        self.utils.print_cmd("\nClient cmd : %s\n" % clicmd)
+        self.utils.print("\nClient cmd : %s\n" % clicmd)
         try:
             subprocess.call(shlex.split(clicmd))
         except Exception as e:
             failed = True
-            self.utils.print_cmd("Exception in launching client : {}".format(e))
+            self.utils.print("Exception in launching client : {}".format(e))
 
         time.sleep(2)
 

--- a/test/iv/cart_iv_two_node.py
+++ b/test/iv/cart_iv_two_node.py
@@ -222,8 +222,6 @@ class CartIvTwoNodeTest(Test):
 
         srvcmd = self.utils.build_cmd(self, self.env, "srv")
 
-        self.utils.print_cmd("\nServer cmd : %s\n" % srvcmd)
-
         try:
             srv_rtn = self.utils.launch_cmd_bg(self, srvcmd)
         except Exception as e:

--- a/test/iv/cart_iv_two_node.py
+++ b/test/iv/cart_iv_two_node.py
@@ -110,19 +110,19 @@ class CartIvTwoNodeTest(Test):
         if (('operation' not in action) or
                 ('rank' not in action) or
                 ('key' not in action)):
-            print("Error happened during action check")
+            self.utils.print_cmd("Error happened during action check")
             raise ValueError("Each action must contain an operation," \
                              " rank, and key")
 
         if len(action['key']) != 2:
-            print("Error key should be tuple of (rank, idx)")
+            self.utils.print_cmd("Error key should be tuple of (rank, idx)")
             raise ValueError("key should be a tuple of (rank, idx)")
 
     def _verify_fetch_operation(self, action):
         """verify fetch operation"""
         if (('return_code' not in action) or
                 ('expected_value' not in action)):
-            print("Error: fetch operation was malformed")
+            self.utils.print_cmd("Error: fetch operation was malformed")
             raise ValueError("Fetch operation malformed")
 
     def _iv_test_actions(self, cmd, actions):
@@ -151,7 +151,7 @@ class CartIvTwoNodeTest(Test):
                             log_path)
                 clicmd += command
 
-                print("\nClient cmd : %s\n" % clicmd)
+                self.utils.print_cmd("\nClient cmd : %s\n" % clicmd)
                 cli_rtn = subprocess.call(shlex.split(clicmd))
 
                 if cli_rtn != 0:
@@ -194,7 +194,7 @@ class CartIvTwoNodeTest(Test):
                                 action['value'])
                 clicmd += command
 
-                print("\nClient cmd : %s\n" % clicmd)
+                self.utils.print_cmd("\nClient cmd : %s\n" % clicmd)
                 cli_rtn = subprocess.call(shlex.split(clicmd))
 
                 if cli_rtn != 0:
@@ -206,7 +206,7 @@ class CartIvTwoNodeTest(Test):
                     command, operation, rank, key_rank, key_idx)
                 clicmd += command
 
-                print("\nClient cmd : %s\n" % clicmd)
+                self.utils.print_cmd("\nClient cmd : %s\n" % clicmd)
                 cli_rtn = subprocess.call(shlex.split(clicmd))
 
                 if cli_rtn != 0:
@@ -222,12 +222,12 @@ class CartIvTwoNodeTest(Test):
 
         srvcmd = self.utils.build_cmd(self, self.env, "srv")
 
-        print("\nServer cmd : %s\n" % srvcmd)
+        self.utils.print_cmd("\nServer cmd : %s\n" % srvcmd)
 
         try:
             srv_rtn = self.utils.launch_cmd_bg(self, srvcmd)
         except Exception as e:
-            print("Exception in launching server : {}".format(e))
+            self.utils.print_cmd("Exception in launching server : {}".format(e))
             self.fail("Test failed.\n")
 
         # Verify the server is still running.
@@ -264,7 +264,7 @@ class CartIvTwoNodeTest(Test):
             self._iv_test_actions(clicmd, actions)
         except ValueError as exception:
             failed = True
-            print("TEST FAILED: %s", str(exception))
+            self.utils.print_cmd("TEST FAILED: %s", str(exception))
 
         ########## Shutdown Servers ##########
 
@@ -276,23 +276,23 @@ class CartIvTwoNodeTest(Test):
         # Request each server shut down gracefully
         for rank in reversed(range(1, int(srv_ppn) * num_servers)):
             clicmd += " -o shutdown -r " + str(rank)
-            print("\nClient cmd : %s\n" % clicmd)
+            self.utils.print_cmd("\nClient cmd : %s\n" % clicmd)
             try:
                 subprocess.call(shlex.split(clicmd))
             except Exception as e:
                 failed = True
-                print("Exception in launching client : {}".format(e))
+                self.utils.print_cmd("Exception in launching client : {}".format(e))
 
         time.sleep(1)
 
         # Shutdown rank 0 separately
         clicmd += " -o shutdown -r 0"
-        print("\nClient cmd : %s\n" % clicmd)
+        self.utils.print_cmd("\nClient cmd : %s\n" % clicmd)
         try:
             subprocess.call(shlex.split(clicmd))
         except Exception as e:
             failed = True
-            print("Exception in launching client : {}".format(e))
+            self.utils.print_cmd("Exception in launching client : {}".format(e))
 
         time.sleep(2)
 

--- a/test/launch.py
+++ b/test/launch.py
@@ -124,7 +124,7 @@ if __name__ == "__main__":
     if not test_files:
         printhelp()
 
-    avocado = ' avocado run'
+    avocado = ' avocado --show app,progress run'
     if sparse:
         output_options = ' --html-job-result on'
     else:

--- a/test/no_pmix/cart_nopmix_multictx_one_node.py
+++ b/test/no_pmix/cart_nopmix_multictx_one_node.py
@@ -70,7 +70,7 @@ class CartNoPmixOneNodeTest(Test):
 
         cmd = self.params.get("tst_bin", '/run/tests/*/')
 
-        print("\nTest cmd : %s\n" % cmd)
+        self.utils.print_cmd("\nTest cmd : %s\n" % cmd)
 
         test_env = self.pass_env
         p = subprocess.Popen([cmd], env=test_env, stdout=subprocess.PIPE)
@@ -78,10 +78,10 @@ class CartNoPmixOneNodeTest(Test):
         rc = self.utils.wait_process(p, 10)
 
         if rc != 0:
-            print("Error waiting for process. returning {}".format(rc))
+            self.utils.print_cmd("Error waiting for process. returning {}".format(rc))
             self.fail("Test failed.\n")
 
-        print("Finished waiting for {}".format(p))
+        self.utils.print_cmd("Finished waiting for {}".format(p))
 
 if __name__ == "__main__":
     main()

--- a/test/no_pmix/cart_nopmix_multictx_one_node.py
+++ b/test/no_pmix/cart_nopmix_multictx_one_node.py
@@ -70,7 +70,7 @@ class CartNoPmixOneNodeTest(Test):
 
         cmd = self.params.get("tst_bin", '/run/tests/*/')
 
-        self.utils.print_cmd("\nTest cmd : %s\n" % cmd)
+        self.utils.print("\nTest cmd : %s\n" % cmd)
 
         test_env = self.pass_env
         p = subprocess.Popen([cmd], env=test_env, stdout=subprocess.PIPE)
@@ -78,10 +78,10 @@ class CartNoPmixOneNodeTest(Test):
         rc = self.utils.wait_process(p, 10)
 
         if rc != 0:
-            self.utils.print_cmd("Error waiting for process. returning {}".format(rc))
+            self.utils.print("Error waiting for process. returning {}".format(rc))
             self.fail("Test failed.\n")
 
-        self.utils.print_cmd("Finished waiting for {}".format(p))
+        self.utils.print("Finished waiting for {}".format(p))
 
 if __name__ == "__main__":
     main()

--- a/test/no_pmix/cart_nopmix_one_node.py
+++ b/test/no_pmix/cart_nopmix_one_node.py
@@ -70,7 +70,7 @@ class CartNoPmixOneNodeTest(Test):
 
         test_bin = self.params.get("tst_bin", '/run/tests/*/')
 
-        print("\nTest cmd : %s\n" % test_bin)
+        self.utils.print_cmd("\nTest cmd : %s\n" % test_bin)
 
         ranks = [1, 2, 3, 10, 4]
         master_rank = 10
@@ -101,17 +101,17 @@ class CartNoPmixOneNodeTest(Test):
             rc = self.utils.wait_process(x, 10)
 
             if rc != 0:
-                print("Error waiting for process. returning {}".format(rc))
+                self.utils.print_cmd("Error waiting for process. returning {}".format(rc))
                 return rc
 
-            print("Finished waiting for {}".format(x))
+            self.utils.print_cmd("Finished waiting for {}".format(x))
 
         rc = self.utils.wait_process(p1, 10)
         if rc != 0:
-            print("error waiting for master process {}".format(rc))
+            self.utils.print_cmd("error waiting for master process {}".format(rc))
             return rc
 
-        print("everything finished successfully")
+        self.utils.print_cmd("everything finished successfully")
 
 if __name__ == "__main__":
     main()

--- a/test/no_pmix/cart_nopmix_one_node.py
+++ b/test/no_pmix/cart_nopmix_one_node.py
@@ -70,7 +70,7 @@ class CartNoPmixOneNodeTest(Test):
 
         test_bin = self.params.get("tst_bin", '/run/tests/*/')
 
-        self.utils.print_cmd("\nTest cmd : %s\n" % test_bin)
+        self.utils.print("\nTest cmd : %s\n" % test_bin)
 
         ranks = [1, 2, 3, 10, 4]
         master_rank = 10
@@ -101,17 +101,17 @@ class CartNoPmixOneNodeTest(Test):
             rc = self.utils.wait_process(x, 10)
 
             if rc != 0:
-                self.utils.print_cmd("Error waiting for process. returning {}".format(rc))
+                self.utils.print("Error waiting for process. returning {}".format(rc))
                 return rc
 
-            self.utils.print_cmd("Finished waiting for {}".format(x))
+            self.utils.print("Finished waiting for {}".format(x))
 
         rc = self.utils.wait_process(p1, 10)
         if rc != 0:
-            self.utils.print_cmd("error waiting for master process {}".format(rc))
+            self.utils.print("error waiting for master process {}".format(rc))
             return rc
 
-        self.utils.print_cmd("everything finished successfully")
+        self.utils.print("everything finished successfully")
 
 if __name__ == "__main__":
     main()

--- a/test/nopmix_launcher/cart_nopmix_launcher_one_node.py
+++ b/test/nopmix_launcher/cart_nopmix_launcher_one_node.py
@@ -75,7 +75,6 @@ class CartNoPmixLauncherOneNodeTest(Test):
         cmd += " {}".format(cli_bin)
         cmd += " {}".format(cli_arg)
 
-        self.utils.print_cmd("\nTest cmd : %s\n" % cmd)
         self.utils.launch_test(self, cmd)
 
 if __name__ == "__main__":

--- a/test/nopmix_launcher/cart_nopmix_launcher_one_node.py
+++ b/test/nopmix_launcher/cart_nopmix_launcher_one_node.py
@@ -75,7 +75,7 @@ class CartNoPmixLauncherOneNodeTest(Test):
         cmd += " {}".format(cli_bin)
         cmd += " {}".format(cli_arg)
 
-        print("\nTest cmd : %s\n" % cmd)
+        self.utils.print_cmd("\nTest cmd : %s\n" % cmd)
         self.utils.launch_test(self, cmd)
 
 if __name__ == "__main__":

--- a/test/rpc/cart_rpc_one_node.py
+++ b/test/rpc/cart_rpc_one_node.py
@@ -61,9 +61,6 @@ class CartRpcOneNodeTest(Test):
         srvcmd = self.utils.build_cmd(self, self.env, "srv", True, urifile)
         clicmd = self.utils.build_cmd(self, self.env, "cli", False, urifile)
 
-        self.utils.print_cmd("\nServer cmd : %s\n" % srvcmd)
-        self.utils.print_cmd("\nClient cmd : %s\n" % clicmd)
-
         self.utils.launch_srv_cli_test(self, srvcmd, clicmd)
 
 if __name__ == "__main__":

--- a/test/rpc/cart_rpc_one_node.py
+++ b/test/rpc/cart_rpc_one_node.py
@@ -61,8 +61,8 @@ class CartRpcOneNodeTest(Test):
         srvcmd = self.utils.build_cmd(self, self.env, "srv", True, urifile)
         clicmd = self.utils.build_cmd(self, self.env, "cli", False, urifile)
 
-        print("\nServer cmd : %s\n" % srvcmd)
-        print("\nClient cmd : %s\n" % clicmd)
+        self.utils.print_cmd("\nServer cmd : %s\n" % srvcmd)
+        self.utils.print_cmd("\nClient cmd : %s\n" % clicmd)
 
         self.utils.launch_srv_cli_test(self, srvcmd, clicmd)
 

--- a/test/rpc/cart_rpc_two_node.py
+++ b/test/rpc/cart_rpc_two_node.py
@@ -61,9 +61,6 @@ class CartRpcTwoNodeTest(Test):
         srvcmd = self.utils.build_cmd(self, self.env, "srv", True, urifile)
         clicmd = self.utils.build_cmd(self, self.env, "cli", False, urifile)
 
-        self.utils.print_cmd("\nServer cmd : %s\n" % srvcmd)
-        self.utils.print_cmd("\nClient cmd : %s\n" % clicmd)
-
         self.utils.launch_srv_cli_test(self, srvcmd, clicmd)
 
 if __name__ == "__main__":

--- a/test/rpc/cart_rpc_two_node.py
+++ b/test/rpc/cart_rpc_two_node.py
@@ -61,8 +61,8 @@ class CartRpcTwoNodeTest(Test):
         srvcmd = self.utils.build_cmd(self, self.env, "srv", True, urifile)
         clicmd = self.utils.build_cmd(self, self.env, "cli", False, urifile)
 
-        print("\nServer cmd : %s\n" % srvcmd)
-        print("\nClient cmd : %s\n" % clicmd)
+        self.utils.print_cmd("\nServer cmd : %s\n" % srvcmd)
+        self.utils.print_cmd("\nClient cmd : %s\n" % clicmd)
 
         self.utils.launch_srv_cli_test(self, srvcmd, clicmd)
 

--- a/test/selftest/cart_selftest_two_node.py
+++ b/test/selftest/cart_selftest_two_node.py
@@ -61,8 +61,8 @@ class CartSelfTwoNodeTest(Test):
         srvcmd = self.utils.build_cmd(self, self.env, "srv", True, urifile)
         clicmd = self.utils.build_cmd(self, self.env, "cli", False, urifile)
 
-        print("\nServer cmd : %s\n" % srvcmd)
-        print("\nClient cmd : %s\n" % clicmd)
+        self.utils.print_cmd("\nServer cmd : %s\n" % srvcmd)
+        self.utils.print_cmd("\nClient cmd : %s\n" % clicmd)
 
         srv_rtn = self.utils.launch_cmd_bg(self, srvcmd)
 

--- a/test/selftest/cart_selftest_two_node.py
+++ b/test/selftest/cart_selftest_two_node.py
@@ -61,9 +61,6 @@ class CartSelfTwoNodeTest(Test):
         srvcmd = self.utils.build_cmd(self, self.env, "srv", True, urifile)
         clicmd = self.utils.build_cmd(self, self.env, "cli", False, urifile)
 
-        self.utils.print_cmd("\nServer cmd : %s\n" % srvcmd)
-        self.utils.print_cmd("\nClient cmd : %s\n" % clicmd)
-
         srv_rtn = self.utils.launch_cmd_bg(self, srvcmd)
 
         # Verify the server is still running.

--- a/test/singleton/cart_singleton_one_node.py
+++ b/test/singleton/cart_singleton_one_node.py
@@ -66,12 +66,12 @@ class CartSingletonOneNodeTest(Test):
 
         srvcmd += " -p {} -s".format(self.tempdir)
 
-        print("\nServer cmd : %s\n" % srvcmd)
+        self.utils.print_cmd("\nServer cmd : %s\n" % srvcmd)
 
         try:
             srv_rtn = self.utils.launch_cmd_bg(self, srvcmd)
         except Exception as e:
-            print("Exception in launching server : {}".format(e))
+            self.utils.print_cmd("Exception in launching server : {}".format(e))
             self.fail("Test failed.\n")
 
         time.sleep(5)
@@ -95,12 +95,12 @@ class CartSingletonOneNodeTest(Test):
 
         clicmd += " -p {} -s".format(self.tempdir)
 
-        print("\nClient cmd : %s\n" % clicmd)
+        self.utils.print_cmd("\nClient cmd : %s\n" % clicmd)
 
         self.utils.launch_test(self, clicmd, srv_rtn)
 
         # Stop the server
-        print("Stopping server process {}".format(srv_rtn))
+        self.utils.print_cmd("Stopping server process {}".format(srv_rtn))
         procrtn = self.utils.stop_process(srv_rtn)
 
         if procrtn:

--- a/test/singleton/cart_singleton_one_node.py
+++ b/test/singleton/cart_singleton_one_node.py
@@ -66,8 +66,6 @@ class CartSingletonOneNodeTest(Test):
 
         srvcmd += " -p {} -s".format(self.tempdir)
 
-        self.utils.print_cmd("\nServer cmd : %s\n" % srvcmd)
-
         try:
             srv_rtn = self.utils.launch_cmd_bg(self, srvcmd)
         except Exception as e:
@@ -94,8 +92,6 @@ class CartSingletonOneNodeTest(Test):
         clicmd = self.params.get("cli_bin", '/run/tests/*/')
 
         clicmd += " -p {} -s".format(self.tempdir)
-
-        self.utils.print_cmd("\nClient cmd : %s\n" % clicmd)
 
         self.utils.launch_test(self, clicmd, srv_rtn)
 

--- a/test/singleton/cart_singleton_one_node.py
+++ b/test/singleton/cart_singleton_one_node.py
@@ -69,7 +69,7 @@ class CartSingletonOneNodeTest(Test):
         try:
             srv_rtn = self.utils.launch_cmd_bg(self, srvcmd)
         except Exception as e:
-            self.utils.print_cmd("Exception in launching server : {}".format(e))
+            self.utils.print("Exception in launching server : {}".format(e))
             self.fail("Test failed.\n")
 
         time.sleep(5)
@@ -96,7 +96,7 @@ class CartSingletonOneNodeTest(Test):
         self.utils.launch_test(self, clicmd, srv_rtn)
 
         # Stop the server
-        self.utils.print_cmd("Stopping server process {}".format(srv_rtn))
+        self.utils.print("Stopping server process {}".format(srv_rtn))
         procrtn = self.utils.stop_process(srv_rtn)
 
         if procrtn:

--- a/test/singleton/cart_singleton_two_node.py
+++ b/test/singleton/cart_singleton_two_node.py
@@ -78,7 +78,7 @@ class CartSingletonTwoNodeTest(Test):
         try:
             srv_rtn = self.utils.launch_cmd_bg(self, srvcmd)
         except Exception as e:
-            self.utils.print_cmd("Exception in launching server : {}".format(e))
+            self.utils.print("Exception in launching server : {}".format(e))
             self.fail("Test failed.\n")
 
         time.sleep(5)
@@ -96,7 +96,7 @@ class CartSingletonTwoNodeTest(Test):
         self.utils.launch_test(self, clicmd, srv_rtn)
 
         # Stop the server
-        self.utils.print_cmd("Stopping server process {}".format(srv_rtn))
+        self.utils.print("Stopping server process {}".format(srv_rtn))
         procrtn = self.utils.stop_process(srv_rtn)
 
         if procrtn:
@@ -128,7 +128,7 @@ class CartSingletonTwoNodeTest(Test):
         try:
             srv_rtn = self.utils.launch_cmd_bg(self, srvcmd)
         except Exception as e:
-            self.utils.print_cmd("Exception in launching server : {}".format(e))
+            self.utils.print("Exception in launching server : {}".format(e))
             self.fail("Test failed.\n")
 
         time.sleep(10)
@@ -146,7 +146,7 @@ class CartSingletonTwoNodeTest(Test):
         self.utils.launch_test(self, clicmd, srv_rtn)
 
         # Stop the server
-        self.utils.print_cmd("Stopping server process {}".format(srv_rtn))
+        self.utils.print("Stopping server process {}".format(srv_rtn))
         procrtn = self.utils.stop_process(srv_rtn)
 
         if procrtn:
@@ -169,7 +169,7 @@ class CartSingletonTwoNodeTest(Test):
         try:
             srv_rtn = self.utils.launch_cmd_bg(self, srvcmd)
         except Exception as e:
-            self.utils.print_cmd("Exception in launching server : {}".format(e))
+            self.utils.print("Exception in launching server : {}".format(e))
             self.fail("Test failed.\n")
 
         time.sleep(10)
@@ -177,7 +177,7 @@ class CartSingletonTwoNodeTest(Test):
         try:
             srv2_rtn = self.utils.launch_cmd_bg(self, srv2cmd)
         except Exception as e:
-            self.utils.print_cmd("Exception in launching server : {}".format(e))
+            self.utils.print("Exception in launching server : {}".format(e))
             self.fail("Test failed.\n")
 
         # Verify the server is still running.
@@ -193,10 +193,10 @@ class CartSingletonTwoNodeTest(Test):
         self.utils.launch_test(self, clicmd, srv_rtn, srv2_rtn)
 
         # Stop the server
-        self.utils.print_cmd("Stopping server process {}".format(srv_rtn))
+        self.utils.print("Stopping server process {}".format(srv_rtn))
         procrtn1 = self.utils.stop_process(srv_rtn)
 
-        self.utils.print_cmd("Stopping server process {}".format(srv2_rtn))
+        self.utils.print("Stopping server process {}".format(srv2_rtn))
         procrtn2 = self.utils.stop_process(srv2_rtn)
 
         if procrtn1 or procrtn2:

--- a/test/singleton/cart_singleton_two_node.py
+++ b/test/singleton/cart_singleton_two_node.py
@@ -75,12 +75,12 @@ class CartSingletonTwoNodeTest(Test):
 
         srvcmd += " -p {} -s".format(self.tempdir)
 
-        print("\nServer cmd : %s\n" % srvcmd)
+        self.utils.print_cmd("\nServer cmd : %s\n" % srvcmd)
 
         try:
             srv_rtn = self.utils.launch_cmd_bg(self, srvcmd)
         except Exception as e:
-            print("Exception in launching server : {}".format(e))
+            self.utils.print_cmd("Exception in launching server : {}".format(e))
             self.fail("Test failed.\n")
 
         time.sleep(5)
@@ -95,12 +95,12 @@ class CartSingletonTwoNodeTest(Test):
 
         clicmd += " -p {} -s".format(self.tempdir)
 
-        print("\nClient cmd : %s\n" % clicmd)
+        self.utils.print_cmd("\nClient cmd : %s\n" % clicmd)
 
         self.utils.launch_test(self, clicmd, srv_rtn)
 
         # Stop the server
-        print("Stopping server process {}".format(srv_rtn))
+        self.utils.print_cmd("Stopping server process {}".format(srv_rtn))
         procrtn = self.utils.stop_process(srv_rtn)
 
         if procrtn:
@@ -129,12 +129,12 @@ class CartSingletonTwoNodeTest(Test):
         srvcmd += " : {} -x CRT_CTX_NUM={} -N {} --hostfile {} {}".format(self.env,
                                       srv2_ctx, srv2_ppn, hostfile, srv2_bin)
 
-        print("\nServer cmd : %s\n" % srvcmd)
+        self.utils.print_cmd("\nServer cmd : %s\n" % srvcmd)
 
         try:
             srv_rtn = self.utils.launch_cmd_bg(self, srvcmd)
         except Exception as e:
-            print("Exception in launching server : {}".format(e))
+            self.utils.print_cmd("Exception in launching server : {}".format(e))
             self.fail("Test failed.\n")
 
         time.sleep(10)
@@ -149,12 +149,12 @@ class CartSingletonTwoNodeTest(Test):
 
         clicmd += " -p {} -s -m".format(self.tempdir)
 
-        print("\nClient cmd : %s\n" % clicmd)
+        self.utils.print_cmd("\nClient cmd : %s\n" % clicmd)
 
         self.utils.launch_test(self, clicmd, srv_rtn)
 
         # Stop the server
-        print("Stopping server process {}".format(srv_rtn))
+        self.utils.print_cmd("Stopping server process {}".format(srv_rtn))
         procrtn = self.utils.stop_process(srv_rtn)
 
         if procrtn:
@@ -175,22 +175,22 @@ class CartSingletonTwoNodeTest(Test):
         srv2cmd = self.utils.build_cmd(self, self.env, "srv2", False, urifile)
 
 
-        print("\nServer cmd : %s\n" % srvcmd)
+        self.utils.print_cmd("\nServer cmd : %s\n" % srvcmd)
 
         try:
             srv_rtn = self.utils.launch_cmd_bg(self, srvcmd)
         except Exception as e:
-            print("Exception in launching server : {}".format(e))
+            self.utils.print_cmd("Exception in launching server : {}".format(e))
             self.fail("Test failed.\n")
 
         time.sleep(10)
 
-        print("\nServer cmd : %s\n" % srv2cmd)
+        self.utils.print_cmd("\nServer cmd : %s\n" % srv2cmd)
 
         try:
             srv2_rtn = self.utils.launch_cmd_bg(self, srv2cmd)
         except Exception as e:
-            print("Exception in launching server : {}".format(e))
+            self.utils.print_cmd("Exception in launching server : {}".format(e))
             self.fail("Test failed.\n")
 
         # Verify the server is still running.
@@ -203,15 +203,15 @@ class CartSingletonTwoNodeTest(Test):
 
         clicmd += " -m"
 
-        print("\nClient cmd : %s\n" % clicmd)
+        self.utils.print_cmd("\nClient cmd : %s\n" % clicmd)
 
         self.utils.launch_test(self, clicmd, srv_rtn, srv2_rtn)
 
         # Stop the server
-        print("Stopping server process {}".format(srv_rtn))
+        self.utils.print_cmd("Stopping server process {}".format(srv_rtn))
         procrtn1 = self.utils.stop_process(srv_rtn)
 
-        print("Stopping server process {}".format(srv2_rtn))
+        self.utils.print_cmd("Stopping server process {}".format(srv2_rtn))
         procrtn2 = self.utils.stop_process(srv2_rtn)
 
         if procrtn1 or procrtn2:

--- a/test/singleton/cart_singleton_two_node.py
+++ b/test/singleton/cart_singleton_two_node.py
@@ -75,8 +75,6 @@ class CartSingletonTwoNodeTest(Test):
 
         srvcmd += " -p {} -s".format(self.tempdir)
 
-        self.utils.print_cmd("\nServer cmd : %s\n" % srvcmd)
-
         try:
             srv_rtn = self.utils.launch_cmd_bg(self, srvcmd)
         except Exception as e:
@@ -94,8 +92,6 @@ class CartSingletonTwoNodeTest(Test):
         clicmd = self.params.get("cli_bin", '/run/tests/*/')
 
         clicmd += " -p {} -s".format(self.tempdir)
-
-        self.utils.print_cmd("\nClient cmd : %s\n" % clicmd)
 
         self.utils.launch_test(self, clicmd, srv_rtn)
 
@@ -129,8 +125,6 @@ class CartSingletonTwoNodeTest(Test):
         srvcmd += " : {} -x CRT_CTX_NUM={} -N {} --hostfile {} {}".format(self.env,
                                       srv2_ctx, srv2_ppn, hostfile, srv2_bin)
 
-        self.utils.print_cmd("\nServer cmd : %s\n" % srvcmd)
-
         try:
             srv_rtn = self.utils.launch_cmd_bg(self, srvcmd)
         except Exception as e:
@@ -148,8 +142,6 @@ class CartSingletonTwoNodeTest(Test):
         clicmd = self.params.get("cli_bin", '/run/tests/*/')
 
         clicmd += " -p {} -s -m".format(self.tempdir)
-
-        self.utils.print_cmd("\nClient cmd : %s\n" % clicmd)
 
         self.utils.launch_test(self, clicmd, srv_rtn)
 
@@ -174,9 +166,6 @@ class CartSingletonTwoNodeTest(Test):
 
         srv2cmd = self.utils.build_cmd(self, self.env, "srv2", False, urifile)
 
-
-        self.utils.print_cmd("\nServer cmd : %s\n" % srvcmd)
-
         try:
             srv_rtn = self.utils.launch_cmd_bg(self, srvcmd)
         except Exception as e:
@@ -184,8 +173,6 @@ class CartSingletonTwoNodeTest(Test):
             self.fail("Test failed.\n")
 
         time.sleep(10)
-
-        self.utils.print_cmd("\nServer cmd : %s\n" % srv2cmd)
 
         try:
             srv2_rtn = self.utils.launch_cmd_bg(self, srv2cmd)
@@ -202,8 +189,6 @@ class CartSingletonTwoNodeTest(Test):
         clicmd = self.utils.build_cmd(self, self.env, "cli", False, urifile)
 
         clicmd += " -m"
-
-        self.utils.print_cmd("\nClient cmd : %s\n" % clicmd)
 
         self.utils.launch_test(self, clicmd, srv_rtn, srv2_rtn)
 

--- a/test/util/cart_utils.py
+++ b/test/util/cart_utils.py
@@ -262,6 +262,8 @@ class CartUtils():
     def launch_test(self, cartobj, cmd, srv1=None, srv2=None):
         """ launches test """
 
+        self.print_cmd("\nCMD : %s\n" % cmd)
+
         cmd = shlex.split(cmd)
         rtn = subprocess.call(cmd)
 
@@ -278,6 +280,8 @@ class CartUtils():
 
     def launch_cmd_bg(self, cartobj, cmd):
         """ launches the given cmd in background """
+
+        self.print_cmd("\nCMD : %s\n" % cmd)
 
         cmd = shlex.split(cmd)
         rtn = subprocess.Popen(cmd)

--- a/test/util/cart_utils.py
+++ b/test/util/cart_utils.py
@@ -118,6 +118,9 @@ class CartUtils():
 
     def get_env(self, cartobj):
         """ return basic env setting in yaml """
+        self.stdout = logging.getLogger('avocado.test.stdout')
+        self.progress_log = logging.getLogger("progress")
+
         env_CCSA = cartobj.params.get("env", "/run/env_CRT_CTX_SHARE_ADDR/*/")
         test_name = cartobj.params.get("name", "/run/tests/*/")
         host_cfg = cartobj.params.get("config", "/run/hosts/*/")
@@ -262,7 +265,7 @@ class CartUtils():
     def launch_test(self, cartobj, cmd, srv1=None, srv2=None):
         """ launches test """
 
-        self.print_cmd("\nCMD : %s\n" % cmd)
+        self.print("\nCMD : %s\n" % cmd)
 
         cmd = shlex.split(cmd)
         rtn = subprocess.call(cmd)
@@ -281,7 +284,7 @@ class CartUtils():
     def launch_cmd_bg(self, cartobj, cmd):
         """ launches the given cmd in background """
 
-        self.print_cmd("\nCMD : %s\n" % cmd)
+        self.print("\nCMD : %s\n" % cmd)
 
         cmd = shlex.split(cmd)
         rtn = subprocess.Popen(cmd)
@@ -291,8 +294,8 @@ class CartUtils():
 
         return rtn
 
-    def print_cmd(self, cmd):
-        stdout = logging.getLogger('avocado.test.stdout')
-        stdout.info(cmd)
-        progress_log = logging.getLogger("progress")
-        progress_log.info(cmd)
+    def print(self, cmd):
+        """ prints the given cmd at runtime and stdout """
+
+        self.stdout.info(cmd)
+        self.progress_log.info(cmd)

--- a/test/util/cart_utils.py
+++ b/test/util/cart_utils.py
@@ -29,6 +29,7 @@ import random
 import json
 import shlex
 import subprocess
+import logging
 
 class CartUtils():
     """CartUtils Class"""
@@ -285,3 +286,9 @@ class CartUtils():
             return -1
 
         return rtn
+
+    def print_cmd(self, cmd):
+        stdout = logging.getLogger('avocado.test.stdout')
+        stdout.info(cmd)
+        progress_log = logging.getLogger("progress")
+        progress_log.info(cmd)

--- a/test/util/cart_utils.py
+++ b/test/util/cart_utils.py
@@ -34,6 +34,11 @@ import logging
 class CartUtils():
     """CartUtils Class"""
 
+    def __init__(self):
+        """ CartUtils init """
+        self.stdout = logging.getLogger('avocado.test.stdout')
+        self.progress_log = logging.getLogger("progress")
+
     def write_host_file(self, hostlist, slots=1):
         """ write out a hostfile suitable for orterun """
 
@@ -118,9 +123,6 @@ class CartUtils():
 
     def get_env(self, cartobj):
         """ return basic env setting in yaml """
-        self.stdout = logging.getLogger('avocado.test.stdout')
-        self.progress_log = logging.getLogger("progress")
-
         env_CCSA = cartobj.params.get("env", "/run/env_CRT_CTX_SHARE_ADDR/*/")
         test_name = cartobj.params.get("name", "/run/tests/*/")
         host_cfg = cartobj.params.get("config", "/run/hosts/*/")


### PR DESCRIPTION
When avocado runs, the server/client cmd prints are directed
to stdout, which is logged in avocado's path.
This patch enables avocado progress logging.
This will make reproducing tests easier by using the underlying
orterun cmd without searching the avocado logs.