### PR TITLE
CART-89 launcher: fix argv in execve

### DIFF
--- a/src/crt_launch/crt_launch.c
+++ b/src/crt_launch/crt_launch.c
@@ -133,7 +133,7 @@ parse_args(int argc, char **argv)
 			break;
 		case 'e':
 			g_opt.app_to_exec = optarg;
-			g_opt.app_args_indx = optind;
+			g_opt.app_args_indx = optind - 1;
 			break;
 		default:
 			g_opt.show_help = true;


### PR DESCRIPTION
argv in execve() should contain the executable name as the first
string. By default getopt and getopt_long starts parsing at the
second string.