### PR TITLE
CART-752 cart: let mercury pick its own ports

### DIFF
--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -452,8 +452,8 @@ crt_get_info_string(char **string)
 		/* OFI_PORT is only for context 0 to use */
 		port = crt_na_ofi_conf.noc_port;
 		crt_na_ofi_conf.noc_port = -1;
-		D_ASPRINTF(*string, "%s://%s", plugin_str,
-			   crt_na_ofi_conf.noc_ip_str);
+		D_ASPRINTF(*string, "%s://%s:%d", plugin_str,
+			   crt_na_ofi_conf.noc_ip_str, port);
 	}
 	if (*string == NULL)
 		return -DER_NOMEM;

--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -444,6 +444,10 @@ crt_get_info_string(char **string)
 
 	if (!crt_na_dict[plugin].nad_port_bind) {
 		D_ASPRINTF(*string, "%s://", plugin_str);
+	} else if (crt_na_ofi_conf.noc_port == -1) {
+		/* OFI_PORT not speicified */
+		D_ASPRINTF(*string, "%s://%s", plugin_str,
+			   crt_na_ofi_conf.noc_ip_str);
 	} else {
 		port = crt_na_ofi_conf.noc_port;
 		crt_na_ofi_conf.noc_port++;

--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -449,10 +449,11 @@ crt_get_info_string(char **string)
 		D_ASPRINTF(*string, "%s://%s", plugin_str,
 			   crt_na_ofi_conf.noc_ip_str);
 	} else {
+		/* OFI_PORT is only for context 0 to use */
 		port = crt_na_ofi_conf.noc_port;
-		crt_na_ofi_conf.noc_port++;
-		D_ASPRINTF(*string, "%s://%s:%d", plugin_str,
-			   crt_na_ofi_conf.noc_ip_str, port);
+		crt_na_ofi_conf.noc_port = -1;
+		D_ASPRINTF(*string, "%s://%s", plugin_str,
+			   crt_na_ofi_conf.noc_ip_str);
 	}
 	if (*string == NULL)
 		return -DER_NOMEM;


### PR DESCRIPTION
If OFI_PORT is not specified, let mercury pick tcp ports. Currently cart
finds a free port then pass it to mercury. When many processes are
running on the same node, processes may use the same port, this will
cause problems.