### PR TITLE
CART-715 Implement common synchronization function to ensure server readiness

### DIFF
--- a/src/test/SConscript
+++ b/src/test/SConscript
@@ -64,6 +64,7 @@ def scons():
 
     tenv = env.Clone()
 
+    tenv.AppendUnique(CPPPATH=['#/src/cart'])
     tenv.AppendUnique(RPATH="$PREFIX/lib")
     tenv.AppendUnique(LIBS=['cart', 'gurt', 'pthread'])
     prereqs.require(tenv, 'crypto', 'pmix', 'mercury')

--- a/src/test/iv_client.c
+++ b/src/test/iv_client.c
@@ -60,8 +60,6 @@
 #include <sys/stat.h>
 #include "iv_common.h"
 
-#include "tests_common.h"
-
 static crt_context_t	g_crt_ctx;
 static crt_endpoint_t	g_server_ep;
 static char		g_hostname[100];

--- a/src/test/iv_common.h
+++ b/src/test/iv_common.h
@@ -39,9 +39,10 @@
  * This is a common file for IV client and IV server
  */
 #include <unistd.h>
-#include <gurt/common.h>
 #include <cart/api.h>
 #include <cart/iv.h>
+
+#include "tests_common.h"
 
 /* Describes internal structure of the value */
 #define MAX_DATA_SIZE 1024

--- a/src/test/iv_server.c
+++ b/src/test/iv_server.c
@@ -50,10 +50,7 @@
 #include <sys/mman.h>
 #include <fcntl.h>
 
-#include <gurt/common.h>
 #include <gurt/list.h>
-
-#include "tests_common.h"
 
 #define _SERVER
 #include "iv_common.h"
@@ -140,14 +137,6 @@ progress_function(void *data)
 	crt_context_destroy(*p_ctx, 1);
 
 	return NULL;
-}
-
-static void
-shutdown(void)
-{
-	DBG_PRINT("Joining progress thread\n");
-	pthread_join(g_progress_thread, NULL);
-	DBG_PRINT("Finished joining progress thread\n");
 }
 
 /* handler for RPC_SHUTDOWN */
@@ -1252,7 +1241,9 @@ int main(int argc, char **argv)
 	deinit_iv_storage();
 	deinit_iv();
 
