### PR TITLE
CART-740 corpc: Add CRT_RPC_FLAG_EXCLUSIVE (quick and dirty draft)

### DIFF
--- a/src/cart/crt_corpc.c
+++ b/src/cart/crt_corpc.c
@@ -742,11 +742,15 @@ crt_corpc_reply_hdlr(const struct crt_cb_info *cb_info)
 			    parent_rpc_priv->crp_pub.cr_output_size > 0) {
 				/*
 				 * when root excluded, copy first reply's
-				 * content to parent.
+				 * content to parent and zero child's copy so
+				 * that any pointers contained therein belong
+				 * solely to parent.
 				 */
 				memcpy(parent_rpc_priv->crp_pub.cr_output,
 				       child_rpc_priv->crp_pub.cr_output,
 				       parent_rpc_priv->crp_pub.cr_output_size);
+				memset(child_rpc_priv->crp_pub.cr_output, 0,
+				       child_rpc_priv->crp_pub.cr_output_size);
 			} else {
 				D_ASSERT(co_ops->co_aggregate != NULL);
 				rc = co_ops->co_aggregate(child_req,

--- a/src/cart/crt_corpc.c
+++ b/src/cart/crt_corpc.c
@@ -44,7 +44,7 @@
 static inline int
 crt_corpc_info_init(struct crt_rpc_priv *rpc_priv,
 		    struct crt_grp_priv *grp_priv, bool grp_ref_taken,
-		    d_rank_list_t *excluded_ranks, uint32_t grp_ver,
+		    d_rank_list_t *filter_ranks, uint32_t grp_ver,
 		    crt_bulk_t co_bulk_hdl, void *priv, uint32_t flags,
 		    int tree_topo, d_rank_t grp_root, bool init_hdr,
 		    bool root_excluded)
@@ -53,6 +53,7 @@ crt_corpc_info_init(struct crt_rpc_priv *rpc_priv,
 	struct crt_corpc_hdr	*co_hdr;
 	int			 rc = 0;
 	d_rank_list_t		*membs;
+	uint32_t		 nr;
 
 	D_ASSERT(rpc_priv != NULL);
 	D_ASSERT(grp_priv != NULL);
@@ -61,8 +62,7 @@ crt_corpc_info_init(struct crt_rpc_priv *rpc_priv,
 	if (co_info == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
-	rc = d_rank_list_dup_sort_uniq(&co_info->co_excluded_ranks,
-				       excluded_ranks);
+	rc = d_rank_list_dup_sort_uniq(&co_info->co_filter_ranks, filter_ranks);
 	if (rc != 0) {
 		D_ERROR("d_rank_list_dup failed, rc: %d.\n", rc);
 		D_FREE_PTR(co_info);
@@ -73,9 +73,19 @@ crt_corpc_info_init(struct crt_rpc_priv *rpc_priv,
 	co_info->co_grp_ref_taken = 1;
 	co_info->co_grp_priv = grp_priv;
 
-	membs = grp_priv_get_membs(grp_priv);
-	d_rank_list_filter(membs,
-			   co_info->co_excluded_ranks, false /* exclude */);
+	if (co_info->co_filter_ranks != NULL) {
+		membs = grp_priv_get_membs(grp_priv);
+		nr = co_info->co_filter_ranks->rl_nr;
+		d_rank_list_filter(membs, co_info->co_filter_ranks,
+				   false /* exclude */);
+		if ((flags & CRT_RPC_FLAG_EXCLUSIVE) &&
+		    (co_info->co_filter_ranks->rl_nr != nr)) {
+			D_ERROR("%u/%u exclusive ranks out of group\n",
+				nr - co_info->co_filter_ranks->rl_nr, nr);
+			D_GOTO(out, rc = -DER_OOG);
+		}
+	}
+
 	co_info->co_grp_ver = grp_ver;
 	co_info->co_tree_topo = tree_topo;
 	co_info->co_root = grp_root;
@@ -94,9 +104,11 @@ crt_corpc_info_init(struct crt_rpc_priv *rpc_priv,
 			rpc_priv->crp_flags |= CRT_RPC_FLAG_PRIMARY_GRP;
 		else if (flags & CRT_RPC_FLAG_GRP_DESTROY)
 			rpc_priv->crp_flags |= CRT_RPC_FLAG_GRP_DESTROY;
+		if (flags & CRT_RPC_FLAG_EXCLUSIVE)
+			rpc_priv->crp_flags |= CRT_RPC_FLAG_EXCLUSIVE;
 
 		co_hdr->coh_grpid = grp_priv->gp_pub.cg_grpid;
-		co_hdr->coh_excluded_ranks = co_info->co_excluded_ranks;
+		co_hdr->coh_filter_ranks = co_info->co_filter_ranks;
 		co_hdr->coh_inline_ranks = NULL;
 		co_hdr->coh_grp_ver = grp_ver;
 		co_hdr->coh_tree_topo = tree_topo;
@@ -115,7 +127,7 @@ void
 crt_corpc_info_fini(struct crt_rpc_priv *rpc_priv)
 {
 	D_ASSERT(rpc_priv->crp_coll && rpc_priv->crp_corpc_info);
-	d_rank_list_free(rpc_priv->crp_corpc_info->co_excluded_ranks);
+	d_rank_list_free(rpc_priv->crp_corpc_info->co_filter_ranks);
 	if (rpc_priv->crp_corpc_info->co_grp_ref_taken)
 		crt_grp_priv_decref(rpc_priv->crp_corpc_info->co_grp_priv);
 	D_FREE_PTR(rpc_priv->crp_corpc_info);
@@ -150,12 +162,13 @@ crt_corpc_initiate(struct crt_rpc_priv *rpc_priv)
 	}
 
 	rc = crt_corpc_info_init(rpc_priv, grp_priv, grp_ref_taken,
-			co_hdr->coh_excluded_ranks,
-			co_hdr->coh_grp_ver /* grp_ver */,
-			rpc_priv->crp_pub.cr_co_bulk_hdl,
-			NULL /* priv */, rpc_priv->crp_flags,
-			co_hdr->coh_tree_topo, co_hdr->coh_root,
-			false /* init_hdr */, false /* root_excluded */);
+				 co_hdr->coh_filter_ranks,
+				 co_hdr->coh_grp_ver /* grp_ver */,
+				 rpc_priv->crp_pub.cr_co_bulk_hdl,
+				 NULL /* priv */, rpc_priv->crp_flags,
+				 co_hdr->coh_tree_topo, co_hdr->coh_root,
+				 false /* init_hdr */,
+				 false /* root_excluded */);
 	if (rc != 0) {
 		/* rollback refcount taken in above */
 		if (grp_ref_taken)
@@ -353,7 +366,7 @@ out:
 
 int
 crt_corpc_req_create(crt_context_t crt_ctx, crt_group_t *grp,
-		     d_rank_list_t *excluded_ranks, crt_opcode_t opc,
+		     d_rank_list_t *filter_ranks, crt_opcode_t opc,
 		     crt_bulk_t co_bulk_hdl, void *priv,  uint32_t flags,
 		     int tree_topo, crt_rpc_t **req)
 {
@@ -361,8 +374,9 @@ crt_corpc_req_create(crt_context_t crt_ctx, crt_group_t *grp,
 	struct crt_grp_priv	*default_grp_priv;
 	struct crt_grp_gdata	*grp_gdata;
 	struct crt_rpc_priv	*rpc_priv = NULL;
-	d_rank_list_t		*tobe_excluded_ranks = NULL;
+	d_rank_list_t		*tobe_filter_ranks = NULL;
 	bool			 root_excluded = false;
+	bool			 exclusive = flags & CRT_RPC_FLAG_EXCLUSIVE;
 	d_rank_t		 grp_root, pri_root;
 	uint32_t		 grp_ver;
 	int			 rc = 0;
@@ -418,33 +432,41 @@ crt_corpc_req_create(crt_context_t crt_ctx, crt_group_t *grp,
 	pri_root = grp_priv_get_primary_rank(grp_priv, grp_root);
 
 
-	tobe_excluded_ranks = excluded_ranks;
+	tobe_filter_ranks = filter_ranks;
 	/*
-	 * if bcast initiator is in excluded ranks, here we remove it and set
+	 * if bcast initiator is not in the scope, here we add it and set
 	 * a special flag to indicate need not to execute RPC handler.
 	 */
-	if (d_rank_in_rank_list(excluded_ranks, pri_root)) {
-		d_rank_list_t		tmp_rank_list;
-		d_rank_t		tmp_rank;
-
-		tmp_rank = pri_root;
-		tmp_rank_list.rl_nr = 1;
-		tmp_rank_list.rl_ranks = &tmp_rank;
-
-		rc =  d_rank_list_dup(&tobe_excluded_ranks, excluded_ranks);
+	rc = d_rank_in_rank_list(filter_ranks, pri_root);
+	if ((exclusive && !rc) || (!exclusive && rc)) {
+		rc = d_rank_list_dup(&tobe_filter_ranks, filter_ranks);
 		if (rc != 0)
 			D_GOTO(out, rc);
 
-		d_rank_list_filter(&tmp_rank_list, tobe_excluded_ranks,
-				   true /* exclude */);
 		root_excluded = true;
+
+		/* make sure pri_root is in the scope */
+		if (exclusive) {
+			rc = d_rank_list_append(tobe_filter_ranks, pri_root);
+			if (rc != 0)
+				D_GOTO(out, rc);
+		} else {
+			d_rank_list_t	tmp_rank_list;
+			d_rank_t	tmp_rank;
+
+			tmp_rank = pri_root;
+			tmp_rank_list.rl_nr = 1;
+			tmp_rank_list.rl_ranks = &tmp_rank;
+			d_rank_list_filter(&tmp_rank_list, tobe_filter_ranks,
+					   true /* exclude */);
+		}
 	}
 
 	D_RWLOCK_RDLOCK(grp_priv->gp_rwlock_ft);
 	grp_ver = default_grp_priv->gp_membs_ver;
 	D_RWLOCK_UNLOCK(grp_priv->gp_rwlock_ft);
 
-	rc = crt_corpc_info_init(rpc_priv, grp_priv, false, tobe_excluded_ranks,
+	rc = crt_corpc_info_init(rpc_priv, grp_priv, false, tobe_filter_ranks,
 				 grp_ver /* grp_ver */, co_bulk_hdl, priv,
 				 flags, tree_topo, grp_root,
 				 true /* init_hdr */, root_excluded);
@@ -459,7 +481,7 @@ out:
 	if (rc < 0)
 		crt_rpc_priv_free(rpc_priv);
 	if (root_excluded)
-		d_rank_list_free(tobe_excluded_ranks);
+		d_rank_list_free(tobe_filter_ranks);
 	return rc;
 }
 
@@ -498,7 +520,7 @@ corpc_add_child_rpc(struct crt_rpc_priv *parent_rpc_priv,
 	child_co_hdr->coh_grpid = parent_co_hdr->coh_grpid;
 	/* child's coh_bulk_hdl is different with parent_co_hdr */
 	child_co_hdr->coh_bulk_hdl = parent_rpc_priv->crp_pub.cr_co_bulk_hdl;
-	child_co_hdr->coh_excluded_ranks = parent_co_hdr->coh_excluded_ranks;
+	child_co_hdr->coh_filter_ranks = parent_co_hdr->coh_filter_ranks;
 	child_co_hdr->coh_inline_ranks = parent_co_hdr->coh_inline_ranks;
 	child_co_hdr->coh_grp_ver = parent_co_hdr->coh_grp_ver;
 	child_co_hdr->coh_tree_topo = parent_co_hdr->coh_tree_topo;
@@ -819,7 +841,8 @@ crt_corpc_req_hdlr(struct crt_rpc_priv *rpc_priv)
 	}
 
 	rc = crt_tree_get_children(co_info->co_grp_priv, co_info->co_grp_ver,
-				   co_info->co_excluded_ranks,
+				   rpc_priv->crp_flags & CRT_RPC_FLAG_EXCLUSIVE,
+				   co_info->co_filter_ranks,
 				   co_info->co_tree_topo, co_info->co_root,
 				   co_info->co_grp_priv->gp_self,
 				   &children_rank_list, &ver_match);

--- a/src/cart/crt_hg_proc.c
+++ b/src/cart/crt_hg_proc.c
@@ -419,7 +419,7 @@ crt_proc_corpc_hdr(crt_proc_t proc, struct crt_corpc_hdr *hdr)
 		D_ERROR("crt proc error, rc: %d.\n", rc);
 		D_GOTO(out, rc);
 	}
-	rc = crt_proc_d_rank_list_ptr_t(hg_proc, &hdr->coh_excluded_ranks);
+	rc = crt_proc_d_rank_list_ptr_t(hg_proc, &hdr->coh_filter_ranks);
 	if (rc != 0) {
 		D_ERROR("crt proc error, rc: %d.\n", rc);
 		D_GOTO(out, rc);

--- a/src/cart/crt_rpc.h
+++ b/src/cart/crt_rpc.h
@@ -73,8 +73,8 @@ struct crt_corpc_hdr {
 	d_string_t		 coh_grpid;
 	/* collective bulk handle */
 	crt_bulk_t		 coh_bulk_hdl;
-	/* optional excluded ranks */
-	d_rank_list_t		*coh_excluded_ranks;
+	/* optional excluded or exclusive ranks */
+	d_rank_list_t		*coh_filter_ranks;
 	/* optional inline ranks, for example piggyback the group members */
 	d_rank_list_t		*coh_inline_ranks;
 	/* group membership version */
@@ -118,7 +118,8 @@ typedef enum {
 /* corpc info to track the tree topo and child RPCs info */
 struct crt_corpc_info {
 	struct crt_grp_priv	*co_grp_priv;
-	d_rank_list_t		*co_excluded_ranks;
+	/* excluded or exclusive ranks */
+	d_rank_list_t		*co_filter_ranks;
 	uint32_t		 co_grp_ver;
 	uint32_t		 co_tree_topo;
 	d_rank_t		 co_root;

--- a/src/cart/crt_tree.h
+++ b/src/cart/crt_tree.h
@@ -52,8 +52,8 @@ int crt_tree_get_nchildren(struct crt_grp_priv *grp_priv, uint32_t grp_ver,
 			   d_rank_t grp_root, d_rank_t grp_self,
 			   uint32_t *nchildren);
 int crt_tree_get_children(struct crt_grp_priv *grp_priv, uint32_t grp_ver,
-			  d_rank_list_t *exclude_ranks, int tree_topo,
-			  d_rank_t grp_root, d_rank_t grp_self,
+			  bool exclusive, d_rank_list_t *filter_ranks,
+			  int tree_topo, d_rank_t grp_root, d_rank_t grp_self,
 			  d_rank_list_t **children_rank_list, bool *ver_match);
 int crt_tree_get_parent(struct crt_grp_priv *grp_priv, uint32_t grp_ver,
 			d_rank_list_t *exclude_ranks, int tree_topo,

--- a/src/include/cart/api.h
+++ b/src/include/cart/api.h
@@ -1165,11 +1165,10 @@ crt_group_rank_s2p(crt_group_t *subgrp, d_rank_t rank_in, d_rank_t *rank_out);
  *
  * \param[in] crt_ctx          CRT context
  * \param[in] grp              CRT group for the collective RPC
- * \param[in] excluded_ranks   optional excluded ranks, the RPC will be
- *                             delivered to all members in the group except
- *                             those in excluded_ranks.
- *                             the ranks in excluded_ranks are numbered in
- *                             primary group.
+ * \param[in] filter_ranks     optional excluded or exclusive ranks. the RPC
+ *                             will be delivered to all members in the group
+ *                             except or exclusively to those in ranks.
+ *                             the ranks are numbered in primary group.
  * \param[in] opc              unique opcode for the RPC
  * \param[in] co_bulk_hdl      collective bulk handle
  * \param[in] priv             A private pointer associated with the request
@@ -1177,7 +1176,9 @@ crt_group_rank_s2p(crt_group_t *subgrp, d_rank_t rank_in, d_rank_t *rank_out);
  *                             2nd parameter.
  * \param[in] flags            collective RPC flags for example taking
  *                             CRT_RPC_FLAG_GRP_DESTROY to destroy the subgroup
- *                             when this bcast RPC successfully finished.
+ *                             when this bcast RPC successfully finished, or
+ *                             CRT_RPC_FLAG_EXCLUSIVE to send exclusively to
+ *                             \a filter_ranks.
  * \param[in] tree_topo        tree topology for the collective propagation,
  *                             can be calculated by crt_tree_topo().
  *                             See \a crt_tree_type,
@@ -1188,7 +1189,7 @@ crt_group_rank_s2p(crt_group_t *subgrp, d_rank_t rank_in, d_rank_t *rank_out);
  */
 int
 crt_corpc_req_create(crt_context_t crt_ctx, crt_group_t *grp,
-		     d_rank_list_t *excluded_ranks, crt_opcode_t opc,
+		     d_rank_list_t *filter_ranks, crt_opcode_t opc,
 		     crt_bulk_t co_bulk_hdl, void *priv,  uint32_t flags,
 		     int tree_topo, crt_rpc_t **req);
 

--- a/src/include/cart/types.h
+++ b/src/include/cart/types.h
@@ -173,6 +173,8 @@ enum crt_rpc_flags {
 	 * destroy subgroup when the bcast RPC finishes, only valid for corpc
 	 */
 	CRT_RPC_FLAG_GRP_DESTROY	= (1U << 0),
+	/** send CORPC exclusively to a specified set of ranks */
+	CRT_RPC_FLAG_EXCLUSIVE		= (1U << 1)
 };
 
 struct crt_rpc;


### PR DESCRIPTION
Add CRT_RPC_FLAG_EXCLUSIVE for CORPCs destinated to an exclusive,
usually small subset of ranks, to avoid forcing users to construct a
large exclusion list for a majority of the group. This also enables a
more controlled way of creating secondary groups using CORPCs in the
primary gorups.

This PR also fixes double frees for root-excluded CORPCs.
When crt_corpc_reply_hdlr copies child replies, extra pointer references
may be created if the replies contain pointers. Zeroing the child replies
after copying avoids the potential double frees. I feel, however, that
calling co_aggregate in this case would be cleaner, though it would
require checking all co_aggregate implementations we have.

Signed-off-by: Li Wei <wei.g.li@intel.com>