### PR TITLE
CART-763 corpc: New optional co_post_reply callback

### DIFF
--- a/src/cart/crt_corpc.c
+++ b/src/cart/crt_corpc.c
@@ -786,8 +786,15 @@ aggregate_done:
 
 	D_SPIN_UNLOCK(&parent_rpc_priv->crp_lock);
 
-	if (req_done)
+	if (req_done) {
+		RPC_ADDREF(parent_rpc_priv);
 		crt_corpc_complete(parent_rpc_priv);
+
+		if (co_ops->co_post_reply)
+			co_ops->co_post_reply(&parent_rpc_priv->crp_pub,
+					co_info->co_priv);
+		RPC_DECREF(parent_rpc_priv);
+	}
 
 out:
 	return;

--- a/src/include/cart/api.h
+++ b/src/include/cart/api.h
@@ -964,6 +964,23 @@ struct crt_corpc_ops {
 	 *				cause CORPC to abort.
 	 */
 	int (*co_pre_forward)(crt_rpc_t *rpc, void *arg);
+
+	/**
+	 * Collective RPC post-reply callback.
+	 * This is an optional callback. If specified, it will execute after
+	 * reply is sent to parent (after co_aggregate executes).
+	 *
+	 * \param[in] rpc		the rpc structure of the parent
+	 * \param[in] arg		the private pointer, valid only on
+	 *				collective RPC initiator (same as the
+	 *				priv pointer passed in for
+	 *				crt_corpc_req_create).
+	 *				Can be used to share data between
+	 *				co_aggregate and co_post_reply  when
+	 *				executing those callbacks on the same
+	 *				node.
+	 */
+	int (*co_post_reply)(crt_rpc_t *rpc, void *arg);
 };
 
 /**


### PR DESCRIPTION
New optional co_post_reply callback to be executed after CORPC
response is sent to the parent (post co_aggregate).

Can be used for cleaning data allocated in co_aggregate callback.

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>