-	shutdown();
+	DBG_PRINT("Joining progress thread\n");
+	pthread_join(g_progress_thread, NULL);
+	DBG_PRINT("Finished joining progress thread\n");
 
 	if (g_my_rank == 0) {
 		rc = crt_group_config_remove(NULL);

--- a/src/test/no_pmix_group_test.c
+++ b/src/test/no_pmix_group_test.c
@@ -46,7 +46,6 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <semaphore.h>
-#include <gurt/common.h>
 #include <cart/api.h>
 
 #include "tests_common.h"

--- a/src/test/no_pmix_launcher_client.c
+++ b/src/test/no_pmix_launcher_client.c
@@ -181,7 +181,7 @@ int main(int argc, char **argv)
 	sleep(2);
 
 	rc = wait_for_ranks(crt_ctx, grp, rank_list, NUM_SERVER_CTX - 1,
-			    NUM_SERVER_CTX, 30);
+			    NUM_SERVER_CTX, 5, 150);
 	if (rc != 0) {
 		D_ERROR("wait_for_ranks() failed; rc=%d\n", rc);
 		assert(0);

--- a/src/test/no_pmix_launcher_client.c
+++ b/src/test/no_pmix_launcher_client.c
@@ -176,7 +176,8 @@ int main(int argc, char **argv)
 	/* This is needed until hg cancel is fully working.
 	 * RPCs in wait_for_ranks are expected to fail
 	 * and needs to be cancelled correctly.
-	 * It should be removed when hg cancel is fixed - HG PR #284 */
+	 * It should be removed when hg cancel is fixed - HG PR #284
+	 */
 	sleep(2);
 
 	rc = wait_for_ranks(crt_ctx, grp, rank_list, NUM_SERVER_CTX - 1,

--- a/src/test/no_pmix_launcher_client.c
+++ b/src/test/no_pmix_launcher_client.c
@@ -46,11 +46,10 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <semaphore.h>
-#include <gurt/common.h>
 #include <cart/api.h>
 
-#include "no_pmix_launcher_common.h"
 #include "tests_common.h"
+#include "no_pmix_launcher_common.h"
 
 static void *
 progress_function(void *data)
@@ -150,9 +149,6 @@ int main(int argc, char **argv)
 		assert(0);
 	}
 
-	/* Give time for servers to start; need better way later on */
-	sleep(2);
-
 	rc = crt_group_size(grp, &grp_size);
 	if (rc != 0) {
 		D_ERROR("crt_group_size() failed; rc=%d\n", rc);
@@ -174,6 +170,19 @@ int main(int argc, char **argv)
 	rc = crt_group_psr_set(grp, rank_list->rl_ranks[0]);
 	if (rc != 0) {
 		D_ERROR("crt_group_psr_set() failed; rc=%d\n", rc);
+		assert(0);
+	}
+
+	/* This is needed until hg cancel is fully working.
+	 * RPCs in wait_for_ranks are expected to fail
+	 * and needs to be cancelled correctly.
+	 * It should be removed when hg cancel is fixed - HG PR #284 */
+	sleep(2);
+
+	rc = wait_for_ranks(crt_ctx, grp, rank_list, NUM_SERVER_CTX - 1,
+			    NUM_SERVER_CTX, 30);
+	if (rc != 0) {
+		D_ERROR("wait_for_ranks() failed; rc=%d\n", rc);
 		assert(0);
 	}
 

--- a/src/test/no_pmix_launcher_server.c
+++ b/src/test/no_pmix_launcher_server.c
@@ -173,7 +173,7 @@ int main(int argc, char **argv)
 
 	/* Wait until shutdown is issued and progress threads exit */
 	for (i = 0; i < NUM_SERVER_CTX; i++)
-	pthread_join(progress_thread[i], NULL);
+		pthread_join(progress_thread[i], NULL);
 
 	rc = crt_finalize();
 	if (rc != 0) {

--- a/src/test/no_pmix_launcher_server.c
+++ b/src/test/no_pmix_launcher_server.c
@@ -46,11 +46,10 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <semaphore.h>
-#include <gurt/common.h>
 #include <cart/api.h>
 
-#include "no_pmix_launcher_common.h"
 #include "tests_common.h"
+#include "no_pmix_launcher_common.h"
 
 static void *
 progress_function(void *data)
@@ -97,31 +96,11 @@ int main(int argc, char **argv)
 		assert(0);
 	}
 
-	rc = crt_proto_register(&my_proto_fmt);
-	if (rc != 0) {
-		D_ERROR("crt_proto_register() failed; rc=%d\n", rc);
-		assert(0);
-	}
-
 	grp = crt_group_lookup(NULL);
 	if (!grp) {
 		D_ERROR("Failed to lookup group\n");
 		assert(0);
 	}
-
-	for (i = 0; i < NUM_SERVER_CTX; i++) {
-		rc = crt_context_create(&crt_ctx[i]);
-		if (rc != 0) {
-			D_ERROR("crt_context_create() failed; rc=%d\n", rc);
-			assert(0);
-		}
-
-		rc = pthread_create(&progress_thread[i], 0,
-				progress_function, &crt_ctx[i]);
-		assert(rc == 0);
-	}
-
-	grp_cfg_file = getenv("CRT_L_GRP_CFG");
 
 	rc = crt_rank_self_set(my_rank);
 	if (rc != 0) {
@@ -129,6 +108,21 @@ int main(int argc, char **argv)
 			my_rank, rc);
 		assert(0);
 	}
+
+	rc = crt_context_create(&crt_ctx[0]);
+	if (rc != 0) {
+		D_ERROR("crt_context_create() failed; rc=%d\n", rc);
+		assert(0);
+	}
+
+	rc = pthread_create(&progress_thread[0], 0,
+			    progress_function, &crt_ctx[0]);
+	if (rc != 0){
+		D_ERROR("pthread_create() failed; rc=%d\n", rc);
+		assert(0);
+	}
+
+	grp_cfg_file = getenv("CRT_L_GRP_CFG");
 
 	rc = crt_rank_uri_get(grp, my_rank, 0, &my_uri);
 	if (rc != 0) {
@@ -138,14 +132,14 @@ int main(int argc, char **argv)
 
 	/* load group info from a config file and delete file upon return */
 	rc = tc_load_group_from_file(grp_cfg_file, crt_ctx[0], grp, my_rank,
-					true);
+                                        true);
 	if (rc != 0) {
 		D_ERROR("tc_load_group_from_file() failed; rc=%d\n", rc);
 		assert(0);
 	}
 
 	DBG_PRINT("self_rank=%d uri=%s grp_cfg_file=%s\n", my_rank,
-			my_uri, grp_cfg_file);
+		  my_uri, grp_cfg_file);
 	D_FREE(my_uri);
 
 	rc = crt_group_size(NULL, &grp_size);
