### PR TITLE
DAOS-3109 test: D_ASSERTF ignores alternate assert registration

### DIFF
--- a/src/include/gurt/debug.h
+++ b/src/include/gurt/debug.h
@@ -329,6 +329,8 @@ int d_register_alt_assert(void (*alt_assert)(const int, const char*,
 do {									\
 	if (!(cond))							\
 		D_FATAL(fmt, ## __VA_ARGS__);				\
+	if (d_alt_assert != NULL)					\
+		d_alt_assert((int64_t)(cond), #cond, __FILE__, __LINE__);\
 	assert(cond);							\
 } while (0)
 

--- a/src/utest/test_gurt.c
+++ b/src/utest/test_gurt.c
@@ -1835,5 +1835,7 @@ main(int argc, char **argv)
 		cmocka_unit_test(test_gurt_atomic),
 	};
 
+	d_register_alt_assert(mock_assert);
+
 	return cmocka_run_group_tests(tests, init_tests, fini_tests);
 }

--- a/src/utest/utest_hlc.c
+++ b/src/utest/utest_hlc.c
@@ -119,5 +119,7 @@ int main(int argc, char **argv)
 		cmocka_unit_test(test_hlc_get_msg),
 	};
 
+	d_register_alt_assert(mock_assert);
+
 	return cmocka_run_group_tests(tests, init_tests, fini_tests);
 }


### PR DESCRIPTION
In order to catch internal assertions in cmocka unit tests,
we need to register mock_assert.   This doesn't work when
the assertion is D_ASSERTF because that code path ignores
the alternate assert function setting.

Also, register mock_assert in unit tests so internal assertions
are properly caught and reported by cmocka.  This doesn't
work for test_linkage.cpp but that is a separate issue that
doesn't need to be solved for this ticket

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>