### PR TITLE
CART-89 build: Create D_HAS_WARNING macro

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -52,7 +52,7 @@ DESIRED_FLAGS = ['-Wno-gnu-designator',
                  '-Wno-gnu-zero-variadic-macro-arguments',
                  '-Wno-tautological-constant-out-of-range-compare']
 
-CART_VERSION = "1.1.0"
+CART_VERSION = "1.2.0"
 
 def save_build_info(env, prereqs, platform):
     """Save the build information"""

--- a/cart.spec
+++ b/cart.spec
@@ -1,7 +1,7 @@
 %define carthome %{_exec_prefix}/lib/%{name}
 
 Name:          cart
-Version:       1.1.0
+Version:       1.2.0
 Release:       1%{?relval}%{?dist}
 Summary:       CaRT
 
@@ -122,6 +122,9 @@ ln %{?buildroot}%{carthome}/{TESTING/.build_vars,.build_vars-Linux}.sh
 %{carthome}/.build_vars-Linux.sh
 
 %changelog
+* Mon Sep 23 2019 Jeffrey V. Olivier <jeffrey.v.olivier@intel.com>
+- Libcart version 1.2.0
+
 * Thu Aug 08 2019 Alexander A. Oganezov <alexander.a.oganezov@intel.com>
 - Libcart version 1.1.0
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+cart (1.2.0-1) unstable; urgency=medium
+
+  [ Jeffrey Olivier ]
+  * 1.2.0 version of CaRT
+
+ -- Jeffrey Olivier <jeffrey.v.olivier@intel.com>  Mon, 23 Sep 2019 14:20:44 +0000
+
 cart (1.1.0-1) unstable; urgency=medium
 
   [ Alexander Oganezov ]

--- a/src/include/cart/api.h
+++ b/src/include/cart/api.h
@@ -624,12 +624,13 @@ crt_ep_abort(crt_endpoint_t *ep);
 		CRT_GEN_STRUCT(rpc_name##_out, fields_out), )		\
 	extern struct crt_req_format CQF_##rpc_name;
 
-#if __GNUC__ >= 8 /* warning was introduced in version 8 of GCC */
+/* warning was introduced in version 8 of GCC */
+#if D_HAS_WARNING(8, "-Wsizeof-pointer-div")
 #define CRT_DISABLE_SIZEOF_POINTER_DIV					\
 	_Pragma("GCC diagnostic ignored \"-Wsizeof-pointer-div\"")
-#else /* __GNUC__ < 8 */
+#else /* warning not available */
 #define CRT_DISABLE_SIZEOF_POINTER_DIV
-#endif /* __GNUC__ >= 8 */
+#endif /* warning is available */
 
 #define CRT_RPC_DEFINE(rpc_name, fields_in, fields_out)			\
 	CRT_GEN_PROC(rpc_name##_in, fields_in)				\

--- a/src/include/cart/types.h
+++ b/src/include/cart/types.h
@@ -55,6 +55,12 @@
 
 #include <boost/preprocessor.hpp>
 
+#if defined(__has_warning)
+#define D_HAS_WARNING(gcc_version, warning)	__has_warning(warning)
+#else  /* !defined(__has_warning) */
+#define D_HAS_WARNING(gcc_version, warning) (__GNUC__ >= gcc_version)
+#endif /* defined(__has_warning) */
+
 /**
  * Initialization options passed during crt_init() call.
  *

--- a/src/include/cart/types.h
+++ b/src/include/cart/types.h
@@ -55,12 +55,6 @@
 
 #include <boost/preprocessor.hpp>
 
-#if defined(__has_warning)
-#define D_HAS_WARNING(gcc_version, warning)	__has_warning(warning)
-#else  /* !defined(__has_warning) */
-#define D_HAS_WARNING(gcc_version, warning) ((gcc_version) <= __GNUC__)
-#endif /* defined(__has_warning) */
-
 /**
  * Initialization options passed during crt_init() call.
  *

--- a/src/include/cart/types.h
+++ b/src/include/cart/types.h
@@ -58,7 +58,7 @@
 #if defined(__has_warning)
 #define D_HAS_WARNING(gcc_version, warning)	__has_warning(warning)
 #else  /* !defined(__has_warning) */
-#define D_HAS_WARNING(gcc_version, warning) (__GNUC__ >= gcc_version)
+#define D_HAS_WARNING(gcc_version, warning) ((gcc_version) <= __GNUC__)
 #endif /* defined(__has_warning) */
 
 /**

--- a/src/include/gurt/types.h
+++ b/src/include/gurt/types.h
@@ -67,6 +67,12 @@
 extern "C" {
 #endif
 
+#if defined(__has_warning)
+#define D_HAS_WARNING(gcc_version, warning)	__has_warning(warning)
+#else  /* !defined(__has_warning) */
+#define D_HAS_WARNING(gcc_version, warning) ((gcc_version) <= __GNUC__)
+#endif /* defined(__has_warning) */
+
 /**
  * hide the dark secret that uuid_t is an array not a structure.
  */


### PR DESCRIPTION
Add a macro to do either clang check or GCC version check
in one step

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>