### PR TITLE
CART-89 cart: add check in crt_rank_uri_get()

### DIFF
--- a/src/cart/crt_group.c
+++ b/src/cart/crt_group.c
@@ -3805,7 +3805,7 @@ crt_rank_uri_get(crt_group_t *group, d_rank_t rank, int tag, char **uri_str)
 		D_GOTO(out, rc = -DER_INVAL);
 	}
 
-	if (rank == grp_priv->gp_self)
+	if (grp_priv->gp_local && rank == grp_priv->gp_self)
 		return crt_self_uri_get(tag, uri_str);
 
 	rc = crt_grp_lc_lookup(grp_priv, 0, rank, tag, &uri, &hg_addr);


### PR DESCRIPTION
crt_rank_uri_get() should return self uri only if called on a local
group.