### PR TITLE
CART-730 swim: unlock SWIM context before DEAD

### DIFF
--- a/src/swim/swim.c
+++ b/src/swim/swim.c
@@ -821,6 +821,7 @@ swim_parse_message(struct swim_context *ctx, swim_id_t from,
 			 * just shut down
 			 */
 			if (upds[i].smu_id == self_id) {
+				swim_ctx_unlock(ctx);
 				SWIM_INFO("%lu: self confirmed DEAD "
 					  "(incarnation=%lu)\n", self_id,
 					  upds[i].smu_state.sms_incarnation);


### PR DESCRIPTION
Fix unlocking context before return from function.