### PR TITLE
CART-737 Adding return code checks before crt_req_fill_tgt_uri

### DIFF
--- a/src/cart/crt_group.c
+++ b/src/cart/crt_group.c
@@ -2218,7 +2218,7 @@ crt_uri_lookup_forward_cb(const struct crt_cb_info *cb_info)
 	ul_fwd_in = crt_req_get(cb_info->cci_rpc);
 	ul_fwd_out = crt_reply_get(cb_info->cci_rpc);
 
-	if (ul_fwd_out->ul_rc != 0) 
+	if (ul_fwd_out->ul_rc != 0)
 		D_GOTO(out, rc = ul_fwd_out->ul_rc);
 
 	crt_ctx = cb_info->cci_rpc->cr_ctx;

--- a/src/cart/crt_group.c
+++ b/src/cart/crt_group.c
@@ -2218,6 +2218,9 @@ crt_uri_lookup_forward_cb(const struct crt_cb_info *cb_info)
 	ul_fwd_in = crt_req_get(cb_info->cci_rpc);
 	ul_fwd_out = crt_reply_get(cb_info->cci_rpc);
 
+	if (ul_fwd_out->ul_rc != 0) 
+		D_GOTO(out, rc = ul_fwd_out->ul_rc);
+
 	crt_ctx = cb_info->cci_rpc->cr_ctx;
 	g_rank = ul_fwd_in->ul_rank;
 	tag = ul_fwd_in->ul_tag;
@@ -2234,7 +2237,7 @@ crt_uri_lookup_forward_cb(const struct crt_cb_info *cb_info)
 out:
 	/* reply to original requester */
 	ul_out = crt_reply_get(ul_req);
-	ul_out->ul_rc = cb_info->cci_rc;
+	ul_out->ul_rc = rc;
 	ul_out->ul_uri = uri;
 
 	rc = crt_reply_send(ul_req);

--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -659,6 +659,10 @@ crt_req_uri_lookup_by_rpc_cb(const struct crt_cb_info *cb_info)
 	/* extract uri */
 	ul_out = crt_reply_get(cb_info->cci_rpc);
 	D_ASSERT(ul_out != NULL);
+
+	if (ul_out->ul_rc != 0)
+		D_GOTO(out, rc = ul_out->ul_rc);
+
 	uri = ul_out->ul_uri;
 
 	/* insert uri to hash table */
@@ -681,6 +685,7 @@ crt_req_uri_lookup_by_rpc_cb(const struct crt_cb_info *cb_info)
 			rc, rpc_priv->crp_pub.cr_opc);
 		D_GOTO(out, rc);
 	}
+
 out:
 	if (rc != 0) {
 		crt_context_req_untrack(rpc_priv);


### PR DESCRIPTION
Checking return code and returning if not 0 in
crt_req_uri_lookup_by_rpc_cb and
crt_uri_lookup_forward_cb
This is to avoid crt_req_fill_tgt_uri asserting NULL uri.