### PR TITLE
yulujia/deprecate-DB_ANY

### DIFF
--- a/src/gurt/debug.c
+++ b/src/gurt/debug.c
@@ -315,10 +315,6 @@ debug_mask_load(const char *mask_name)
 	cur = strtok(mask_str, DD_SEP);
 	d_dbglog_data.dd_mask = 0;
 	while (cur != NULL) {
-		if (strncasecmp(cur, "any", sizeof("any")) == 0) {
-			D_PRINT_ERR("DB_ANY deprecated, use DB_MISC instead.\n");
-			continue;
-		}
 		for (i = 0; i < NUM_DBG_BIT_ENTRIES; i++) {
 			d = &d_dbg_bit_dict[i];
 			if (d->db_name != NULL &&

--- a/src/gurt/debug.c
+++ b/src/gurt/debug.c
@@ -316,7 +316,7 @@ debug_mask_load(const char *mask_name)
 	d_dbglog_data.dd_mask = 0;
 	while (cur != NULL) {
 		if (strncasecmp(cur, "any", sizeof("any")) == 0) {
-			D_PRINT_ERR("DB_ANY deprecated, use DB_ALL instead.\n");
+			D_PRINT_ERR("DB_ANY deprecated, use DB_MISC instead.\n");
 			continue;
 		}
 		for (i = 0; i < NUM_DBG_BIT_ENTRIES; i++) {
@@ -370,9 +370,6 @@ d_log_dbg_grp_alloc(d_dbug_t dbgmask, char *grpname, uint32_t flags)
 
 	if (grpname == NULL || dbgmask == 0)
 		return -1;
-
-	if (dbgmask && d_dbg_grp_dict[1].dg_mask)
-		D_PRINT_ERR("DB_ANY deprecated, use DB_ALL instead.\n");
 
 	name_sz = strlen(grpname) + 1;
 	set_as_default = flags & D_LOG_SET_AS_DEFAULT;

--- a/src/gurt/debug.c
+++ b/src/gurt/debug.c
@@ -371,7 +371,7 @@ d_log_dbg_grp_alloc(d_dbug_t dbgmask, char *grpname, uint32_t flags)
 	if (grpname == NULL || dbgmask == 0)
 		return -1;
 
-	if (dbgmask && d_dbg_bit_dict[1])
+	if (dbgmask && d_dbg_grp_dict[1].dg_mask)
 		D_PRINT_ERR("DB_ANY deprecated, use DB_ALL instead.\n");
 
 	name_sz = strlen(grpname) + 1;

--- a/src/gurt/debug.c
+++ b/src/gurt/debug.c
@@ -315,6 +315,10 @@ debug_mask_load(const char *mask_name)
 	cur = strtok(mask_str, DD_SEP);
 	d_dbglog_data.dd_mask = 0;
 	while (cur != NULL) {
+		if (strncasecmp(cur, "any", sizeof("any")) == 0) {
+			D_PRINT_ERR("DB_ANY deprecated, use DB_ALL instead.\n");
+			continue;
+		}
 		for (i = 0; i < NUM_DBG_BIT_ENTRIES; i++) {
 			d = &d_dbg_bit_dict[i];
 			if (d->db_name != NULL &&
@@ -366,6 +370,9 @@ d_log_dbg_grp_alloc(d_dbug_t dbgmask, char *grpname, uint32_t flags)
 
 	if (grpname == NULL || dbgmask == 0)
 		return -1;
+
+	if (dbgmask && d_dbg_bit_dict[1])
+		D_PRINT_ERR("DB_ANY deprecated, use DB_ALL instead.\n");
 
 	name_sz = strlen(grpname) + 1;
 	set_as_default = flags & D_LOG_SET_AS_DEFAULT;
@@ -426,7 +433,7 @@ debug_prio_err_load_env(void)
 static void
 debug_mask_load_env(void)
 {
-	char		    *mask_env;
+	char	*mask_env;
 
 	mask_env = getenv(DD_MASK_ENV);
 	if (mask_env == NULL)

--- a/src/include/gurt/debug_setup.h
+++ b/src/include/gurt/debug_setup.h
@@ -75,7 +75,7 @@
 	/** All debug streams */                \
 	ACTION(DB_ALL,   all,   all,   0, arg)  \
 	/** Generic debug stream */             \
-	ACTION(DB_ANY,   any,   any,   0, arg)  \
+	ACTION(DB_MISC,  misc,  misc,  0, arg)  \
 	/** Extremely verbose debug stream */   \
 	ACTION(DB_TRACE, trace, trace, 0, arg)  \
 	/** Memory operations */                \

--- a/src/include/gurt/debug_setup.h
+++ b/src/include/gurt/debug_setup.h
@@ -64,18 +64,23 @@
 #define D_LOGFAC	DD_GURT_FAC(misc)
 #endif
 
-/** Arguments to priority bit macros are
+/**
+ * Arguments to priority bit macros are
  *      flag            Variable name of the priority bit flag
  *      s_name          Short name of the flag
  *      l_name          Long name of the flag
  *      default_mask    Should always be 0 for debug bits
  *      arg             Argument passed along.  Use D_NOOP when not required
+ *
+ * \note DB_ALL is special in that it sets all bits in the bitfield. If one
+ *       wants to always log, when any debug is enabled, use DB_ALL instead of
+ *       DB_ANY.
  */
 #define D_FOREACH_GURT_DB(ACTION, arg)          \
-	/** All debug streams */                \
+	/** Set all debug bits */               \
 	ACTION(DB_ALL,   all,   all,   0, arg)  \
-	/** Generic debug stream */             \
-	ACTION(DB_MISC,  misc,  misc,  0, arg)  \
+	/** Stream for uncategorized messages */\
+	ACTION(DB_ANY,   any,   any,   0, arg)  \
 	/** Extremely verbose debug stream */   \
 	ACTION(DB_TRACE, trace, trace, 0, arg)  \
 	/** Memory operations */                \

--- a/src/include/gurt/debug_setup.h
+++ b/src/include/gurt/debug_setup.h
@@ -198,13 +198,15 @@
 
 /** Internal macro for initializing facility cache defined by DD_*_CACHE */
 #define _D_LOG_INITIALIZE_FIELD(flag, s_name, l_name, mask, fac) DLOG_UNINIT,
-/** These macros are used intended to be used with FOREACH macros that define
- *  log facilities in your library.   It will utilize internal FOREACH macros
- *  to define debug bits as well as user defined macros.  See
- *  D_FOREACH_GURT_FAC for an example.
+
+/**
+ * These macros are intended to be used with FOREACH macros that define log
+ * facilities in your library.   It will utilize internal FOREACH macros to
+ * define debug bits as well as user defined macros.  See D_FOREACH_GURT_FAC for
+ * an example.
  *
- * These macros can also be used standalone but are not quite as convenient
- * due to required but unused arguments
+ * These macros can also be used standalone but are not quite as convenient due
+ * to required but unused arguments
  */
 
 #ifdef D_LOG_USE_V2 /* Macros for D_DEBUG version 2 */


### PR DESCRIPTION
CART-707 debug: deprecate DB_ANY
 deprecate DB_ANY, for it has the same meaning as DB_ALL. Will completely
 remove it on the next cart version change.
