### PR TITLE
CRT-760 rpc: optimization RPC serialization pipeline

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -52,7 +52,7 @@ DESIRED_FLAGS = ['-Wno-gnu-designator',
                  '-Wno-gnu-zero-variadic-macro-arguments',
                  '-Wno-tautological-constant-out-of-range-compare']
 
-CART_VERSION = "1.2.0"
+CART_VERSION = "1.3.0"
 
 def save_build_info(env, prereqs, platform):
     """Save the build information"""

--- a/cart.spec
+++ b/cart.spec
@@ -1,7 +1,7 @@
 %define carthome %{_exec_prefix}/lib/%{name}
 
 Name:          cart
-Version:       1.2.0
+Version:       1.3.0
 Release:       1%{?relval}%{?dist}
 Summary:       CaRT
 
@@ -122,6 +122,9 @@ ln %{?buildroot}%{carthome}/{TESTING/.build_vars,.build_vars-Linux}.sh
 %{carthome}/.build_vars-Linux.sh
 
 %changelog
+* Wed Sep 25 2019 Dmitry Eremin <dmitry.eremin@intel.com>
+- Libcart version 1.3.0
+
 * Mon Sep 23 2019 Jeffrey V. Olivier <jeffrey.v.olivier@intel.com>
 - Libcart version 1.2.0
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+cart (1.3.0-1) unstable; urgency=medium
+
+  [ Dmitry Eremin ]
+  * 1.3.0 version of CaRT
+
+ -- Dmitry Eremin <dmitry.eremin@intel.com>  Wed, 25 Sep 2019 22:20:44 +0000
+
 cart (1.2.0-1) unstable; urgency=medium
 
   [ Jeffrey Olivier ]

--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -905,10 +905,10 @@ crt_rpc_handler_common(hg_handle_t hg_hdl)
 	}
 
 	D_ASSERT(rpc_priv->crp_srv != 0);
