### PR TITLE
DAOS-2469 rpc: refine crt_req_abort handling

### DIFF
--- a/src/cart/crt_context.c
+++ b/src/cart/crt_context.c
@@ -712,7 +712,9 @@ crt_req_timeout_hdlr(struct crt_rpc_priv *rpc_priv)
 		D_ASSERT(ul_req != NULL);
 		ul_in = crt_req_get(ul_req);
 		RPC_ERROR(rpc_priv,
-			  "timedout due to URI_LOOKUP to group %s, rank %d through PSR %d timedout\n",
+			  "timedout due to URI_LOOKUP(rpc_priv %p) to group %s,"
+			  "rank %d through PSR %d timedout\n",
+			  container_of(ul_req, struct crt_rpc_priv, crp_pub),
 			  ul_in->ul_grp_id,
 			  ul_in->ul_rank,
 			  ul_req->cr_ep.ep_rank);
@@ -720,7 +722,7 @@ crt_req_timeout_hdlr(struct crt_rpc_priv *rpc_priv)
 		/*
 		 * don't crt_rpc_complete rpc_priv here, because crt_req_abort
 		 * above will lead to ul_req's completion callback --
-		 * crt_req_uri_lookup_psr_cb() be called inside there will
+		 * crt_req_uri_lookup_by_rpc_cb() be called inside there will
 		 * complete this rpc_priv.
 		 */
 		/* crt_rpc_complete(rpc_priv, -DER_PROTO); */

--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -1225,14 +1225,6 @@ crt_hg_req_cancel(struct crt_rpc_priv *rpc_priv)
 	if (!rpc_priv->crp_hg_hdl)
 		D_GOTO(out, rc = -DER_INVAL);
 
-	if (rpc_priv->crp_state != RPC_STATE_REQ_SENT ||
-	    rpc_priv->crp_on_wire != 1) {
-		RPC_TRACE(DB_NET, rpc_priv,
-			  "rpc_priv->crp_state %#x, RPC not sent, skipping.\n",
-			  rpc_priv->crp_state);
-		return rc;
-	}
-
 	hg_ret = HG_Cancel(rpc_priv->crp_hg_hdl);
 	if (hg_ret != HG_SUCCESS) {
 		RPC_ERROR(rpc_priv, "crt_hg_req_cancel failed, hg_ret: %d\n",

--- a/src/cart/crt_rpc.h
+++ b/src/cart/crt_rpc.h
@@ -151,6 +151,7 @@ struct crt_corpc_info {
 };
 
 struct crt_rpc_priv {
+	crt_rpc_t		crp_pub; /* public part */
 	/* link to crt_ep_inflight::epi_req_q/::epi_req_waitq */
 	d_list_t		crp_epi_link;
 	/* tmp_link used in crt_context_req_untrack */
@@ -167,7 +168,6 @@ struct crt_rpc_priv {
 	void			*crp_arg; /* argument for crp_complete_cb */
 	struct crt_ep_inflight	*crp_epi; /* point back to inflight ep */
 
-	crt_rpc_t		crp_pub; /* public part */
 	crt_rpc_state_t		crp_state; /* RPC state */
 	hg_handle_t		crp_hg_hdl; /* HG request handle */
 	hg_addr_t		crp_hg_addr; /* target na address */


### PR DESCRIPTION
1) If the RPC is inflight then depend on HG_Cancel() that it will
   trigger the RPC's completion.
2) For other cases, trigger the RPC's completion only once.

The motivation is to fix a timeout caused hang for DAOS-2469, in that
case the URI_LOOKUP timedout then the original RPC hang, it should due
to in crt_req_timeout_hdlr() it calls crt_req_abort() but that did not
trigger RPC completion.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>