### PR TITLE
CART-713: Add new group atomic modification apis

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -52,7 +52,7 @@ DESIRED_FLAGS = ['-Wno-gnu-designator',
                  '-Wno-gnu-zero-variadic-macro-arguments',
                  '-Wno-tautological-constant-out-of-range-compare']
 
-CART_VERSION = "1.0.0"
+CART_VERSION = "1.1.0"
 
 def save_build_info(env, prereqs, platform):
     """Save the build information"""

--- a/cart.spec
+++ b/cart.spec
@@ -1,8 +1,8 @@
 %define carthome %{_exec_prefix}/lib/%{name}
 
 Name:          cart
-Version:       1.0.0
-Release:       2%{?relval}%{?dist}
+Version:       1.1.0
+Release:       1%{?relval}%{?dist}
 Summary:       CaRT
 
 License:       Apache
@@ -122,6 +122,9 @@ ln %{?buildroot}%{carthome}/{TESTING/.build_vars,.build_vars-Linux}.sh
 %{carthome}/.build_vars-Linux.sh
 
 %changelog
+* Thu Aug 08 2019 Alexander A. Oganezov <alexander.a.oganezov@intel.com>
+- Libcart version 1.1.0
+
 * Wed Aug 07 2019 Brian J. Murrell <brian.murrell@intel.com>
 - Add git hash and commit count to release
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+cart (1.1.0-1) unstable; urgency=medium
+
+  [ Alexander Oganezov ]
+  * 1.1.0 version of CaRT
+
+ -- Alexander Oganezov <alexander.a.oganezov@intel.com>  Thu, 8 Aug 2019 18:54:44 +0000
+
 cart (1.0.0-1) unstable; urgency=medium
 
   [ John Malmberg ]

--- a/src/cart/crt_group.c
+++ b/src/cart/crt_group.c
@@ -682,7 +682,8 @@ crt_grp_lc_uri_insert(struct crt_grp_priv *passed_grp_priv, int ctx_idx,
 	}
 
 	D_RWLOCK_WRLOCK(&grp_priv->gp_rwlock);
-	rc = grp_lc_uri_insert_internal_locked(grp_priv, ctx_idx, rank, tag, uri);
+	rc = grp_lc_uri_insert_internal_locked(grp_priv, ctx_idx, rank, tag,
+						uri);
 	D_RWLOCK_UNLOCK(&grp_priv->gp_rwlock);
 
 	return rc;
