### PR TITLE
CART-592 test: fix test_corpc_version failure

### DIFF
--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -884,6 +884,7 @@ crt_rpc_handler_common(hg_handle_t hg_hdl)
 	}
 
 	rpc_priv->crp_opc_info = opc_info;
+	rpc_pub->cr_opc = rpc_tmp.crp_pub.cr_opc;
 
 	RPC_TRACE(DB_TRACE, rpc_priv,
 		  "(opc: %#x rpc_pub: %p) allocated per RPC request received.\n",
@@ -1185,7 +1186,9 @@ crt_hg_req_send(struct crt_rpc_priv *rpc_priv)
 			  hg_ret);
 	} else {
 		RPC_TRACE(DB_TRACE, rpc_priv,
-			  "sent to uri: %s\n", rpc_priv->crp_tgt_uri);
+			  "sent to rank %d uri: %s\n",
+			  rpc_priv->crp_pub.cr_ep.ep_rank,
+			  rpc_priv->crp_tgt_uri);
 	}
 
 	if (hg_ret == HG_NA_ERROR) {

--- a/src/cart/crt_internal.h
+++ b/src/cart/crt_internal.h
@@ -66,7 +66,7 @@
 #define RPC_TRACE(mask, rpc, fmt, ...)					\
 	do {								\
 		D_TRACE_DEBUG(mask, rpc,				\
-			" [opc=0x%x xid=%x:%x tag=%d] " fmt,		\
+			" [opc=0x%x rank:xid=%d:0x%x tag=%d] " fmt,	\
 			rpc->crp_pub.cr_opc,				\
 			rpc->crp_pub.cr_ep.ep_rank,			\
 			rpc->crp_req_hdr.cch_xid,			\
@@ -77,7 +77,8 @@
 /* Log an error with a RPC descriptor */
 #define RPC_ERROR(rpc, fmt, ...)					\
 	do {								\
-		D_TRACE_ERROR(rpc, " [opc=0x%x xid=%x:%x tag=%d] " fmt,	\
+		D_TRACE_ERROR(rpc,					\
+			" [opc=0x%x rank:xid=%d:0x%x tag=%d] " fmt,	\
 			rpc->crp_pub.cr_opc,				\
 			rpc->crp_pub.cr_ep.ep_rank,			\
 			rpc->crp_req_hdr.cch_xid,			\

--- a/src/cart/crt_register.c
+++ b/src/cart/crt_register.c
@@ -293,7 +293,8 @@ crt_opc_reg(struct crt_opc_info *opc_info, crt_opcode_t opc, uint32_t flags,
 	opc_info->coi_reset_timer = D_BIT_IS_SET(flags, CRT_RPC_FEAT_NO_TIMEOUT);
 	opc_info->coi_queue_front = D_BIT_IS_SET(flags, CRT_RPC_FEAT_QUEUE_FRONT);
 
-	D_DEBUG(DB_TRACE, "opc %#x, reply %s, reset_timer %s, queue_front %s\n",
+	D_DEBUG(DB_TRACE,
+		"opc %#x, no_reply %s, reset_timer %s, queue_front %s\n",
 		opc,
 		opc_info->coi_no_reply ? "enabled" : "disabled",
 		opc_info->coi_reset_timer ? "enabled" : "disabled",

--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -251,6 +251,7 @@ crt_rpc_priv_alloc(crt_opcode_t opc, struct crt_rpc_priv **priv_allocated,
 	rpc_priv->crp_opc_info = opc_info;
 	rpc_priv->crp_forward = forward;
 	*priv_allocated = rpc_priv;
+	rpc_priv->crp_pub.cr_opc = opc;
 
 	RPC_TRACE(DB_TRACE, rpc_priv, "(opc: %#x rpc_pub: %p) allocated.\n",
 		  rpc_priv->crp_opc_info->coi_opc,


### PR DESCRIPTION
fix intermittent failure of the test_corpc_version test.

After using the HG_Cancel() workaround in mercury, the reported error in
the ticket doesn't show up any more. Instead the test hangs from time to
time.

The reason was 1) during shutdown the lm module is interfering with the
corpc version mismatch test. 2) when runing many (tried 32 and 64)
processes on a single node, sometimes two processes pick the same port
number. If one process finishes early and exits, the other process can't
receive the shtudown RPC anymore. This causes a hang.

The reason 2 above is still not fixed.