-	D_ASSERT(opc_info->coi_input_size == rpc_pub->cr_input_size);
 	if (rpc_pub->cr_input_size > 0) {
 		D_ASSERT(rpc_pub->cr_input != NULL);
 		D_ASSERT(opc_info->coi_crf != NULL);
+		D_ASSERT(opc_info->coi_crf->crf_size_in == rpc_pub->cr_input_size);
 		/* corresponding to HG_Free_input in crt_hg_req_destroy */
 		rc = crt_hg_unpack_body(rpc_priv, proc);
 		if (rc == 0) {

--- a/src/cart/crt_hg.h
+++ b/src/cart/crt_hg.h
@@ -155,7 +155,6 @@ int crt_hg_get_addr(hg_class_t *hg_class, char *addr_str, size_t *str_size);
 int crt_rpc_handler_common(hg_handle_t hg_hdl);
 
 /* crt_hg_proc.c */
-int crt_proc_corpc_hdr(crt_proc_t proc, struct crt_corpc_hdr *hdr);
 int crt_hg_unpack_header(hg_handle_t hg_hdl, struct crt_rpc_priv *rpc_priv,
 			 crt_proc_t *proc);
 void crt_hg_header_copy(struct crt_rpc_priv *in, struct crt_rpc_priv *out);

--- a/src/cart/crt_internal_types.h
+++ b/src/cart/crt_internal_types.h
@@ -232,8 +232,6 @@ struct crt_opc_info {
 
 	crt_rpc_cb_t		 coi_rpc_cb;
 	struct crt_corpc_ops	*coi_co_ops;
-	size_t			 coi_input_size;
-	size_t			 coi_output_size;
 
 	/* Sizes/offset used when buffers are part of the same allocation
 	 * as the rpc descriptor.

--- a/src/cart/crt_rpc.h
+++ b/src/cart/crt_rpc.h
@@ -218,15 +218,16 @@ struct crt_rpc_priv {
 		0, &CQF_crt_grp_create,					\
 		crt_hdlr_grp_create, &crt_grp_create_co_ops),		\
 	X(CRT_OPC_GRP_DESTROY,						\
-		0,  &CQF_crt_grp_destroy,				\
+		0, &CQF_crt_grp_destroy,				\
 		crt_hdlr_grp_destroy, &crt_grp_destroy_co_ops),		\
 	X(CRT_OPC_URI_LOOKUP,						\
 		0, &CQF_crt_uri_lookup,					\
 		crt_hdlr_uri_lookup, NULL),				\
 	X(CRT_OPC_SELF_TEST_BOTH_EMPTY,					\
-		0, NULL, crt_self_test_msg_handler, NULL),		\
+		0, NULL,						\
+		crt_self_test_msg_handler, NULL),			\
 	X(CRT_OPC_SELF_TEST_SEND_ID_REPLY_IOV,				\
-		0,  &CQF_crt_st_send_id_reply_iov,			\
+		0, &CQF_crt_st_send_id_reply_iov,			\
 		crt_self_test_msg_handler, NULL),			\
 	X(CRT_OPC_SELF_TEST_SEND_IOV_REPLY_EMPTY,			\
 		0, &CQF_crt_st_send_iov_reply_empty,			\
@@ -256,9 +257,11 @@ struct crt_rpc_priv {
 		0, &CQF_crt_st_status_req,				\
 		crt_self_test_status_req_handler, NULL),		\
 	X(CRT_OPC_IV_FETCH,						\
-		0, &CQF_crt_iv_fetch, crt_hdlr_iv_fetch, NULL),		\
+		0, &CQF_crt_iv_fetch,					\
+		crt_hdlr_iv_fetch, NULL),				\
 	X(CRT_OPC_IV_UPDATE,						\
-		0, &CQF_crt_iv_update, crt_hdlr_iv_update, NULL),	\
+		0, &CQF_crt_iv_update,					\
+		crt_hdlr_iv_update, NULL),				\
 	X(CRT_OPC_IV_SYNC,						\
 		0, &CQF_crt_iv_sync,					\
 		crt_hdlr_iv_sync, &crt_iv_sync_co_ops),			\
@@ -278,21 +281,23 @@ struct crt_rpc_priv {
 		0, &CQF_crt_ctl_get_uri_cache,				\
 		crt_hdlr_ctl_get_uri_cache, NULL),			\
 	X(CRT_OPC_CTL_LS,						\
-		0, &CQF_crt_ctl_ep_ls, crt_hdlr_ctl_ls, NULL),		\
+		0, &CQF_crt_ctl_ep_ls,					\
+		crt_hdlr_ctl_ls, NULL),					\
 	X(CRT_OPC_CTL_GET_HOSTNAME,					\
 		0, &CQF_crt_ctl_get_host,				\
 		crt_hdlr_ctl_get_hostname, NULL),			\
 	X(CRT_OPC_CTL_GET_PID,						\
-		0, &CQF_crt_ctl_get_pid, crt_hdlr_ctl_get_pid, NULL),	\
+		0, &CQF_crt_ctl_get_pid,				\
+		crt_hdlr_ctl_get_pid, NULL),				\
 	X(CRT_OPC_PROTO_QUERY,						\
-		0, &CQF_crt_proto_query, crt_hdlr_proto_query, NULL),	\
+		0, &CQF_crt_proto_query,				\
+		crt_hdlr_proto_query, NULL),				\
 	X(CRT_OPC_CTL_FI_TOGGLE,					\
 		0, &CQF_crt_ctl_fi_toggle,				\
 		crt_hdlr_ctl_fi_toggle, NULL),				\
 	X(CRT_OPC_CTL_FI_SET_ATTR,					\
-		0, &CQF_crt_ctl_fi_attr_set, crt_hdlr_ctl_fi_attr_set,	\
-		NULL)
-
+		0, &CQF_crt_ctl_fi_attr_set,				\
+		crt_hdlr_ctl_fi_attr_set, NULL)
 
 /* Define for RPC enum population below */
 #define X(a, b, c, d, e) a
@@ -582,24 +587,6 @@ CRT_RPC_DECLARE(crt_ctl_fi_attr_set, CRT_ISEQ_CTL_FI_ATTR_SET,
 
 CRT_RPC_DECLARE(crt_ctl_fi_toggle,
 		CRT_ISEQ_CTL_FI_TOGGLE, CRT_OSEQ_CTL_FI_TOGGLE)
-
-/* CRT internal RPC format definitions */
-struct crt_internal_rpc {
-	/* Name of the RPC */
-	const char		*ir_name;
-	/* Operation code associated with the RPC */
-	crt_opcode_t		 ir_opc;
-	/* RPC version */
-	int			 ir_ver;
-	/* Operation flags, TBD */
-	int			 ir_flags;
-	/* RPC request format */
-	struct crt_req_format	*ir_req_fmt;
-	/* RPC handler */
-	crt_rpc_cb_t		 ir_hdlr;
-	/* collective ops */
-	struct crt_corpc_ops	*ir_co_ops;
-};
 
 /* Internal macros for crt_req_(add|dec)ref from within cart.  These take
  * a crt_internal_rpc pointer and provide better logging than the public

--- a/src/test/test_swim_net.c
+++ b/src/test/test_swim_net.c
@@ -61,37 +61,12 @@
 #define CRT_OSEQ_RPC_SWIM	/* output fields */
 
 static int
-crt_proc_struct_swim_member_state(crt_proc_t proc,
-				  struct swim_member_state *data)
-{
-	int rc;
-
-	rc = crt_proc_uint64_t(proc, &data->sms_incarnation);
-	if (rc != 0)
-		return -DER_HG;
-
-	rc = crt_proc_uint32_t(proc, &data->sms_status);
-	if (rc != 0)
-		return -DER_HG;
-
-	rc = crt_proc_uint32_t(proc, &data->sms_padding);
-	if (rc != 0)
-		return -DER_HG;
-
-	return 0;
-}
-
-static int
 crt_proc_struct_swim_member_update(crt_proc_t proc,
 				   struct swim_member_update *data)
 {
 	int rc;
 
-	rc = crt_proc_uint64_t(proc, &data->smu_id);
-	if (rc != 0)
-		return -DER_HG;
-
-	rc = crt_proc_struct_swim_member_state(proc, &data->smu_state);
+	rc = crt_proc_memcpy(proc, data, sizeof(*data));
 	if (rc != 0)
 		return -DER_HG;
 

--- a/src/utest/test_linkage.cpp
+++ b/src/utest/test_linkage.cpp
@@ -54,14 +54,6 @@
 
 using namespace std;
 
-struct crt_msg_field *linkage_test_rpc_in[] = {
-	&CMF_UINT32,
-};
-
-struct crt_msg_field *linkage_test_rpc_out[] = {
-	&CMF_UINT32,
-};
-
 #define TEST_LINKAGE_BASE 0x010000000
 #define TEST_LINKAGE_VER  0
 

--- a/utils/test_cart_lib.sh
+++ b/utils/test_cart_lib.sh
@@ -57,7 +57,7 @@ else
     echo "checking libcart.so"
     nm -g "${SL_PREFIX}/lib/libcart.so" |
         grep -v " U " |  grep -v " w " |  grep -v " crt_" | grep -v " swim_" |
-        grep -v "D CMF_" | grep -v "D CQF_" |
+        grep -v " D CQF_" |
         grep -v " D _edata" | grep -v " T _fini" | grep -v " T _init" |
         grep -v " B __bss_start" | grep -v " B _end";
     if [ $? -ne 1 ]; then RC=1; fi


### PR DESCRIPTION
* remove old unused code (simplify serialization pipeline)
* add new RAW member in macro to copy whole struct
* make few functions static
* copy whole struct insted of coping by each member