### PR TITLE
CART-89 cart: Add new error code `DER_NOTREPLICA`

### DIFF
--- a/src/include/gurt/errno.h
+++ b/src/include/gurt/errno.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2017-2018 Intel Corporation
+/* Copyright (C) 2017-2019 Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -162,7 +162,9 @@
 	/** Operation now in progress */				\
 	ACTION(DER_INPROGRESS,		(DER_ERR_DAOS_BASE + 18))	\
 	/** Not applicable. */						\
-	ACTION(DER_NOTAPPLICABLE,	(DER_ERR_DAOS_BASE + 19))
+	ACTION(DER_NOTAPPLICABLE,	(DER_ERR_DAOS_BASE + 19))	\
+	/** Not a service replica */					\
+	ACTION(DER_NOTREPLICA,		(DER_ERR_DAOS_BASE + 20))
 
 #define D_FOREACH_ERR_RANGE(ACTION)	\
 	ACTION(GURT,	1000)		\


### PR DESCRIPTION
Add a new error code `DER_NOTREPLICA` used by rsvc when a given
DB is not found on a server. It currently returns `DER_NONEXIST`
which is also returned by the service leader in case of other error
conditions; this makes it impossible for the client to know whether
the error occurred during leader operation or because a service DB
truly does not exist.

Signed-off-by: Omkar Kulkarni <omkar.kulkarni@intel.com>