### PR TITLE
CART-759 corpc: Incorrect tree generation for secondary groups

### DIFF
--- a/src/cart/crt_corpc.c
+++ b/src/cart/crt_corpc.c
@@ -803,7 +803,6 @@ out:
 int
 crt_corpc_req_hdlr(struct crt_rpc_priv *rpc_priv)
 {
-	d_rank_list_t		*membs;
 	struct crt_corpc_info	*co_info;
 	d_rank_list_t		*children_rank_list = NULL;
 	d_rank_t		 grp_rank;
@@ -882,7 +881,6 @@ crt_corpc_req_hdlr(struct crt_rpc_priv *rpc_priv)
 		D_GOTO(forward_done, rc);
 	}
 
-	membs = grp_priv_get_membs(co_info->co_grp_priv);
 
 	/* firstly forward RPC to children if any */
 	for (i = 0; i < co_info->co_child_num; i++) {
@@ -895,7 +893,10 @@ crt_corpc_req_hdlr(struct crt_rpc_priv *rpc_priv)
 		 * Convert here to secondary ranks.
 		 */
 		if (CRT_PMIX_ENABLED() && !co_info->co_grp_priv->gp_primary) {
-			uint32_t	 idx;
+			uint32_t	 	idx;
+			d_rank_list_t		*membs;
+
+			membs = grp_priv_get_membs(co_info->co_grp_priv);
 
 			rc = d_idx_in_rank_list(membs,
 				children_rank_list->rl_ranks[i], &idx);
@@ -912,6 +913,7 @@ crt_corpc_req_hdlr(struct crt_rpc_priv *rpc_priv)
 		} else {
 			tgt_ep.ep_rank = children_rank_list->rl_ranks[i];
 		}
+
 		tgt_ep.ep_grp = &co_info->co_grp_priv->gp_pub;
 
 		rc = crt_req_create_internal(rpc_priv->crp_pub.cr_ctx, &tgt_ep,

--- a/src/cart/crt_corpc.c
+++ b/src/cart/crt_corpc.c
@@ -893,8 +893,8 @@ crt_corpc_req_hdlr(struct crt_rpc_priv *rpc_priv)
 		 * Convert here to secondary ranks.
 		 */
 		if (CRT_PMIX_ENABLED() && !co_info->co_grp_priv->gp_primary) {
-			uint32_t	 	idx;
-			d_rank_list_t		*membs;
+			uint32_t	idx;
+			d_rank_list_t	*membs;
 
 			membs = grp_priv_get_membs(co_info->co_grp_priv);
 

--- a/src/cart/crt_tree.c
+++ b/src/cart/crt_tree.c
@@ -59,6 +59,10 @@ crt_get_filtered_grp_rank_list(struct crt_grp_priv *grp_priv, uint32_t grp_ver,
 	if (CRT_PMIX_ENABLED()) {
 		live_ranks = grp_priv_get_live_ranks(grp_priv);
 		membs = grp_priv_get_membs(grp_priv);
+
+		/* Note: In pmi case liver_ranks/membs contain primary ranks */
+		root = grp_priv_get_primary_rank(grp_priv, root);
+		self = grp_priv_get_primary_rank(grp_priv, self);
 	} else {
 		membs = grp_priv_get_membs(grp_priv);
 		live_ranks = membs;

--- a/src/cart/crt_tree.c
+++ b/src/cart/crt_tree.c
@@ -60,7 +60,7 @@ crt_get_filtered_grp_rank_list(struct crt_grp_priv *grp_priv, uint32_t grp_ver,
 		live_ranks = grp_priv_get_live_ranks(grp_priv);
 		membs = grp_priv_get_membs(grp_priv);
 
-		/* Note: In pmi case liver_ranks/membs contain primary ranks */
+		/* Note: In PMIX case liver_ranks/membs contain primary ranks */
 		root = grp_priv_get_primary_rank(grp_priv, root);
 		self = grp_priv_get_primary_rank(grp_priv, self);
 	} else {

--- a/src/test/no_pmix_group_test.c
+++ b/src/test/no_pmix_group_test.c
@@ -558,6 +558,21 @@ int main(int argc, char **argv)
 	/* TODO: This will be replaced by proper sync when CART-715 is done */
 	sleep(10);
 
+	rc = crt_group_ranks_get(grp, &rank_list);
+	if (rc != 0) {
+		D_ERROR("crt_group_ranks_get() failed; rc=%d\n", rc);
+		assert(0);
+	}
+
+	rc = wait_for_ranks(crt_ctx[0], grp, rank_list, 0,
+			NUM_SERVER_CTX, 10, 100.0);
+	if (rc != 0) {
+		D_ERROR("wait_for_ranks() failed; rc=%d\n", rc);
+		assert(0);
+	}
+
+	D_FREE(rank_list->rl_ranks);
+	D_FREE(rank_list);
 	/* This section only executes for my_rank == 0 */
 
 	DBG_PRINT("------------------------------------\n");

--- a/test/corpc/cart_corpc_five_node.yaml
+++ b/test/corpc/cart_corpc_five_node.yaml
@@ -28,9 +28,9 @@ tests: !mux
     srv_arg: "--name service_group --is_service"
     srv_env: ""
     srv_ppn: "5"
-  #corpc_version:
-    #name: corpc_version
-    #srv_bin: tests/test_corpc_version
-    #srv_arg: "--name service_group --is_service"
-    #srv_env: ""
-    #srv_ppn: "5"
+  corpc_version:
+    name: corpc_version
+    srv_bin: tests/test_corpc_version
+    srv_arg: "--name service_group --is_service"
+    srv_env: ""
+    srv_ppn: "5"

--- a/test/corpc/cart_corpc_one_node.yaml
+++ b/test/corpc/cart_corpc_one_node.yaml
@@ -27,12 +27,12 @@ tests: !mux
     srv_arg: "--name service_group --is_service"
     srv_env: ""
     srv_ppn: "5"
-  #corpc_version:
-    #name: corpc_version
-    #srv_bin: tests/test_corpc_version
-    #srv_arg: "--name service_group --is_service"
-    #srv_env: ""
-    #srv_ppn: "5"
+  corpc_version:
+    name: corpc_version
+    srv_bin: tests/test_corpc_version
+    srv_arg: "--name service_group --is_service"
+    srv_env: ""
+    srv_ppn: "5"
   corpc_exclusive:
     name: corpc_exclusive
     srv_bin: tests/test_corpc_exclusive

--- a/test/corpc/cart_corpc_two_node.yaml
+++ b/test/corpc/cart_corpc_two_node.yaml
@@ -28,9 +28,9 @@ tests: !mux
     srv_arg: "--name service_group --is_service"
     srv_env: ""
     srv_ppn: "5"
-  #corpc_version:
-    #name: corpc_version
-    #srv_bin: tests/test_corpc_version
-    #srv_arg: "--name service_group --is_service"
-    #srv_env: ""
-    #srv_ppn: "5"
+  corpc_version:
+    name: corpc_version
+    srv_bin: tests/test_corpc_version
+    srv_arg: "--name service_group --is_service"
+    srv_env: ""
+    srv_ppn: "5"


### PR DESCRIPTION
- CORPC tree was not being generated correctly for secondary groups
when running in PMIX enabled mode.
- Re-enabled corpc version test that hit issues previously due to this
bug

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>