### PR TITLE
CART-706 test: Convert IV tests to no-pmix mode

### DIFF
--- a/src/cart/crt_group.c
+++ b/src/cart/crt_group.c
@@ -3152,8 +3152,8 @@ crt_grp_config_psr_load(struct crt_grp_priv *grp_priv, d_rank_t psr_rank)
 
 		if (CRT_PMIX_ENABLED()) {
 			if (!forall || rank == psr_rank) {
-				D_DEBUG(DB_TRACE, "grp %s selected psr_rank %d, "
-					"uri %s.\n", grpid, rank, addr_str);
+				D_DEBUG(DB_TRACE, "grp %s selected psr_rank %d"
+					", uri %s.\n", grpid, rank, addr_str);
 				crt_grp_psr_set(grp_priv, rank, addr_str);
 				rc = 0;
 
@@ -3163,12 +3163,15 @@ crt_grp_config_psr_load(struct crt_grp_priv *grp_priv, d_rank_t psr_rank)
 
 		if (!CRT_PMIX_ENABLED()) {
 			crt_node_info_t	node_info;
+
 			node_info.uri = addr_str;
 
 			rc = crt_group_node_add_internal(grp_priv, rank, 0,
 					node_info);
 			if (rc != 0) {
-				D_ERROR("crt_group_node_add_internal() failed; rc=%d\n", rc);
+				D_ERROR("crt_group_node_add_internal() failed;"
+					" rank=%d uri='%s' rc=%d\n",
+					rank, addr_str, rc);
 				break;
 			}
 

--- a/src/cart/crt_group.c
+++ b/src/cart/crt_group.c
@@ -43,6 +43,10 @@
 #include "crt_internal.h"
 #include <sys/stat.h>
 
+static int crt_group_node_add_internal(struct crt_grp_priv *grp_priv,
+					d_rank_t rank, int tag,
+					crt_node_info_t info);
+
 /* global CRT group list */
 D_LIST_HEAD(crt_grp_list);
 /* protect global group list */
@@ -2337,6 +2341,26 @@ crt_group_attach(crt_group_id_t srv_grpid, crt_group_t **attached_grp)
 		D_ERROR("crt group not initialized.\n");
 		D_GOTO(out, rc = -DER_UNINIT);
 	}
+
+	/* For non-PMIX case attach is a group view creation + cfg load */
+	if (!CRT_PMIX_ENABLED()) {
+		rc = crt_group_view_create(srv_grpid, attached_grp);
+		if (rc != 0) {
+			D_ERROR("crt_group_view_create() failed; rc=%d\n", rc);
+			D_GOTO(out, rc);
+		}
+
+		grp_priv = container_of(*attached_grp,
+				struct crt_grp_priv, gp_pub);
+		rc = crt_grp_config_load(grp_priv);
+		if (rc != 0) {
+			D_ERROR("crt_grp_config_load() failed; rc=%d\n", rc);
+			crt_group_view_destroy(*attached_grp);
+		}
+
+		D_GOTO(out, rc);
+	}
+
 	grp_gdata = crt_gdata.cg_grp;
 	D_ASSERT(grp_gdata != NULL);
 
@@ -2458,6 +2482,11 @@ crt_grp_attach(crt_group_id_t srv_grpid, crt_group_t **attached_grp)
 
 	D_ASSERT(srv_grpid != NULL);
 	D_ASSERT(attached_grp != NULL);
+
+	if (!CRT_PMIX_ENABLED()) {
+		D_ERROR("Should never be called for non-pmix mode\n");
+		D_ASSERT(0);
+	}
 
 	rc = crt_grp_priv_create(&grp_priv, srv_grpid, true /* primary group */,
 				 NULL /* member_ranks */,
@@ -2916,15 +2945,31 @@ crt_group_config_save(crt_group_t *grp, bool forall)
 		char *uri;
 
 		uri = NULL;
-		rc = crt_pmix_uri_lookup(grpid, rank, &uri);
-		if (rc != 0) {
-			D_ERROR("crt_pmix_uri_lookup(grp %s, rank %d), failed "
-				"rc: %d.\n", grpid, rank, rc);
-			D_GOTO(out, rc);
+
+		if (CRT_PMIX_ENABLED()) {
+			rc = crt_pmix_uri_lookup(grpid, rank, &uri);
+			if (rc != 0) {
+				D_ERROR("crt_pmix_uri_lookup(grp %s, rank %d) "
+					"failed rc: %d.\n", grpid, rank, rc);
+				D_GOTO(out, rc);
+			}
+		} else {
+			rc = crt_rank_uri_get(grp, rank, 0, &uri);
+			if (rc != 0) {
+				D_ERROR("crt_rank_uri_get(%s, %d) failed "
+					"rc: %d.\n", grpid, rank, rc);
+				D_GOTO(out, rc);
+			}
 		}
+
 		D_ASSERT(uri != NULL);
 		rc = fprintf(fp, "%d %s\n", rank, uri);
-		free(uri);
+
+		if (CRT_PMIX_ENABLED())
+			free(uri);
+		else
+			D_FREE(uri);
+
 		if (rc < 0) {
 			D_ERROR("write to file %s failed (%s).\n",
 				tmp_name, strerror(errno));
@@ -3012,8 +3057,9 @@ crt_grp_config_psr_load(struct crt_grp_priv *grp_priv, d_rank_t psr_rank)
 	char		all_or_self[8] = {'\0'};
 	char		fmt[64] = {'\0'};
 	crt_phy_addr_t	addr_str = NULL;
-	d_rank_t	rank, idx;
+	d_rank_t	rank;
 	bool		forall;
+	int		grp_size;
 	int		rc = 0;
 
 	D_ASSERT(crt_initialized());
@@ -3047,12 +3093,18 @@ crt_grp_config_psr_load(struct crt_grp_priv *grp_priv, d_rank_t psr_rank)
 		D_GOTO(out, rc = -DER_INVAL);
 	}
 
-	rc = fscanf(fp, "%*s%d", &grp_priv->gp_size);
+	grp_size = 0;
+
+	rc = fscanf(fp, "%*s%d", &grp_size);
 	if (rc == EOF) {
 		D_ERROR("read from file %s failed (%s).\n",
 			filename, strerror(errno));
 		D_GOTO(out, rc = d_errno2der(errno));
 	}
+
+	/* Non pmix case will populate group size later on */
+	if (CRT_PMIX_ENABLED())
+		grp_priv->gp_size = grp_size;
 
 	rc = fscanf(fp, "%4s", all_or_self);
 	if (rc == EOF) {
@@ -3074,33 +3126,63 @@ crt_grp_config_psr_load(struct crt_grp_priv *grp_priv, d_rank_t psr_rank)
 	if (addr_str == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
-	if (psr_rank == -1) {
-		crt_group_rank(NULL, &rank);
-		psr_rank = rank % grp_priv->gp_size;
-	} else {
-		if (psr_rank >= grp_priv->gp_size) {
-			D_ERROR("invalid parameter (psr %d, gp_size %d).\n",
-				psr_rank, grp_priv->gp_size);
-			D_GOTO(out, rc = -DER_INVAL);
+	if (CRT_PMIX_ENABLED()) {
+		if (psr_rank == -1) {
+			crt_group_rank(NULL, &rank);
+			psr_rank = rank % grp_priv->gp_size;
+		} else {
+			if (psr_rank >= grp_priv->gp_size) {
+				D_ERROR("invalid param (psr %d, gp_size %d)\n",
+					psr_rank, grp_priv->gp_size);
+				D_GOTO(out, rc = -DER_INVAL);
+			}
 		}
 	}
 
 	memset(fmt, 0, 64);
 	snprintf(fmt, 64, "%%d %%%ds", CRT_ADDR_STR_MAX_LEN);
 	rc = -DER_INVAL;
-	for (idx = 0; idx < grp_priv->gp_size; idx++) {
+
+	while (1) {
 		rc = fscanf(fp, fmt, &rank, (char *)addr_str);
 		if (rc == EOF) {
-			D_ERROR("read from file %s failed (%s).\n",
-				filename, strerror(errno));
-			D_GOTO(out, rc = d_errno2der(errno));
-		}
-		if (!forall || rank == psr_rank) {
-			D_DEBUG(DB_TRACE, "grp %s selected psr_rank %d, "
-				"uri %s.\n", grpid, rank, addr_str);
-			crt_grp_psr_set(grp_priv, rank, addr_str);
 			rc = 0;
 			break;
+		}
+
+		if (CRT_PMIX_ENABLED()) {
+			if (!forall || rank == psr_rank) {
+				D_DEBUG(DB_TRACE, "grp %s selected psr_rank %d, "
+					"uri %s.\n", grpid, rank, addr_str);
+				crt_grp_psr_set(grp_priv, rank, addr_str);
+				rc = 0;
+
+				break;
+			}
+		}
+
+		if (!CRT_PMIX_ENABLED()) {
+			crt_node_info_t	node_info;
+			node_info.uri = addr_str;
+
+			rc = crt_group_node_add_internal(grp_priv, rank, 0,
+					node_info);
+			if (rc != 0) {
+				D_ERROR("crt_group_node_add_internal() failed; rc=%d\n", rc);
+				break;
+			}
+
+			if (rank == psr_rank) {
+				crt_grp_psr_set(grp_priv, rank, addr_str);
+			}
+		}
+	}
+
+	/* If PSR was not specified, pick for now last added node as PSR */
+	if (!CRT_PMIX_ENABLED()) {
+		/* TODO: PSR selection logic to be changed with CART-688 */
+		if (psr_rank != -1) {
+			crt_grp_psr_set(grp_priv, rank, addr_str);
 		}
 	}
 
@@ -3675,6 +3757,38 @@ out:
 }
 
 
+static int crt_group_node_add_internal(struct crt_grp_priv *grp_priv,
+					d_rank_t rank, int tag,
+					crt_node_info_t info)
+{
+	int i;
+	int rc;
+
+	if (!grp_priv->gp_primary) {
+		D_ERROR("Only available for primary groups\n");
+		D_GOTO(out, rc = -DER_INVAL);
+	}
+
+	for (i = 0; i < CRT_SRV_CONTEXT_NUM; i++) {
+		rc = crt_grp_lc_uri_insert(grp_priv, i, rank, tag, info.uri);
+		if (rc != 0) {
+			D_ERROR("crt_grp_lc_uri_insert() failed; rc=%d\n", rc);
+			D_GOTO(out, rc);
+		}
+	}
+
+	/* Only add node to membership list once, for tag 0 */
+	/* TODO: This logic needs to be refactored as part of CART-517 */
+	if (tag == 0) {
+		D_RWLOCK_WRLOCK(&grp_priv->gp_rwlock);
+		rc = grp_add_to_membs_list(grp_priv, rank);
+		D_RWLOCK_UNLOCK(&grp_priv->gp_rwlock);
+	}
+
+out:
+	return rc;
+}
+
 int
 crt_group_node_add(crt_group_t *group, d_rank_t rank, int tag,
 		crt_node_info_t info)
@@ -3694,25 +3808,7 @@ crt_group_node_add(crt_group_t *group, d_rank_t rank, int tag,
 
 	grp_priv = crt_grp_pub2priv(group);
 
-	if (!grp_priv->gp_primary) {
-		D_ERROR("Only available for primary groups\n");
-		D_GOTO(out, rc = -DER_INVAL);
-	}
-
-	rc = crt_grp_lc_uri_insert_all(group, rank, tag, info.uri);
-	if (rc != 0) {
-		D_ERROR("crt_grp_lc_uri_insert_all() failed; rc=%d\n", rc);
-		D_GOTO(out, rc);
-	}
-
-	/* Only add node to membership list once, for tag 0 */
-	/* TODO: This logic needs to be refactored as part of CART-517 */
-	if (tag == 0) {
-		D_RWLOCK_WRLOCK(&grp_priv->gp_rwlock);
-		rc = grp_add_to_membs_list(grp_priv, rank);
-		D_RWLOCK_UNLOCK(&grp_priv->gp_rwlock);
-	}
-
+	rc = crt_group_node_add_internal(grp_priv, rank, tag, info);
 out:
 	return rc;
 }

--- a/src/cart/crt_group.c
+++ b/src/cart/crt_group.c
@@ -1117,7 +1117,7 @@ crt_grp_priv_destroy(struct crt_grp_priv *grp_priv)
 	grp_priv_fini_membs(grp_priv);
 
 	if (grp_priv->gp_psr_phy_addr != NULL)
-		free(grp_priv->gp_psr_phy_addr);
+		D_FREE(grp_priv->gp_psr_phy_addr);
 	D_RWLOCK_DESTROY(&grp_priv->gp_rwlock);
 	D_FREE(grp_priv->gp_pub.cg_grpid);
 
@@ -3195,11 +3195,12 @@ out:
 	if (filename != NULL)
 		free(filename);
 	D_FREE(grpname);
-	if (rc != 0) {
-		D_FREE(addr_str);
+	D_FREE(addr_str);
+
+	if (rc != 0)
 		D_ERROR("crt_grp_config_psr_load (grpid %s) failed, rc: %d.\n",
 			grpid, rc);
-	}
+
 	return rc;
 }
 
@@ -3549,7 +3550,7 @@ int
 crt_grp_psr_reload(struct crt_grp_priv *grp_priv)
 {
 	d_rank_t	psr_rank;
-	crt_phy_addr_t	uri = NULL, psr_phy_addr = NULL;
+	crt_phy_addr_t	uri = NULL;
 	int		rc = 0;
 
 	psr_rank = grp_priv->gp_psr_rank;
@@ -3565,10 +3566,7 @@ crt_grp_psr_reload(struct crt_grp_priv *grp_priv)
 			if (uri == NULL)
 				break;
 
-			D_STRNDUP(psr_phy_addr, uri, CRT_ADDR_STR_MAX_LEN);
-			if (psr_phy_addr == NULL)
-				D_GOTO(out, rc = -DER_NOMEM);
-			crt_grp_psr_set(grp_priv, psr_rank, psr_phy_addr);
+			crt_grp_psr_set(grp_priv, psr_rank, uri);
 			D_GOTO(out, rc = 0);
 		} else if (rc != -DER_EVICTED) {
 			/*
@@ -4316,6 +4314,7 @@ int crt_group_psr_set(crt_group_t *grp, d_rank_t rank)
 	}
 
 	crt_grp_psr_set(grp_priv, rank, uri);
+	D_FREE(uri);
 
 out:
 	return rc;

--- a/src/cart/crt_group.h
+++ b/src/cart/crt_group.h
@@ -571,6 +571,8 @@ crt_grp_psr_set(struct crt_grp_priv *grp_priv, d_rank_t psr_rank,
 	D_RWLOCK_WRLOCK(&grp_priv->gp_rwlock);
 	D_FREE(grp_priv->gp_psr_phy_addr);
 	grp_priv->gp_psr_rank = psr_rank;
+	D_STRNDUP(grp_priv->gp_psr_phy_addr, psr_addr,
+		CRT_ADDR_STR_MAX_LEN);
 	grp_priv->gp_psr_phy_addr = psr_addr;
 	D_RWLOCK_UNLOCK(&grp_priv->gp_rwlock);
 	D_DEBUG(DB_TRACE, "group %s, set psr rank %d, uri %s.\n",

--- a/src/cart/crt_group.h
+++ b/src/cart/crt_group.h
@@ -573,7 +573,6 @@ crt_grp_psr_set(struct crt_grp_priv *grp_priv, d_rank_t psr_rank,
 	grp_priv->gp_psr_rank = psr_rank;
 	D_STRNDUP(grp_priv->gp_psr_phy_addr, psr_addr,
 		CRT_ADDR_STR_MAX_LEN);
-	grp_priv->gp_psr_phy_addr = psr_addr;
 	D_RWLOCK_UNLOCK(&grp_priv->gp_rwlock);
 	D_DEBUG(DB_TRACE, "group %s, set psr rank %d, uri %s.\n",
 		grp_priv->gp_pub.cg_grpid, psr_rank, psr_addr);

--- a/src/cart/crt_pmix.c
+++ b/src/cart/crt_pmix.c
@@ -538,9 +538,10 @@ crt_pmix_psr_load(struct crt_grp_priv *grp_priv, d_rank_t psr_rank)
 
 	rc = crt_pmix_uri_lookup(grp_priv->gp_pub.cg_grpid,
 				 psr_rank, &uri);
-	if (rc == 0)
+	if (rc == 0) {
 		crt_grp_psr_set(grp_priv, psr_rank, uri);
-	else
+		free(uri);
+	} else
 		D_ERROR("crt_pmix_uri_lookup(grpid: %s, rank %d) failed, "
 			"rc: %d.\n", grp_priv->gp_pub.cg_grpid, psr_rank, rc);
 

--- a/src/crt_launch/crt_launch.c
+++ b/src/crt_launch/crt_launch.c
@@ -134,7 +134,7 @@ parse_args(int argc, char **argv)
 		case 'e':
 			g_opt.app_to_exec = optarg;
 			g_opt.app_args_indx = optind - 1;
-			break;
+			return 0;
 		default:
 			g_opt.show_help = true;
 			return 1;

--- a/src/test/iv_client.c
+++ b/src/test/iv_client.c
@@ -60,6 +60,8 @@
 #include <sys/stat.h>
 #include "iv_common.h"
 
+#include "tests_common.h"
+
 static crt_context_t	g_crt_ctx;
 static crt_endpoint_t	g_server_ep;
 static char		g_hostname[100];
@@ -507,7 +509,8 @@ int main(int argc, char **argv)
 		}
 	}
 
-	rc = crt_init(IV_GRP_NAME, CRT_FLAG_BIT_SINGLETON);
+	rc = crt_init(IV_GRP_NAME, CRT_FLAG_BIT_SINGLETON |
+			CRT_FLAG_BIT_PMIX_DISABLE | CRT_FLAG_BIT_LM_DISABLE);
 	assert(rc == 0);
 
 	rc = crt_context_create(&g_crt_ctx);
@@ -525,6 +528,7 @@ int main(int argc, char **argv)
 		sleep(1);
 	}
 	assert(rc == 0);
+
 	rc = pthread_create(&progress_thread, 0, progress_function, &g_crt_ctx);
 	assert(rc == 0);
 

--- a/src/test/iv_server.c
+++ b/src/test/iv_server.c
@@ -53,6 +53,8 @@
 #include <gurt/common.h>
 #include <gurt/list.h>
 
+#include "tests_common.h"
+
 #define _SERVER
 #include "iv_common.h"
 
@@ -1155,9 +1157,13 @@ show_usage(char *app_name)
 
 int main(int argc, char **argv)
 {
-	char	*arg_verbose = NULL;
-	int	 c;
-	int	 rc;
+	char		*arg_verbose = NULL;
+	char		*env_self_rank;
+	char		*grp_cfg_file;
+	crt_group_t	*grp;
+	d_rank_t	my_rank;
+	int	 	c;
+	int	 	rc;
 
 	while ((c = getopt(argc, argv, "v:")) != -1) {
 		switch (c) {
@@ -1181,10 +1187,42 @@ int main(int argc, char **argv)
 		return -1;
 	}
 
+	env_self_rank = getenv("CRT_L_RANK");
+	if (env_self_rank == NULL) {
+		printf("CRT_L_RANK was not set\n");
+		return -1;
+	}
+
+	my_rank = atoi(env_self_rank);
+
 	init_hostname(g_hostname, sizeof(g_hostname));
 
-	rc = crt_init(IV_GRP_NAME, CRT_FLAG_BIT_SERVER);
+	rc = crt_init(IV_GRP_NAME, CRT_FLAG_BIT_SERVER |
+			CRT_FLAG_BIT_PMIX_DISABLE);
 	assert(rc == 0);
+
+	DBG_PRINT("SELF rank set to %d\n", my_rank);
+	rc = crt_rank_self_set(my_rank);
+	assert(rc == 0);
+
+	grp = crt_group_lookup(IV_GRP_NAME);
+	if (grp == NULL) {
+		D_ERROR("Failed to lookup group %s\n", IV_GRP_NAME);
+		assert(0);
+	}
+
+
+	grp_cfg_file = getenv("CRT_L_GRP_CFG");
+	if (grp_cfg_file == NULL) {
+		D_ERROR("CRT_L_GRP_CFG was not set\n");
+		assert(0);
+	}
+
+	rc = tc_load_group_from_file(grp_cfg_file, grp, 1, my_rank, true);
+	if (rc != 0) {
+		D_ERROR("Failed to load group file %s\n", grp_cfg_file);
+		assert(0);
+	}
 
 	DBG_PRINT("Server starting\n");
 
@@ -1206,7 +1244,7 @@ int main(int argc, char **argv)
 	 */
 	wait_for_namespace();
 
-	rc = crt_group_config_save(NULL, true);
+	rc = crt_group_config_save(grp, true);
 	assert(rc == 0);
 
 	while (!g_do_shutdown)

--- a/src/test/iv_server.c
+++ b/src/test/iv_server.c
@@ -1162,8 +1162,8 @@ int main(int argc, char **argv)
 	char		*grp_cfg_file;
 	crt_group_t	*grp;
 	d_rank_t	my_rank;
-	int	 	c;
-	int	 	rc;
+	int		c;
+	int		rc;
 
 	while ((c = getopt(argc, argv, "v:")) != -1) {
 		switch (c) {

--- a/src/test/iv_server.c
+++ b/src/test/iv_server.c
@@ -1201,7 +1201,6 @@ int main(int argc, char **argv)
 			CRT_FLAG_BIT_PMIX_DISABLE);
 	assert(rc == 0);
 
-	DBG_PRINT("SELF rank set to %d\n", my_rank);
 	rc = crt_rank_self_set(my_rank);
 	assert(rc == 0);
 
@@ -1210,7 +1209,6 @@ int main(int argc, char **argv)
 		D_ERROR("Failed to lookup group %s\n", IV_GRP_NAME);
 		assert(0);
 	}
-
 
 	grp_cfg_file = getenv("CRT_L_GRP_CFG");
 	if (grp_cfg_file == NULL) {
@@ -1224,7 +1222,7 @@ int main(int argc, char **argv)
 		assert(0);
 	}
 
-	DBG_PRINT("Server starting\n");
+	DBG_PRINT("Server starting, self_rank=%d\n", my_rank);
 
 	rc = crt_proto_register(&my_proto_fmt_iv);
 	assert(rc == 0);

--- a/src/test/tests_common.h
+++ b/src/test/tests_common.h
@@ -40,6 +40,9 @@
  */
 #ifndef __TESTS_COMMON_H__
 #define __TESTS_COMMON_H__
+#include <semaphore.h>
+#include <cart/api.h>
+#include <gurt/common.h>
 
 int
 tc_load_group_from_file(const char *grp_cfg_file, crt_group_t *grp,

--- a/test/iv/cart_iv_one_node.yaml
+++ b/test/iv/cart_iv_one_node.yaml
@@ -26,8 +26,8 @@ hosts: !mux
 tests: !mux
   iv:
     name: iv_basic
-    srv_bin: tests/iv_server
-    srv_arg: "-v 3"
+    srv_bin: crt_launch
+    srv_arg: "-e tests/iv_server -v 3"
     srv_env: "-x CRT_ALLOW_SINGLETON=1"
     srv_ppn: "2"
 

--- a/test/iv/cart_iv_two_node.yaml
+++ b/test/iv/cart_iv_two_node.yaml
@@ -27,8 +27,8 @@ hosts: !mux
 tests: !mux
   iv:
     name: iv_basic
-    srv_bin: tests/iv_server
-    srv_arg: "-v 3"
+    srv_bin: crt_launch
+    srv_arg: "-e tests/iv_server -v 3"
     srv_env: "-x CRT_ALLOW_SINGLETON=1"
     srv_ppn: "1"
 


### PR DESCRIPTION
- iv_client/iv_server converted to no-pmix mode of operation
- iv_server is now launched using crt_launch tool
- crt_launch fixed to stop processing arguments after 'cmd to exec'
  is parsed out.
- crt_group_attach() changed for non-pmix mode to create group view
  and populate all uris in internal cache
- crt_group_config_save() fixed for non-pmix mode to not rely on
  pmix lookups.

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>