### PR TITLE
CART-751 build: update dockerfiles

### DIFF
--- a/utils/docker/Dockerfile-debbuild.ubuntu.18.04
+++ b/utils/docker/Dockerfile-debbuild.ubuntu.18.04
@@ -80,8 +80,8 @@ RUN curl -sS -f -L -O ${UBUNTU_URL}/libopenmpi-dev_3.1.2-6_amd64.deb; \
     ln -s /usr/lib/x86_64-linux-gnu/pmix/lib/libpmix.so.2 \
       /usr/lib/x86_64-linux-gnu/pmix/lib/libpmix.so
 
-RUN curl -sS -f -L -O ${MER_ART}/libmercury1_1.0.1-8_amd64.deb; \
-    curl -sS -f -L -O ${MER_ART}/libmercury-dev_1.0.1-8_amd64.deb; \
+RUN curl -sS -f -L -O ${MER_ART}/libmercury1_1.0.1-9_amd64.deb; \
+    curl -sS -f -L -O ${MER_ART}/libmercury-dev_1.0.1-9_amd64.deb; \
     apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
       ./libmercury*_amd64.deb
 

--- a/utils/docker/Dockerfile-debbuild.ubuntu.18.10
+++ b/utils/docker/Dockerfile-debbuild.ubuntu.18.10
@@ -52,8 +52,8 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
       /usr/lib/x86_64-linux-gnu/pmix/lib/libpmix.so
 
 
-RUN curl -sS -f -L -O ${MER_ART}/libmercury1_1.0.1-8_amd64.deb; \
-    curl -sS -f -L -O ${MER_ART}/libmercury-dev_1.0.1-8_amd64.deb; \
+RUN curl -sS -f -L -O ${MER_ART}/libmercury1_1.0.1-9_amd64.deb; \
+    curl -sS -f -L -O ${MER_ART}/libmercury-dev_1.0.1-9_amd64.deb; \
     apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
       ./libmercury*_amd64.deb
 

--- a/utils/docker/Dockerfile.leap.15
+++ b/utils/docker/Dockerfile.leap.15
@@ -40,7 +40,7 @@
 #
 
 # Pull base image
-FROM opensuse/leap:15.0
+FROM opensuse/leap:15
 MAINTAINER Johann Lombardi <johann.lombardi@intel.com>
 
 # Build arguments can be set via -build-arg


### PR DESCRIPTION
- update the mercury deb version to libmercury1_1.0.1-9 to match the
version in the mercury deb build repo

- fix dockerfile for leap 15: should be requesting "leap:15" not
  "leap15.0"