### PR TITLE
CART-730 swim: introduce INACTIVE member status

### DIFF
--- a/src/cart/_structures_from_macros_.h
+++ b/src/cart/_structures_from_macros_.h
@@ -212,6 +212,22 @@ struct crt_proto_query_out {
 	int32_t pq_rc;
 };
 
+struct crt_rpc_swim_in {
+	swim_id_t src;
+	struct {
+	uint64_t ca_count;
+	struct swim_member_update *ca_arrays;
+	} upds;
+};
+
+struct crt_rpc_swim_wack_in {
+	swim_id_t src;
+	struct {
+	uint64_t ca_count;
+	struct swim_member_update *ca_arrays;
+	} upds;
+};
+
 struct crt_st_both_bulk_in {
 	uint64_t unused1;
 	crt_bulk_t unused2;

--- a/src/cart/crt_context.c
+++ b/src/cart/crt_context.c
@@ -699,6 +699,7 @@ crt_req_timeout_hdlr(struct crt_rpc_priv *rpc_priv)
 	crt_endpoint_t			*tgt_ep;
 	crt_rpc_t			*ul_req;
 	struct crt_uri_lookup_in	*ul_in;
+	int				 rc;
 
 	if (crt_req_timeout_reset(rpc_priv)) {
 		RPC_TRACE(DB_NET, rpc_priv,
@@ -759,7 +760,9 @@ crt_req_timeout_hdlr(struct crt_rpc_priv *rpc_priv)
 				  "aborting to group %s, rank %d, tgt_uri %s\n",
 				  grp_priv->gp_pub.cg_grpid,
 				  tgt_ep->ep_rank, rpc_priv->crp_tgt_uri);
-			crt_req_abort(&rpc_priv->crp_pub);
+			rc = crt_req_abort(&rpc_priv->crp_pub);
+			if (rc)
+				crt_context_req_untrack(rpc_priv);
 		}
 		break;
 	}

--- a/src/cart/crt_group.c
+++ b/src/cart/crt_group.c
@@ -792,7 +792,7 @@ crt_grp_ctx_invalid(struct crt_context *ctx, bool locked)
 		D_RWLOCK_RDLOCK(&grp_gdata->gg_rwlock);
 	grp_priv = grp_gdata->gg_srv_pri_grp;
 	if (grp_priv != NULL) {
-		crt_swim_disable_all(grp_priv);
+		crt_swim_disable_all();
 		rc = crt_grp_lc_ctx_invalid(grp_priv, ctx);
 		if (rc != 0) {
 			D_ERROR("crt_grp_lc_ctx_invalid failed, group %s, "

--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -1347,7 +1347,7 @@ crt_req_abort(crt_rpc_t *req)
 		RPC_ERROR(rpc_priv, "crt_hg_req_cancel failed, rc: %d, "
 			  "opc: %#x.\n", rc, rpc_priv->crp_pub.cr_opc);
 		crt_rpc_complete(rpc_priv, rc);
-		D_GOTO(out, rc = 0);
+		D_GOTO(out, rc);
 	}
 
 out:

--- a/src/cart/crt_swim.h
+++ b/src/cart/crt_swim.h
@@ -69,7 +69,7 @@ void crt_swim_fini(void);
 
 int  crt_swim_enable(struct crt_grp_priv *grp_priv, int crt_ctx_idx);
 int  crt_swim_disable(struct crt_grp_priv *grp_priv, int crt_ctx_idx);
-void crt_swim_disable_all(struct crt_grp_priv *grp_priv);
+void crt_swim_disable_all(void);
 int  crt_swim_rank_add(struct crt_grp_priv *grp_priv, d_rank_t rank);
 int  crt_swim_rank_del(struct crt_grp_priv *grp_priv, d_rank_t rank);
 void crt_swim_rank_del_all(struct crt_grp_priv *grp_priv);

--- a/src/include/cart/swim.h
+++ b/src/include/cart/swim.h
@@ -59,8 +59,12 @@ typedef uint64_t swim_id_t;
 enum swim_member_status {
 	SWIM_MEMBER_ALIVE = 0,
 	SWIM_MEMBER_SUSPECT,
-	SWIM_MEMBER_DEAD
+	SWIM_MEMBER_DEAD,
+	SWIM_MEMBER_INACTIVE
 };
+
+/** This chars should represent values of enum swim_member_status to print */
+#define SWIM_STATUS_CHARS "ASDI"
 
 /** SWIM state associated with each group member */
 struct swim_member_state {

--- a/src/test/test_corpc_exclusive.c
+++ b/src/test/test_corpc_exclusive.c
@@ -118,6 +118,7 @@ static struct crt_proto_format my_proto_fmt_basic_corpc = {
 	.cpf_base = TEST_CORPC_PREFWD_BASE,
 };
 
+void crt_swim_disable_all(void);
 
 int main(void)
 {
@@ -177,6 +178,7 @@ int main(void)
 		crt_progress(g_main_ctx, 1000, NULL, NULL);
 
 	D_DEBUG(DB_TEST, "Shutting down\n");
+	crt_swim_disable_all();
 
 	tc_drain_queue(g_main_ctx);
 

--- a/src/test/test_corpc_prefwd.c
+++ b/src/test/test_corpc_prefwd.c
@@ -141,6 +141,7 @@ static struct crt_proto_format my_proto_fmt_basic_corpc = {
 	.cpf_base = TEST_CORPC_PREFWD_BASE,
 };
 
+void crt_swim_disable_all(void);
 
 int main(void)
 {
@@ -187,6 +188,7 @@ int main(void)
 		crt_progress(g_main_ctx, 1000, NULL, NULL);
 
 	D_DEBUG(DB_TEST, "Shutting down\n");
+	crt_swim_disable_all();
 
 	tc_drain_queue(g_main_ctx);
 

--- a/src/test/test_swim.c
+++ b/src/test/test_swim.c
@@ -166,6 +166,8 @@ static int test_set_member_state(struct swim_context *ctx,
 	int i, cnt, rc = 0;
 
 	switch (state->sms_status) {
+	case SWIM_MEMBER_INACTIVE:
+		break;
 	case SWIM_MEMBER_ALIVE:
 		break;
 	case SWIM_MEMBER_SUSPECT:


### PR DESCRIPTION
During bootstrapping not all members initialized in the same time.
So, to avoid false positive DEAD detection during bootstrapping
let's introduce INACTIVE status for member which mean the following:
 - member will be INACTIVE until first ping response or remove
 - each member will try to ping it but just ignore if it fails