@@ -5001,7 +5002,7 @@ crt_group_secondary_modify(crt_group_t *grp, d_rank_list_t *sec_ranks,
 		}
 
 		if (sec_ranks->rl_nr != prim_ranks->rl_nr) {
-			D_ERROR("Primary list size=%d differs from secondary=%d\n",
+			D_ERROR("Prim list size=%d differs from sec=%d\n",
 				prim_ranks->rl_nr, sec_ranks->rl_nr);
 			D_GOTO(out, rc = -DER_INVAL);
 		}

--- a/src/cart/crt_group.c
+++ b/src/cart/crt_group.c
@@ -563,44 +563,24 @@ crt_grp_lc_uri_remove(struct crt_grp_priv *passed_grp_priv, int ctx_idx,
 	d_hash_rec_delete_at(&grp_priv->gp_lookup_cache[ctx_idx], rlink);
 }
 
-/*
- * Fill in the base URI of rank in the lookup cache of the crt_ctx.
- */
-int
-crt_grp_lc_uri_insert(struct crt_grp_priv *passed_grp_priv, int ctx_idx,
-		      d_rank_t rank, uint32_t tag, const char *uri)
+
+static int
+grp_lc_uri_insert_internal_locked(struct crt_grp_priv *grp_priv,
+				int ctx_idx, d_rank_t rank,
+				uint32_t tag,
+				const char *uri)
 {
-	d_list_t		*rlink;
-	struct crt_grp_priv	*grp_priv;
 	struct crt_lookup_item	*li;
 	int			 rc = 0;
+	d_list_t		*rlink;
 
-	D_ASSERT(ctx_idx >= 0 && ctx_idx < CRT_SRV_CONTEXT_NUM);
-	if (tag >= CRT_SRV_CONTEXT_NUM) {
-		D_ERROR("tag %d out of range [0, %d].\n",
-			tag, CRT_SRV_CONTEXT_NUM - 1);
-		return -DER_INVAL;
-	}
-
-	grp_priv = passed_grp_priv;
-
-	if (passed_grp_priv->gp_primary == 0) {
-		if (CRT_PMIX_ENABLED())
-			grp_priv = crt_grp_pub2priv(NULL);
-		else
-			grp_priv = passed_grp_priv->gp_priv_prim;
-
-		rank = grp_priv_get_primary_rank(passed_grp_priv, rank);
-	}
-
-	D_RWLOCK_WRLOCK(&grp_priv->gp_rwlock);
 	rlink = d_hash_rec_find(&grp_priv->gp_lookup_cache[ctx_idx],
 				(void *)&rank, sizeof(rank));
 	if (rlink == NULL) {
 		/* target rank not in cache */
 		D_ALLOC_PTR(li);
 		if (li == NULL)
-			D_GOTO(unlock, rc = -DER_NOMEM);
+			D_GOTO(out, rc = -DER_NOMEM);
 
 		rc = D_MUTEX_INIT(&li->li_mutex, NULL);
 		if (rc != 0)
@@ -633,7 +613,7 @@ crt_grp_lc_uri_insert(struct crt_grp_priv *passed_grp_priv, int ctx_idx,
 				" grp_priv %p ctx_idx %d, rank: %d, rlink %p\n",
 				grp_priv, ctx_idx, rank, &li->li_link);
 		}
-		D_GOTO(unlock, rc);
+		D_GOTO(out, rc);
 	}
 
 	if (!uri)
@@ -662,18 +642,51 @@ crt_grp_lc_uri_insert(struct crt_grp_priv *passed_grp_priv, int ctx_idx,
 
 decref:
 	d_hash_rec_decref(&grp_priv->gp_lookup_cache[ctx_idx], rlink);
-
-unlock:
-	D_RWLOCK_UNLOCK(&grp_priv->gp_rwlock);
 	return rc;
 
 err_destroy_mutex:
 	D_MUTEX_DESTROY(&li->li_mutex);
+
 err_free_li:
 	D_FREE(li);
 
-	D_RWLOCK_UNLOCK(&grp_priv->gp_rwlock);
+out:
 	return rc;
+}
+/*
+ * Fill in the base URI of rank in the lookup cache of the crt_ctx.
+ */
+int
+crt_grp_lc_uri_insert(struct crt_grp_priv *passed_grp_priv, int ctx_idx,
+		      d_rank_t rank, uint32_t tag, const char *uri)
+{
+	struct crt_grp_priv	*grp_priv;
+	int			 rc = 0;
+
+	D_ASSERT(ctx_idx >= 0 && ctx_idx < CRT_SRV_CONTEXT_NUM);
+	if (tag >= CRT_SRV_CONTEXT_NUM) {
+		D_ERROR("tag %d out of range [0, %d].\n",
+			tag, CRT_SRV_CONTEXT_NUM - 1);
+		return -DER_INVAL;
+	}
+
+	grp_priv = passed_grp_priv;
+
+	if (passed_grp_priv->gp_primary == 0) {
+		if (CRT_PMIX_ENABLED())
+			grp_priv = crt_grp_pub2priv(NULL);
+		else
+			grp_priv = passed_grp_priv->gp_priv_prim;
+
+		rank = grp_priv_get_primary_rank(passed_grp_priv, rank);
+	}
+
+	D_RWLOCK_WRLOCK(&grp_priv->gp_rwlock);
+	rc = grp_lc_uri_insert_internal_locked(grp_priv, ctx_idx, rank, tag, uri);
+	D_RWLOCK_UNLOCK(&grp_priv->gp_rwlock);
+
+	return rc;
+
 }
 
 /**
@@ -4062,28 +4075,14 @@ out:
 	return rc;
 }
 
-int
-crt_group_rank_remove(crt_group_t *group, d_rank_t rank)
+static int
+crt_group_rank_remove_internal(struct crt_grp_priv *grp_priv, d_rank_t rank)
 {
-	struct crt_grp_priv	*grp_priv;
 	d_rank_list_t		*membs;
 	d_list_t		*rlink;
 	struct crt_rank_mapping *rm;
-	struct crt_grp_priv	*sec_priv;
 	int			i;
-	int			rc = -DER_OOG;
-
-	if (CRT_PMIX_ENABLED()) {
-		D_ERROR("This api only avaialble when PMIX is disabled\n");
-		D_GOTO(out, rc = -DER_INVAL);
-	}
-
-	if (group == NULL) {
-		D_ERROR("Passed group is NULL\n");
-		D_GOTO(out, rc = -DER_INVAL);
-	}
-
-	grp_priv = crt_grp_pub2priv(group);
+	int			rc = 0;
 
 	if (grp_priv->gp_primary) {
 		rlink = d_hash_rec_find(&grp_priv->gp_uri_lookup_cache,
@@ -4105,7 +4104,6 @@ crt_group_rank_remove(crt_group_t *group, d_rank_t rank)
 
 		rlink = d_hash_rec_find(&grp_priv->gp_s2p_table,
 				(void *)&rank, sizeof(rank));
-
 		if (!rlink) {
 			D_ERROR("Rank %d is not part of the group\n", rank);
 			D_GOTO(out, rc = -DER_OOG);
@@ -4118,12 +4116,10 @@ crt_group_rank_remove(crt_group_t *group, d_rank_t rank)
 
 		d_hash_rec_delete(&grp_priv->gp_s2p_table,
 				&rank, sizeof(d_rank_t));
-
 		d_hash_rec_delete(&grp_priv->gp_p2s_table,
 				&prim_rank, sizeof(d_rank_t));
 	}
 
-	D_RWLOCK_WRLOCK(&grp_priv->gp_rwlock);
 	membs = grp_priv->gp_membs.cgm_list;
 
 	for (i = 0; i < membs->rl_nr; i++) {
@@ -4139,39 +4135,86 @@ crt_group_rank_remove(crt_group_t *group, d_rank_t rank)
 		}
 
 	}
-	D_RWLOCK_UNLOCK(&grp_priv->gp_rwlock);
+out:
+	return rc;
+}
 
-	/* Go through associated secondary groups and remove rank from them */
-	if (grp_priv->gp_primary) {
+static int
+crt_grp_remove_from_secondaries(struct crt_grp_priv *grp_priv,
+				d_rank_t rank)
+{
+	struct crt_grp_priv	*sec_priv;
+	struct crt_rank_mapping *rm;
+	d_list_t		*rlink;
+	int			rc;
+	int			i;
 
-		for (i = 0; i < CRT_MAX_SEC_GRPS; i++) {
-			sec_priv = grp_priv->gp_priv_sec[i];
-			if (sec_priv == NULL)
-				continue;
+	for (i = 0; i < CRT_MAX_SEC_GRPS; i++) {
+		sec_priv = grp_priv->gp_priv_sec[i];
+		if (sec_priv == NULL)
+			continue;
 
-			rlink = d_hash_rec_find(&sec_priv->gp_p2s_table,
-						(void *)&rank, sizeof(rank));
-			if (!rlink)
-				continue;
-
-			rm = crt_rm_link2ptr(rlink);
-			rc = crt_group_rank_remove(&sec_priv->gp_pub,
-						rm->rm_value);
-
-			if (rc != 0) {
-				D_ERROR("crt_group_rank_remove(%s,%d) failed; "
-					"rc=%d\n",
-					sec_priv->gp_pub.cg_grpid, rm->rm_value,
-					rc);
-			}
-
-			d_hash_rec_decref(&sec_priv->gp_p2s_table, rlink);
+		D_RWLOCK_WRLOCK(&sec_priv->gp_rwlock);
+		rlink = d_hash_rec_find(&sec_priv->gp_p2s_table,
+					(void *)&rank, sizeof(rank));
+		if (!rlink) {
+			D_RWLOCK_UNLOCK(&sec_priv->gp_rwlock);
+			continue;
 		}
+
+		rm = crt_rm_link2ptr(rlink);
+
+		rc = crt_group_rank_remove_internal(sec_priv, rm->rm_value);
+		if (rc != 0) {
+			D_ERROR("crt_group_rank_remove(%s,%d) failed; rc=%d\n",
+				sec_priv->gp_pub.cg_grpid, rm->rm_value, rc);
+		}
+
+		d_hash_rec_decref(&sec_priv->gp_p2s_table, rlink);
+		D_RWLOCK_UNLOCK(&sec_priv->gp_rwlock);
 	}
 
-	if (rc == 0)
-		crt_swim_rank_del(grp_priv, rank);
+	return 0;
+}
+
+int
+crt_group_rank_remove(crt_group_t *group, d_rank_t rank)
+{
+	struct crt_grp_priv	*grp_priv;
+	int			rc = -DER_OOG;
+
+	if (CRT_PMIX_ENABLED()) {
+		D_ERROR("This api only avaialble when PMIX is disabled\n");
+		D_GOTO(out, rc = -DER_INVAL);
+	}
+
+	if (group == NULL) {
+		D_ERROR("Passed group is NULL\n");
+		D_GOTO(out, rc = -DER_INVAL);
+	}
+
+	grp_priv = crt_grp_pub2priv(group);
+
+	D_RWLOCK_WRLOCK(&grp_priv->gp_rwlock);
+	rc = crt_group_rank_remove_internal(grp_priv, rank);
+	D_RWLOCK_UNLOCK(&grp_priv->gp_rwlock);
+
+	if (rc != 0)
+		D_GOTO(out, rc);
+
+	/* If it's not a primary group - we are done */
+	if (!grp_priv->gp_primary)
+		D_GOTO(out, rc);
+
+	/* Go through associated secondary groups and remove rank from them */
+	D_RWLOCK_RDLOCK(&grp_priv->gp_rwlock);
+	crt_grp_remove_from_secondaries(grp_priv, rank);
+	D_RWLOCK_UNLOCK(&grp_priv->gp_rwlock);
+
 out:
+	if (rc == 0 && grp_priv->gp_primary)
+		crt_swim_rank_del(grp_priv, rank);
+
 	return rc;
 }
 
@@ -4530,16 +4573,95 @@ out:
 	return rm;
 }
 
+static int
+crt_group_secondary_rank_add_internal(struct crt_grp_priv *grp_priv,
+				d_rank_t sec_rank, d_rank_t prim_rank)
+{
+	struct crt_rank_mapping *rm_p2s;
+	struct crt_rank_mapping *rm_s2p;
+	d_list_t		*rlink;
+	d_rank_list_t		*prim_membs;
+	int			rc = 0;
+
+	/* Verify passed primary rank is valid */
+	prim_membs = grp_priv_get_membs(grp_priv->gp_priv_prim);
+	if (!d_rank_in_rank_list(prim_membs, prim_rank)) {
+		D_ERROR("rank %d is not part of associated primary group %s\n",
+			prim_rank, grp_priv->gp_priv_prim->gp_pub.cg_grpid);
+		D_GOTO(out, rc = -DER_OOG);
+	}
+
+	if (prim_rank == grp_priv->gp_priv_prim->gp_self) {
+		D_DEBUG(DB_ALL, "Setting rank %d as self rank for grp %s\n",
+			sec_rank, grp_priv->gp_pub.cg_grpid);
+		grp_priv->gp_self = sec_rank;
+	}
+
+	/* Verify secondary rank isn't already added */
+	rlink = d_hash_rec_find(&grp_priv->gp_s2p_table,
+				(void *)&sec_rank, sizeof(sec_rank));
+	if (rlink != NULL) {
+		D_ERROR("Entry for secondary_rank = %d already exists\n",
+			sec_rank);
+		d_hash_rec_decref(&grp_priv->gp_s2p_table, rlink);
+		D_GOTO(out, rc = -DER_EXIST);
+	}
+
+	/* Add entry to lookup table. Secondary group table contains ranks */
+	rm_s2p = crt_rank_mapping_init(sec_rank, prim_rank);
+	if (!rm_s2p) {
+		D_ERROR("Failed to allocate entry\n");
+		D_GOTO(out, rc = -DER_NOMEM);
+	}
+
+	rm_p2s = crt_rank_mapping_init(prim_rank, sec_rank);
+	if (!rm_p2s) {
+		D_ERROR("Failed to allocate entry\n");
+		crt_rm_destroy(rm_s2p);
+		D_GOTO(out, rc = -DER_NOMEM);
+	}
+
+	rc = d_hash_rec_insert(&grp_priv->gp_s2p_table,
+				&sec_rank, sizeof(sec_rank),
+				&rm_s2p->rm_link, true);
+	if (rc != 0) {
+		D_ERROR("Failed to add entry; rc=%d\n", rc);
+		crt_rm_destroy(rm_s2p);
+		crt_rm_destroy(rm_p2s);
+		D_GOTO(out, rc);
+	}
+
+	rc = d_hash_rec_insert(&grp_priv->gp_p2s_table,
+				&prim_rank, sizeof(prim_rank),
+				&rm_p2s->rm_link, true);
+	if (rc != 0) {
+		D_ERROR("Failed to add entry; rc=%d\n", rc);
+		d_hash_rec_delete(&grp_priv->gp_s2p_table,
+				&sec_rank, sizeof(sec_rank));
+		crt_rm_destroy(rm_p2s);
+		D_GOTO(out, rc);
+	}
+
+	/* Add secondary rank to membership list  */
+	rc = grp_add_to_membs_list(grp_priv, sec_rank);
+	if (rc != 0) {
+		d_hash_rec_delete(&grp_priv->gp_s2p_table,
+				&sec_rank, sizeof(sec_rank));
+
+		d_hash_rec_delete(&grp_priv->gp_s2p_table,
+				&prim_rank, sizeof(prim_rank));
+		D_GOTO(out, rc);
+	}
+
+out:
+	return rc;
+}
 
 int
 crt_group_secondary_rank_add(crt_group_t *grp, d_rank_t sec_rank,
 				d_rank_t prim_rank)
 {
 	struct crt_grp_priv	*grp_priv;
-	struct crt_rank_mapping *rm_p2s;
-	struct crt_rank_mapping *rm_s2p;
-	d_list_t		*rlink;
-	d_rank_list_t		*prim_membs;
 	int			rc = 0;
 
 	grp_priv = crt_grp_pub2priv(grp);
@@ -4556,78 +4678,8 @@ crt_group_secondary_rank_add(crt_group_t *grp, d_rank_t sec_rank,
 
 
 	D_RWLOCK_WRLOCK(&grp_priv->gp_rwlock);
-
-	/* Verify passed primary rank is valid */
-	prim_membs = grp_priv_get_membs(grp_priv->gp_priv_prim);
-	if (!d_rank_in_rank_list(prim_membs, prim_rank)) {
-		D_ERROR("rank %d is not part of associated primary group %s\n",
-			prim_rank, grp_priv->gp_priv_prim->gp_pub.cg_grpid);
-		D_GOTO(unlock, rc = -DER_OOG);
-	}
-
-	if (prim_rank == grp_priv->gp_priv_prim->gp_self) {
-		D_DEBUG(DB_ALL, "Setting rank %d as self rank for grp %s\n",
-			sec_rank, grp_priv->gp_pub.cg_grpid);
-		grp_priv->gp_self = sec_rank;
-	}
-
-	/* Verify secondary rank isn't already added */
-	rlink = d_hash_rec_find(&grp_priv->gp_s2p_table,
-				(void *)&sec_rank, sizeof(sec_rank));
-	if (rlink != NULL) {
-		D_ERROR("Entry for secondary_rank = %d already exists\n",
-			sec_rank);
-		d_hash_rec_decref(&grp_priv->gp_s2p_table, rlink);
-		D_GOTO(unlock, rc = -DER_EXIST);
-	}
-
-	/* Add entry to lookup table. Secondary group table contains ranks */
-	rm_s2p = crt_rank_mapping_init(sec_rank, prim_rank);
-	if (!rm_s2p) {
-		D_ERROR("Failed to allocate entry\n");
-		D_GOTO(unlock, rc = -DER_NOMEM);
-	}
-
-	rm_p2s = crt_rank_mapping_init(prim_rank, sec_rank);
-	if (!rm_p2s) {
-		D_ERROR("Failed to allocate entry\n");
-		crt_rm_destroy(rm_s2p);
-		D_GOTO(unlock, rc = -DER_NOMEM);
-	}
-
-	rc = d_hash_rec_insert(&grp_priv->gp_s2p_table,
-				&sec_rank, sizeof(sec_rank),
-				&rm_s2p->rm_link, true);
-	if (rc != 0) {
-		D_ERROR("Failed to add entry; rc=%d\n", rc);
-		crt_rm_destroy(rm_s2p);
-		crt_rm_destroy(rm_p2s);
-		D_GOTO(unlock, rc);
-	}
-
-	rc = d_hash_rec_insert(&grp_priv->gp_p2s_table,
-				&prim_rank, sizeof(prim_rank),
-				&rm_p2s->rm_link, true);
-	if (rc != 0) {
-		D_ERROR("Failed to add entry; rc=%d\n", rc);
-		d_hash_rec_delete(&grp_priv->gp_s2p_table,
-				&sec_rank, sizeof(sec_rank));
-		crt_rm_destroy(rm_p2s);
-		D_GOTO(unlock, rc);
-	}
-
-	/* Add secondary rank to membership list  */
-	rc = grp_add_to_membs_list(grp_priv, sec_rank);
-	if (rc != 0) {
-		d_hash_rec_delete(&grp_priv->gp_s2p_table,
-				&sec_rank, sizeof(sec_rank));
-
-		d_hash_rec_delete(&grp_priv->gp_s2p_table,
-				&prim_rank, sizeof(prim_rank));
-		D_GOTO(unlock, rc);
-	}
-
-unlock:
+	rc = crt_group_secondary_rank_add_internal(grp_priv,
+					sec_rank, prim_rank);
 	D_RWLOCK_UNLOCK(&grp_priv->gp_rwlock);
 
 out:
@@ -4654,3 +4706,354 @@ out:
 	return rc;
 }
 
+/*
+ * Helper function to return back rank lists of nodes to add,
+ * to remove, and index of ranks to be added.
+ *
+ * Index of ranks to add is used for accessing proper URIs
+ * when adding new ranks
+ */
+static int
+crt_group_mod_get(d_rank_list_t *grp_membs, d_rank_list_t *mod_membs,
+		crt_group_mod_op_t op, d_rank_list_t **ret_to_add,
+		d_rank_list_t **ret_to_remove, uint32_t **ret_idx_to_add)
+
+{
+	d_rank_t	rank;
+	int		rc = 0;
+	d_rank_list_t	*to_add = NULL;
+	d_rank_list_t	*to_remove = NULL;
+	uint32_t	*idx_to_add = NULL;
+	int		i;
+
+	D_ASSERT(grp_membs != NULL);
+	D_ASSERT(mod_membs != NULL);
+	D_ASSERT(ret_to_add != NULL);
+	D_ASSERT(ret_to_remove != NULL);
+	D_ASSERT(ret_idx_to_add != NULL);
+
+	/* At most we will remove all members from old group */
+	to_remove = d_rank_list_alloc(grp_membs->rl_nr);
+
+	/* At most we will add all members from new group */
+	to_add = d_rank_list_alloc(mod_membs->rl_nr);
+
+	if (to_remove == NULL || to_add == NULL) {
+		D_ERROR("Failed to allocate lists\n");
+		D_GOTO(cleanup, rc = -DER_NOMEM);
+	}
+
+	/* Array will have at most 'mod_membs' elements */
+	D_ALLOC_ARRAY(idx_to_add, mod_membs->rl_nr);
+	if (!idx_to_add) {
+		D_ERROR("Failed to allocate array\n");
+		D_GOTO(cleanup, rc = -DER_NOMEM);
+	}
+
+	to_add->rl_nr = 0;
+	to_remove->rl_nr = 0;
+	/* Build to_add and to_remove lists based on op specified */
+	if (op == CRT_GROUP_MOD_OP_REPLACE) {
+		/*
+		 * Replace:
+		 * If rank exists in mod_membs but not in grp_membs - add it
+		 * If rank exists in grp_membs but not in mod_membs - remove it
+		 * Otherwise leave rank unchanged
+		 */
+
+		/* Build list of new ranks to add */
+		for (i = 0; i < mod_membs->rl_nr; i++) {
+			rank = mod_membs->rl_ranks[i];
+
+			if (d_rank_in_rank_list(grp_membs, rank) == false) {
+				idx_to_add[to_add->rl_nr] = i;
+				to_add->rl_ranks[to_add->rl_nr++] = rank;
+			}
+		}
+
+		/* Build list of ranks to remove */
+		for (i = 0; i < grp_membs->rl_nr; i++) {
+			rank = grp_membs->rl_ranks[i];
+
+			if (d_rank_in_rank_list(mod_membs, rank) == false)
+				to_remove->rl_ranks[to_remove->rl_nr++] = rank;
+		}
+	} else if (op == CRT_GROUP_MOD_OP_ADD) {
+		/* Build list of ranks to add; nothing to remove */
+		for (i = 0; i < mod_membs->rl_nr; i++) {
+			rank = mod_membs->rl_ranks[i];
+
+			if (d_rank_in_rank_list(grp_membs, rank) == false) {
+				idx_to_add[to_add->rl_nr] = i;
+				to_add->rl_ranks[to_add->rl_nr++] = rank;
+			}
+		}
+
+		to_remove->rl_nr = 0;
+
+	} else if (op == CRT_GROUP_MOD_OP_REMOVE) {
+		/* Build list of ranks to remove; nothing to add */
+		for (i = 0; i < mod_membs->rl_nr; i++) {
+			rank = mod_membs->rl_ranks[i];
+
+			if (d_rank_in_rank_list(grp_membs, rank) == true) {
+				to_remove->rl_ranks[to_remove->rl_nr++] = rank;
+			}
+		}
+
+		to_add->rl_nr = 0;
+	} else {
+		D_ERROR("Should never get here\n");
+		D_ASSERT(0);
+	}
+
+	if (to_add->rl_nr == 0 && to_remove->rl_nr == 0)
+		D_WARN("Membership unchanged. No modification performed\n");
+
+	*ret_to_add = to_add;
+	*ret_to_remove = to_remove;
+	*ret_idx_to_add = idx_to_add;
+
+	return rc;
+
+cleanup:
+	if (to_add != NULL)
+		d_rank_list_free(to_add);
+
+	if (to_remove != NULL)
+		d_rank_list_free(to_remove);
+
+	D_FREE(idx_to_add);
+	return rc;
+}
+
+/*
+ * 'uris' is an array of uris; expected to be of size ranks->rl_nr * num_ctxs
+ * In the case of single provider num_ctxs=1,
+ * For multi-provider support contexts for each provider are to be passed
+ * In multi-provider support uris should be formed as:
+ * [uri0 for provider0]
+ * [uri1 for provider0]
+ * ....
+ * [uriX for provider0]
+ * [uri0 for provider1]
+ * [uri1 for provider1]
+ * ...
+ * [uriX for provider1]
+ * [uri0 for provider2]
+ * etc...
+ */
+int
+crt_group_primary_modify(crt_group_t *grp, crt_context_t *ctxs, int num_ctxs,
+			d_rank_list_t *ranks, char **uris,
+			crt_group_mod_op_t op)
+{
+	struct crt_grp_priv	*grp_priv;
+	d_rank_list_t		*grp_membs;
+	d_rank_list_t		*to_remove;
+	d_rank_list_t		*to_add;
+	uint32_t		*uri_idx;
+	d_rank_t		rank;
+	int			k;
+	int			i;
+	int			rc = 0;
+
+	grp_priv = crt_grp_pub2priv(grp);
+
+	if (grp_priv == NULL) {
+		D_ERROR("Failed to get grp_priv\n");
+		D_GOTO(out, rc = -DER_INVAL);
+	}
+
+	if (!grp_priv->gp_primary) {
+		D_ERROR("Passed group is not primary\n");
+		D_GOTO(out, rc = -DER_INVAL);
+	}
+
+	if (op >= CRT_GROUP_MOD_OP_COUNT) {
+		D_ERROR("Invalid operation %d\n", op);
+		D_GOTO(out, rc = -DER_INVAL);
+	}
+
+	if (ranks == NULL || ranks->rl_nr == 0 || ranks->rl_ranks == NULL) {
+		D_ERROR("Modification has no members\n");
+		D_GOTO(out, rc = -DER_INVAL);
+	}
+
+	if (op != CRT_GROUP_MOD_OP_REMOVE && uris == NULL) {
+		D_ERROR("URI array is null\n");
+		D_GOTO(out, rc = -DER_INVAL);
+	}
+
+	D_RWLOCK_WRLOCK(&grp_priv->gp_rwlock);
+
+	grp_membs = grp_priv_get_membs(grp_priv);
+
+	/* Get back list of nodes to add, to remove and uri index list */
+	rc = crt_group_mod_get(grp_membs, ranks, op, &to_add, &to_remove,
+			&uri_idx);
+	if (rc != 0)
+		D_GOTO(unlock, rc);
+
+	/* Add ranks based on to_add list */
+	for (i = 0; i < to_add->rl_nr; i++) {
+		rank = to_add->rl_ranks[i];
+
+		rc = grp_add_to_membs_list(grp_priv, rank);
+		if (rc != 0) {
+			D_ERROR("grp_add_to_memb_list %d failed; rc=%d\n",
+				rank, rc);
+			D_GOTO(cleanup, rc);
+		}
+
+		/* TODO: Change for multi-provider support */
+		for (k = 0; k < CRT_SRV_CONTEXT_NUM; k++) {
+			rc = grp_lc_uri_insert_internal_locked(grp_priv,
+				k, rank, 0, uris[uri_idx[i]]);
+
+			if (rc != 0)
+				D_GOTO(cleanup, rc);
+		}
+	}
+
+	/* Remove ranks based on to_remove list */
+	for (i = 0; i < to_remove->rl_nr; i++) {
+		rank = to_remove->rl_ranks[i];
+		crt_group_rank_remove_internal(grp_priv, rank);
+
+		/* Remove rank from associated secondary groups */
+		crt_grp_remove_from_secondaries(grp_priv, rank);
+
+		/* Remove rank from swim tracking */
+		crt_swim_rank_del(grp_priv, rank);
+	}
+
+	d_rank_list_free(to_add);
+	d_rank_list_free(to_remove);
+	D_FREE(uri_idx);
+unlock:
+	D_RWLOCK_UNLOCK(&grp_priv->gp_rwlock);
+
+out:
+	return rc;
+
+cleanup:
+
+	D_ERROR("Failure when adding node %d, rc=%d\n",
+		to_add->rl_ranks[i], rc);
+
+	for (k = 0; k < i; k++)
+		crt_group_rank_remove_internal(grp_priv, to_add->rl_ranks[k]);
+
+	d_rank_list_free(to_add);
+	d_rank_list_free(to_remove);
+	D_FREE(uri_idx);
+
+	D_RWLOCK_UNLOCK(&grp_priv->gp_rwlock);
+
+	return rc;
+}
+
+
+int
+crt_group_secondary_modify(crt_group_t *grp, d_rank_list_t *sec_ranks,
+			d_rank_list_t *prim_ranks, crt_group_mod_op_t op)
+{
+	struct crt_grp_priv	*grp_priv;
+	d_rank_list_t		*grp_membs;
+	d_rank_list_t		*to_remove;
+	d_rank_list_t		*to_add;
+	uint32_t		*prim_idx;
+	d_rank_t		rank;
+	int			k;
+	int			i;
+	int			rc = 0;
+
+	grp_priv = crt_grp_pub2priv(grp);
+
+	if (grp_priv == NULL) {
+		D_ERROR("Failed to get grp_priv\n");
+		D_GOTO(out, rc = -DER_INVAL);
+	}
+
+	if (grp_priv->gp_primary) {
+		D_ERROR("Passed group is primary\n");
+		D_GOTO(out, rc = -DER_INVAL);
+	}
+
+	if (op >= CRT_GROUP_MOD_OP_COUNT) {
+		D_ERROR("Invalid operation %d\n", op);
+		D_GOTO(out, rc = -DER_INVAL);
+	}
+
+	if (sec_ranks == NULL || sec_ranks->rl_nr == 0 ||
+		sec_ranks->rl_ranks == NULL) {
+
+		D_ERROR("Modification has no members\n");
+		D_GOTO(out, rc = -DER_INVAL);
+	}
+
+	if (op != CRT_GROUP_MOD_OP_REMOVE) {
+		if (prim_ranks == NULL || prim_ranks->rl_nr == 0 ||
+			prim_ranks->rl_ranks == NULL) {
+			D_ERROR("Primary rank list is empty\n");
+			D_GOTO(out, rc = -DER_INVAL);
+		}
+
+		if (sec_ranks->rl_nr != prim_ranks->rl_nr) {
+			D_ERROR("Primary list size=%d differs from secondary=%d\n",
+				prim_ranks->rl_nr, sec_ranks->rl_nr);
+			D_GOTO(out, rc = -DER_INVAL);
+		}
+	}
+
+	D_RWLOCK_WRLOCK(&grp_priv->gp_rwlock);
+
+	grp_membs = grp_priv_get_membs(grp_priv);
+
+	/* Get back list of nodes to add, to remove and primary rank list */
+	rc = crt_group_mod_get(grp_membs, sec_ranks, op, &to_add, &to_remove,
+			&prim_idx);
+	if (rc != 0)
+		D_GOTO(unlock, rc);
+
+	/* Add ranks based on to_add list */
+	for (i = 0; i < to_add->rl_nr; i++) {
+		rc = crt_group_secondary_rank_add_internal(grp_priv,
+					to_add->rl_ranks[i],
+					prim_ranks->rl_ranks[prim_idx[i]]);
+		if (rc != 0)
+			D_GOTO(cleanup, rc);
+	}
+
+	/* Remove ranks based on to_remove list */
+	for (i = 0; i < to_remove->rl_nr; i++) {
+		rank = to_remove->rl_ranks[i];
+		crt_group_rank_remove_internal(grp_priv, rank);
+	}
+
+	d_rank_list_free(to_add);
+	d_rank_list_free(to_remove);
+	D_FREE(prim_idx);
+unlock:
+	D_RWLOCK_UNLOCK(&grp_priv->gp_rwlock);
+
+out:
+	return rc;
+
+cleanup:
+
+	D_ERROR("Failure when adding rank %d, rc=%d\n",
+		to_add->rl_ranks[i], rc);
+
+	for (k = 0; k < i; k++)
+		crt_group_rank_remove_internal(grp_priv, to_add->rl_ranks[k]);
+
+	d_rank_list_free(to_add);
+	d_rank_list_free(to_remove);
+	D_FREE(prim_idx);
+
+	D_RWLOCK_UNLOCK(&grp_priv->gp_rwlock);
+
+	return rc;
+}

--- a/src/include/cart/api.h
+++ b/src/include/cart/api.h
@@ -1947,6 +1947,64 @@ int crt_group_secondary_create(crt_group_id_t grp_name,
  */
 int crt_group_secondary_destroy(crt_group_t *grp);
 
+
+/**
+ * Perform a primary group modification in an atomic fashion based on the
+ * operation specified. Currently supported operations are 'add', 'remove'
+ * and 'replace'. This API allows multiple ranks to be added or removed
+ * at the same time with a single call.
+ *
+ * Add: Ranks in the rank list are added to the group with corresponding uris
+ * Remove: Ranks in the rank list are removed from the group
+ * Replace:
+ *     Ranks that exist in group and not in rank list get removed
+ *     Ranks that exist in rank list and not in group get added
+ *     Ranks that exist in both rank list and group are left unmodified
+ *
+ * \param[in] grp                Group handle
+ * \param[in] ctxs               Array of contexts
+ * \param[in] num_ctxs           Number of contexts
+ * \param[in] ranks              Modification rank list
+ * \param[in] uris               Array of URIs corresponding to contexts and
+ *                               rank list
+ * \param[in] op                 Modification operation.
+ *
+ * \return                       DER_SUCCESS on success, negative value on
+ *                               failure.
+ *
+ * Note: \ref uris is an array of srings; expected to be of size ranks->rl_nr * num_ctxs
+ * In multi-provider support uris should be formed as:
+ * [uri0 for provider0]
+ * [uri1 for provider0]
+ * ....
+ * [uriX for provider0]
+ * [uri0 for provider1]
+ * [uri1 for provider1]
+ * ...
+ * [uriX for provider1]
+ * [uri0 for provider2]
+ * etc...
+ */
+int crt_group_primary_modify(crt_group_t *grp, crt_context_t *ctxs,
+			int num_ctxs, d_rank_list_t *ranks, char **uris,
+			crt_group_mod_op_t op);
+
+/**
+ * Perform a secondary group modification in an atomic fashion based on the
+ * operation type specified. Operations are the same as in
+ * \ref crt_group_primary_modify API.
+ *
+ * \param[in] grp                Group handle
+ * \param[in] sec_ranks          List of secondary ranks
+ * \param[in] prim_ranks         List of primary ranks
+ * \param[in] op                 Modification operation
+ *
+ * \return                       DER_SUCCESS on success, negative value on
+ *                               failure.
+ */
+int crt_group_secondary_modify(crt_group_t *grp, d_rank_list_t *sec_ranks,
+			d_rank_list_t *prim_ranks, crt_group_mod_op_t op);
+
 #define crt_proc__Bool			crt_proc_bool
 #define crt_proc_d_rank_t		crt_proc_uint32_t
 #define crt_proc_int			crt_proc_int32_t

--- a/src/include/cart/api.h
+++ b/src/include/cart/api.h
@@ -1972,18 +1972,20 @@ int crt_group_secondary_destroy(crt_group_t *grp);
  * \return                       DER_SUCCESS on success, negative value on
  *                               failure.
  *
- * Note: \ref uris is an array of srings; expected to be of size
- * ranks->rl_nr * num_ctxs
- * In multi-provider support uris should be formed as:
- * [uri0 for provider0]
+ * Note: \ref uris shall be an array of (ranks->rl_nr * num_ctxs) strings
+ * In multi-provider case, where num_ctxs > 1, uris array should be
+ * formed as follows:
+ * [uri0 for provider0 identified by ctx0]
  * [uri1 for provider0]
  * ....
  * [uriX for provider0]
- * [uri0 for provider1]
+ *
+ * [uri0 for provider1 identified by ctx1]
  * [uri1 for provider1]
  * ...
  * [uriX for provider1]
- * [uri0 for provider2]
+ *
+ * [uri0 for provider2 identified by ctx2]
  * etc...
  */
 int crt_group_primary_modify(crt_group_t *grp, crt_context_t *ctxs,

--- a/src/include/cart/api.h
+++ b/src/include/cart/api.h
@@ -1972,7 +1972,8 @@ int crt_group_secondary_destroy(crt_group_t *grp);
  * \return                       DER_SUCCESS on success, negative value on
  *                               failure.
  *
- * Note: \ref uris is an array of srings; expected to be of size ranks->rl_nr * num_ctxs
+ * Note: \ref uris is an array of srings; expected to be of size
+ * ranks->rl_nr * num_ctxs
  * In multi-provider support uris should be formed as:
  * [uri0 for provider0]
  * [uri1 for provider0]

--- a/src/include/cart/types.h
+++ b/src/include/cart/types.h
@@ -574,6 +574,24 @@ enum crt_init_flag_bits {
 	CRT_FLAG_BIT_PMIX_DISABLE = 1U << 3,
 };
 
+/**
+ * Operations for \ref crt_group_primary_modify and
+ * \ref crt_group_secondary_modify APIs. See \ref crt_group_primary_modify
+ * for description of operation behavior.
+ */
+typedef enum {
+	/** Replace operation */
+	CRT_GROUP_MOD_OP_REPLACE = 0,
+
+	/** Addition operation */
+	CRT_GROUP_MOD_OP_ADD,
+
+	/** Removal operation */
+	CRT_GROUP_MOD_OP_REMOVE,
+
+	/** Total count of supported operations */
+	CRT_GROUP_MOD_OP_COUNT,
+} crt_group_mod_op_t;
 
 
 /** @}

--- a/src/test/no_pmix_group_test.c
+++ b/src/test/no_pmix_group_test.c
@@ -673,7 +673,7 @@ int main(int argc, char **argv)
 
 	mod_ranks = d_rank_list_alloc(10);
 	if (!mod_ranks) {
-		D_ASSERT("rank list allocation failed\n");
+		D_ERROR("rank list allocation failed\n");
 		assert(0);
 	}
 

--- a/src/test/no_pmix_group_test.c
+++ b/src/test/no_pmix_group_test.c
@@ -234,13 +234,35 @@ __dump_ranks(crt_group_t *grp) {
 }
 
 static void
+__dump_ranklist(const char *msg, d_rank_list_t *rl)
+{
+	int i;
+
+	DBG_PRINT(msg);
+	for (i = 0; i < rl->rl_nr; i++)
+		DBG_PRINT("rank[%d] = %d\n", i, rl->rl_ranks[i]);
+
+}
+
+static void
 __verify_ranks(crt_group_t *grp, d_rank_t *exp_ranks, int size)
 {
 	uint32_t	grp_size;
 	d_rank_list_t	*rank_list;
 	int		i;
 	int		rc;
+	d_rank_list_t	*sorted_list;
+	d_rank_list_t	exp_list;
+	d_rank_list_t	*exp_sorted;
 
+	exp_list.rl_nr = size;
+	exp_list.rl_ranks = exp_ranks;
+
+	rc = d_rank_list_dup_sort_uniq(&exp_sorted, &exp_list);
+	if (rc != 0) {
+		D_ERROR("d_rank_list_dup_sort_uniq() failed; rc=%d\n", rc);
+		assert(0);
+	}
 
 	rc = crt_group_size(grp, &grp_size);
 	if (rc != 0) {
@@ -263,20 +285,30 @@ __verify_ranks(crt_group_t *grp, d_rank_t *exp_ranks, int size)
 	if (rank_list->rl_nr != size) {
 		D_ERROR("rank_list size expected=%d got=%d\n",
 			size, rank_list->rl_nr);
+
+		assert(0);
+	}
+
+	rc = d_rank_list_dup_sort_uniq(&sorted_list, rank_list);
+	if (rc != 0) {
+		D_ERROR("d_rank_list_dup_sort_uniq() failed; rc=%d\n", rc);
 		assert(0);
 	}
 
 	for (i = 0; i < size; i++) {
-		if (rank_list->rl_ranks[i] != exp_ranks[i]) {
+		if (sorted_list->rl_ranks[i] != exp_sorted->rl_ranks[i]) {
 			D_ERROR("rank_list[%d] expected=%d got=%d\n",
-				i, rank_list->rl_ranks[i],
-				exp_ranks[i]);
+				i, sorted_list->rl_ranks[i],
+				exp_sorted->rl_ranks[i]);
+			__dump_ranklist("Expected\n", exp_sorted);
+			__dump_ranklist("Actual\n", sorted_list);
 			assert(0);
 		}
 	}
 
-	D_FREE(rank_list->rl_ranks);
-	D_FREE(rank_list);
+	d_rank_list_free(rank_list);
+	d_rank_list_free(sorted_list);
+	d_rank_list_free(exp_sorted);
 }
 
 #define VERIFY_RANKS(grp, list...)			\
@@ -304,6 +336,10 @@ int main(int argc, char **argv)
 	crt_group_t		*grp;
 	crt_context_t		crt_ctx[NUM_SERVER_CTX];
 	pthread_t		progress_thread[NUM_SERVER_CTX];
+	d_rank_list_t		*mod_ranks;
+	char			*uris[10];
+	d_rank_list_t		*mod_prim_ranks;
+	d_rank_list_t		*mod_sec_ranks;
 	int			i;
 	char			*my_uri;
 	char			*env_self_rank;
@@ -470,7 +506,7 @@ int main(int argc, char **argv)
 		assert(0);
 	}
 
-	VERIFY_RANKS(sec_grp1, 10, 9, 7, 6, 41, 42, 43);
+	VERIFY_RANKS(sec_grp1, 6, 7, 9, 10, 41, 42, 43);
 
 	/* Add new sec_rank=50 after the removal of previous one */
 	rc = crt_group_secondary_rank_add(sec_grp1, 50, 2);
@@ -479,7 +515,7 @@ int main(int argc, char **argv)
 		assert(0);
 	}
 
-	VERIFY_RANKS(sec_grp1, 10, 9, 50, 7, 6, 41, 42, 43);
+	VERIFY_RANKS(sec_grp1, 6, 7, 9, 10, 41, 42, 43, 50);
 
 	/* Verify new ranks secondary to primary conversion */
 	rc = crt_group_rank_s2p(sec_grp1, 50, &tmp_rank);
@@ -629,9 +665,157 @@ int main(int argc, char **argv)
 		assert(0);
 	}
 
-	VERIFY_RANKS(sec_grp1, 10, 9, 7, 6, 41, 42, 43);
+	VERIFY_RANKS(sec_grp1, 6, 7, 9, 10, 41, 42, 43);
+	VERIFY_RANKS(grp, 0, 1, 3, 4, 5, 6, 7);
 
-	/* Shutdown self (prim_rank=0) */
+	DBG_PRINT("----------------------------\n");
+	DBG_PRINT("Testing crt_group_primary_modify()\n");
+
+	mod_ranks = d_rank_list_alloc(10);
+	if (!mod_ranks) {
+		D_ASSERT("rank list allocation failed\n");
+		assert(0);
+	}
+
+	for (i = 0; i < 10; i++) {
+		asprintf(&uris[i], "ofi+sockets://127.0.0.1:%d", 10000 + i);
+		mod_ranks->rl_ranks[i] = i + 1;
+	}
+
+	DBG_PRINT("primary modify: Add\n");
+	rc = crt_group_primary_modify(grp, &crt_ctx[1], 1,
+				mod_ranks, uris,
+				CRT_GROUP_MOD_OP_ADD);
+	if (rc != 0) {
+		D_ERROR("crt_group_primary_modify() failed; rc = %d\n", rc);
+		assert(0);
+	}
+
+	VERIFY_RANKS(grp, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+
+	mod_ranks->rl_ranks[0] = 0;
+	mod_ranks->rl_ranks[1] = 5;
+	mod_ranks->rl_ranks[2] = 11;
+	mod_ranks->rl_ranks[3] = 15;
+	mod_ranks->rl_ranks[4] = 18;
+	mod_ranks->rl_nr = 5;
+
+	DBG_PRINT("primary modify: Replace\n");
+	rc = crt_group_primary_modify(grp, &crt_ctx[1], 1,
+				mod_ranks, uris,
+				CRT_GROUP_MOD_OP_REPLACE);
+	if (rc != 0) {
+		D_ERROR("crt_group_primary_modify() failed; rc=%d\n", rc);
+		assert(0);
+	}
+
+	VERIFY_RANKS(grp, 0, 5, 11, 15, 18);
+	VERIFY_RANKS(sec_grp1, 10, 41);
+
+	mod_ranks->rl_ranks[0] = 5;
+	mod_ranks->rl_ranks[1] = 15;
+	mod_ranks->rl_nr = 2;
+
+	DBG_PRINT("primary modify: Remove\n");
+	rc = crt_group_primary_modify(grp, &crt_ctx[1], 1,
+				mod_ranks, NULL,
+				CRT_GROUP_MOD_OP_REMOVE);
+	if (rc != 0) {
+		D_ERROR("crt_group_primary_modify() failed; rc=%d\n", rc);
+		assert(0);
+	}
+
+	VERIFY_RANKS(grp, 0, 11, 18);
+	VERIFY_RANKS(sec_grp1, 10);
+
+	mod_ranks->rl_ranks[0] = 1;
+	mod_ranks->rl_ranks[1] = 2;
+	mod_ranks->rl_ranks[2] = 12;
+	mod_ranks->rl_nr = 3;
+
+	rc = crt_group_primary_modify(grp, &crt_ctx[1], 1,
+				mod_ranks, uris,
+				CRT_GROUP_MOD_OP_ADD);
+	if (rc != 0) {
+		D_ERROR("crt_group_primary_modify() failed; rc=%d\n", rc);
+		assert(0);
+	}
+
+	VERIFY_RANKS(grp, 0, 1, 2, 11, 12, 18);
+
+	d_rank_list_free(mod_ranks);
+
+	/* Allocated above with asprintf */
+	for (i = 0; i < 10; i++)
+		free(uris[i]);
+
+	mod_prim_ranks = d_rank_list_alloc(10);
+	mod_sec_ranks = d_rank_list_alloc(10);
+
+	if (!mod_prim_ranks || !mod_sec_ranks) {
+		D_ERROR("Failed to allocate lists\n");
+		assert(0);
+	}
+
+	mod_prim_ranks->rl_ranks[0] = 1;
+	mod_prim_ranks->rl_ranks[1] = 2;
+	mod_prim_ranks->rl_ranks[2] = 18;
+
+	mod_sec_ranks->rl_ranks[0] = 55;
+	mod_sec_ranks->rl_ranks[1] = 102;
+	mod_sec_ranks->rl_ranks[2] = 48;
+
+	mod_sec_ranks->rl_nr = 3;
+	mod_prim_ranks->rl_nr = 3;
+
+	DBG_PRINT("secondary group: Add\n");
+	rc = crt_group_secondary_modify(sec_grp1, mod_sec_ranks,
+					mod_prim_ranks, CRT_GROUP_MOD_OP_ADD);
+	if (rc != 0) {
+		D_ERROR("crt_group_secondary_modify() failed; rc=%d\n", rc);
+		assert(0);
+	}
+
+	VERIFY_RANKS(sec_grp1, 10, 48, 55, 102);
+
+	mod_prim_ranks->rl_ranks[0] = 0;
+	mod_sec_ranks->rl_ranks[0] = 10;
+
+	mod_prim_ranks->rl_ranks[1] = 18;
+	mod_sec_ranks->rl_ranks[1] = 55;
+
+	mod_prim_ranks->rl_ranks[2] = 12;
+	mod_sec_ranks->rl_ranks[2] = 114;
+
+	mod_prim_ranks->rl_nr = 3;
+	mod_sec_ranks->rl_nr = 3;
+
+	DBG_PRINT("secondary group: Replace\n");
+	rc = crt_group_secondary_modify(sec_grp1, mod_sec_ranks, mod_prim_ranks,
+					CRT_GROUP_MOD_OP_REPLACE);
+	if (rc != 0) {
+		D_ERROR("crt_group_secondary_modify() failed; rc=%d\n", rc);
+		assert(0);
+	}
+
+	VERIFY_RANKS(sec_grp1, 10, 55, 114);
+
+	mod_sec_ranks->rl_ranks[0] = 55;
+	mod_sec_ranks->rl_nr = 1;
+
+	DBG_PRINT("secondary group: Remove\n");
+	rc = crt_group_secondary_modify(sec_grp1, mod_sec_ranks, NULL,
+					CRT_GROUP_MOD_OP_REMOVE);
+	if (rc != 0) {
+		D_ERROR("crt_group_secondary_modify() failed; rc=%d\n", rc);
+		assert(0);
+	}
+
+	VERIFY_RANKS(sec_grp1, 10, 114);
+
+	d_rank_list_free(mod_prim_ranks);
+	d_rank_list_free(mod_sec_ranks);
+
 	g_do_shutdown = 1;
 	sem_destroy(&sem);
 

--- a/src/test/no_pmix_group_test.c
+++ b/src/test/no_pmix_group_test.c
@@ -678,7 +678,7 @@ int main(int argc, char **argv)
 	}
 
 	for (i = 0; i < 10; i++) {
-		rc = asprintf(&uris[i], "ofi+sockets://127.0.0.1:%d", 
+		rc = asprintf(&uris[i], "ofi+sockets://127.0.0.1:%d",
 				10000 + i);
 		if (rc == -1) {
 			D_ERROR("asprintf() failed\n");

--- a/src/test/no_pmix_group_test.c
+++ b/src/test/no_pmix_group_test.c
@@ -238,7 +238,7 @@ __dump_ranklist(const char *msg, d_rank_list_t *rl)
 {
 	int i;
 
-	DBG_PRINT(msg);
+	DBG_PRINT("%s", msg);
 	for (i = 0; i < rl->rl_nr; i++)
 		DBG_PRINT("rank[%d] = %d\n", i, rl->rl_ranks[i]);
 
@@ -678,7 +678,12 @@ int main(int argc, char **argv)
 	}
 
 	for (i = 0; i < 10; i++) {
-		asprintf(&uris[i], "ofi+sockets://127.0.0.1:%d", 10000 + i);
+		rc = asprintf(&uris[i], "ofi+sockets://127.0.0.1:%d", 
+				10000 + i);
+		if (rc == -1) {
+			D_ERROR("asprintf() failed\n");
+			assert(0);
+		}
 		mod_ranks->rl_ranks[i] = i + 1;
 	}
 


### PR DESCRIPTION
New APIs:
- crt_group_primary_modify
- crt_group_secondary_modify

New APIs allow atomic modification of primary/secondary group
membership based on the operation type specified. Currently supported
operations are: Replace, Add, Remove.

New Type:
- crt_group_mod_op_t

no_pmix_group_test updated to include test cases of newly added APIs.

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>