@@ -154,9 +148,32 @@ int main(int argc, char **argv)
 		assert(0);
 	}
 
+	rc = crt_proto_register(&my_proto_fmt);
+	if (rc != 0) {
+		D_ERROR("crt_proto_register() failed; rc=%d\n", rc);
+		assert(0);
+	}
+
+	for (i = 1; i < NUM_SERVER_CTX; i++) {
+		rc = crt_context_create(&crt_ctx[i]);
+		if (rc != 0) {
+			D_ERROR("crt_context_create() failed; rc=%d\n", rc);
+			assert(0);
+		}
+	}
+
+	for (i = 1; i < NUM_SERVER_CTX; i++) {
+		rc = pthread_create(&progress_thread[i], 0,
+				    progress_function, &crt_ctx[i]);
+		if (rc != 0){
+			D_ERROR("pthread_create() failed; rc=%d\n", rc);
+			assert(0);
+		}
+	}
+
 	/* Wait until shutdown is issued and progress threads exit */
 	for (i = 0; i < NUM_SERVER_CTX; i++)
-		pthread_join(progress_thread[i], NULL);
+	pthread_join(progress_thread[i], NULL);
 
 	rc = crt_finalize();
 	if (rc != 0) {

--- a/src/test/no_pmix_launcher_server.c
+++ b/src/test/no_pmix_launcher_server.c
@@ -117,7 +117,7 @@ int main(int argc, char **argv)
 
 	rc = pthread_create(&progress_thread[0], 0,
 			    progress_function, &crt_ctx[0]);
-	if (rc != 0){
+	if (rc != 0) {
 		D_ERROR("pthread_create() failed; rc=%d\n", rc);
 		assert(0);
 	}
@@ -132,7 +132,7 @@ int main(int argc, char **argv)
 
 	/* load group info from a config file and delete file upon return */
 	rc = tc_load_group_from_file(grp_cfg_file, crt_ctx[0], grp, my_rank,
-                                        true);
+					true);
 	if (rc != 0) {
 		D_ERROR("tc_load_group_from_file() failed; rc=%d\n", rc);
 		assert(0);
@@ -165,7 +165,7 @@ int main(int argc, char **argv)
 	for (i = 1; i < NUM_SERVER_CTX; i++) {
 		rc = pthread_create(&progress_thread[i], 0,
 				    progress_function, &crt_ctx[i]);
-		if (rc != 0){
+		if (rc != 0) {
 			D_ERROR("pthread_create() failed; rc=%d\n", rc);
 			assert(0);
 		}

--- a/src/test/tests_common.h
+++ b/src/test/tests_common.h
@@ -64,8 +64,8 @@ sync_timedwait(struct wfr_status *wfrs, int sec, int line_number)
 	deadline.tv_sec += sec;
 
 	rc = sem_timedwait(&wfrs->sem, &deadline);
-	if (rc != 0)
-		wfrs->rc = rc;
+	D_ASSERTF(rc == 0, "Sync timed out at line %d rc: %d\n",
+		  line_number, rc);
 }
 
 static void

--- a/src/test/tests_common.h
+++ b/src/test/tests_common.h
@@ -63,9 +63,6 @@ sync_timedwait(struct wfr_status *wfrs, int sec, int line_number)
 
 	deadline.tv_sec += sec;
 
-	/* If this fails timeout, return and retry
-	 * else, retry based on status of rpc
-	 */
 	rc = sem_timedwait(&wfrs->sem, &deadline);
 	if (rc != 0)
 		wfrs->rc = rc;
@@ -147,6 +144,8 @@ wait_for_ranks(crt_context_t ctx, crt_group_t *grp, d_rank_list_t *rank_list,
 
 		if (rc == 0)
 			sync_timedwait(&ws, 120, __LINE__);
+		else
+			ws.rc = rc;
 
 		while (ws.rc != 0 && time_s < total_timeout) {
 			rc = crt_req_create(ctx, &server_ep,
@@ -169,6 +168,8 @@ wait_for_ranks(crt_context_t ctx, crt_group_t *grp, d_rank_list_t *rank_list,
 
 			if (rc == 0)
 				sync_timedwait(&ws, 120, __LINE__);
+			else
+				ws.rc = rc;
 
 			rc = d_gettime(&t2);
 			D_ASSERTF(rc == 0, "d_gettime() failed; rc=%d\n", rc);


### PR DESCRIPTION
A new function "wait_for_ranks" in tests_common that can be used in tests
to ensure server readiness before starting main test. The function uses
internal RPC to ping server until all rank:tag are ready.