### PR TITLE
CART-89 build: Fix a warning with later versions of clang

### DIFF
--- a/src/include/cart/api.h
+++ b/src/include/cart/api.h
@@ -627,9 +627,16 @@ crt_ep_abort(crt_endpoint_t *ep);
 #if __GNUC__ >= 8 /* warning was introduced in version 8 of GCC */
 #define CRT_DISABLE_SIZEOF_POINTER_DIV					\
 	_Pragma("GCC diagnostic ignored \"-Wsizeof-pointer-div\"")
-#else /* __GNUC__ < 8 */
+#elif defined(__has_warning) /* clang check */
+#if __has_warning("-Wsizeof-pointer-div")
+#define CRT_DISABLE_SIZEOF_POINTER_DIV					\
+	_Pragma("GCC diagnostic ignored \"-Wsizeof-pointer-div\"")
+#endif /* clang check available */
+#endif /* Platforms with the warning */
+
+#if !defined(CRT_DISABLE_SIZEOF_POINTER_DIV)
 #define CRT_DISABLE_SIZEOF_POINTER_DIV
-#endif /* __GNUC__ >= 8 */
+#endif /* platforms without this warning */
 
 #define CRT_RPC_DEFINE(rpc_name, fields_in, fields_out)			\
 	CRT_GEN_PROC(rpc_name##_in, fields_in)				\
@@ -981,6 +988,7 @@ struct crt_corpc_ops {
 	 *				node.
 	 */
 	int (*co_post_reply)(crt_rpc_t *rpc, void *arg);
+
 };
 
 /**


### PR DESCRIPTION
On Fedora 30, I get the warning disabled by the pragma in the
cart api.   It's warning when NULL is passed to the macro.
The warning is incorrect in this case.   Clang has a macro
for checking whether a warning is enabled.  Use this macro
to disable the warning on demand.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>