### PR TITLE
CART-89 cart: fix bug in crt_context_flush()

### DIFF
--- a/src/cart/crt_context.c
+++ b/src/cart/crt_context.c
@@ -530,7 +530,7 @@ crt_context_flush(crt_context_t crt_ctx, uint64_t timeout)
 		if (timeout == 0)
 			continue;
 		ts_now = d_timeus_secdiff(0);
-	} while (ts_now >= ts_deadline);
+	} while (ts_now <= ts_deadline);
 
 	if (timeout > 0 && ts_now >= ts_deadline)
 		rc = -DER_TIMEDOUT;

--- a/src/include/cart/api.h
+++ b/src/include/cart/api.h
@@ -182,10 +182,10 @@ crt_context_ep_empty(crt_context_t crt_ctx);
  * Flush pending RPCs associated with the specified context.
  *
  * \param[in] crt_ctx           CRT transport context to flush
- * \param[in] timeout           max time duration (in micro seconds) to try to
- *                              flush. 0 means infinite timeout. After
- *                              \a timeout amount of time, this function will
- *                              return even if there are still RPCs pending.
+ * \param[in] timeout           max time duration (in seconds) to try to flush.
+ *                              0 means infinite timeout. After \a timeout
+ *                              amount of time, this function will return even
+ *                              if there are still RPCs pending.
  *
  * \return                      DER_SUCCESS if there are no more pending RPCs,
  *                              -DER_TIMEDOUT if time out is reached before all


### PR DESCRIPTION
Fix a bug in crt_context_flush(). When the timeout value is not 0,
crt_context_flush() returns right away instead of keep progressing the
context for timeout amout of time.