### PR TITLE
CART-89 logging: add more logging

### DIFF
--- a/src/cart/crt_context.c
+++ b/src/cart/crt_context.c
@@ -251,6 +251,7 @@ crt_context_create(crt_context_t *crt_ctx)
 	D_RWLOCK_UNLOCK(&crt_gdata.cg_rwlock);
 
 	*crt_ctx = (crt_context_t)ctx;
+	D_DEBUG(DB_TRACE, "created context (idx %d)\n", ctx->cc_idx);
 
 out:
 	return rc;
@@ -497,6 +498,8 @@ crt_context_destroy(crt_context_t crt_ctx, int force)
 	D_RWLOCK_UNLOCK(&crt_gdata.cg_rwlock);
 
 	D_MUTEX_DESTROY(&ctx->cc_mutex);
+	D_DEBUG(DB_TRACE, "destroyed context (idx %d, force %d)\n",
+		ctx->cc_idx, force);
 	D_FREE(ctx);
 
 out:

--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -896,7 +896,7 @@ crt_rpc_handler_common(hg_handle_t hg_hdl)
 	rpc_priv->crp_opc_info = opc_info;
 	rpc_pub->cr_opc = rpc_tmp.crp_pub.cr_opc;
 
-	D_DEBUG(DB_TRACE, rpc_priv,
+	D_DEBUG(DB_TRACE,
 		"(opc: %#x rpc_pub: %p) allocated per RPC request received.\n",
 		rpc_priv->crp_opc_info->coi_opc,
 		&rpc_priv->crp_pub);

--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -857,10 +857,9 @@ crt_rpc_handler_common(hg_handle_t hg_hdl)
 	 * correctly logged.
 	 */
 	rpc_tmp.crp_pub.cr_opc = opc;
-	rpc_tmp.crp_pub.cr_ep.ep_rank = rpc_tmp.crp_req_hdr.cch_rank;
-	rpc_tmp.crp_pub.cr_ep.ep_tag = rpc_tmp.crp_req_hdr.cch_tag;
-	RPC_TRACE(DB_TRACE, &rpc_tmp, "received.\n");
-
+	D_DEBUG(DB_TRACE, "Received RPC (opc: %#x xid=%#x) "
+		"from rank:tag=%d:%d.\n", opc, rpc_tmp.crp_req_hdr.cch_xid,
+		rpc_tmp.crp_req_hdr.cch_rank, rpc_tmp.crp_req_hdr.cch_tag);
 
 	opc_info = crt_opc_lookup(crt_gdata.cg_opc_map, opc, CRT_UNLOCK);
 	if (opc_info == NULL) {
@@ -887,6 +886,8 @@ crt_rpc_handler_common(hg_handle_t hg_hdl)
 	}
 	crt_hg_header_copy(&rpc_tmp, rpc_priv);
 	rpc_pub = &rpc_priv->crp_pub;
+	rpc_pub->cr_ep.ep_rank = rpc_priv->crp_req_hdr.cch_rank;
+	rpc_pub->cr_ep.ep_tag = rpc_priv->crp_req_hdr.cch_tag;
 
 	if (rpc_priv->crp_flags & CRT_RPC_FLAG_COLL) {
 		is_coll_req = true;
@@ -896,7 +897,7 @@ crt_rpc_handler_common(hg_handle_t hg_hdl)
 	rpc_priv->crp_opc_info = opc_info;
 	rpc_pub->cr_opc = rpc_tmp.crp_pub.cr_opc;
 
-	D_DEBUG(DB_TRACE,
+	RPC_TRACE(DB_TRACE, rpc_priv,
 		"(opc: %#x rpc_pub: %p) allocated per RPC request received.\n",
 		rpc_priv->crp_opc_info->coi_opc,
 		&rpc_priv->crp_pub);
@@ -918,8 +919,6 @@ crt_rpc_handler_common(hg_handle_t hg_hdl)
 		rc = crt_hg_unpack_body(rpc_priv, proc);
 		if (rc == 0) {
 			rpc_priv->crp_input_got = 1;
-			rpc_pub->cr_ep.ep_rank = rpc_priv->crp_req_hdr.cch_rank;
-			rpc_pub->cr_ep.ep_tag = rpc_priv->crp_req_hdr.cch_tag;
 			rpc_pub->cr_ep.ep_grp = NULL;
 			/* TODO lookup by rpc_priv->crp_req_hdr.cch_grp_id */
 		} else {

--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -853,13 +853,9 @@ crt_rpc_handler_common(hg_handle_t hg_hdl)
 	opc = rpc_tmp.crp_req_hdr.cch_opc;
 
 	/**
-	 * Set the opcode, rank and tag in the temp RPC so that it can be
-	 * correctly logged.
+	 * Set the opcode in the temp RPC so that it can be correctly logged.
 	 */
 	rpc_tmp.crp_pub.cr_opc = opc;
-	D_DEBUG(DB_TRACE, "Received RPC (opc: %#x xid=%#x) "
-		"from rank:tag=%d:%d.\n", opc, rpc_tmp.crp_req_hdr.cch_xid,
-		rpc_tmp.crp_req_hdr.cch_rank, rpc_tmp.crp_req_hdr.cch_tag);
 
 	opc_info = crt_opc_lookup(crt_gdata.cg_opc_map, opc, CRT_UNLOCK);
 	if (opc_info == NULL) {
@@ -886,8 +882,6 @@ crt_rpc_handler_common(hg_handle_t hg_hdl)
 	}
 	crt_hg_header_copy(&rpc_tmp, rpc_priv);
 	rpc_pub = &rpc_priv->crp_pub;
-	rpc_pub->cr_ep.ep_rank = rpc_priv->crp_req_hdr.cch_rank;
-	rpc_pub->cr_ep.ep_tag = rpc_priv->crp_req_hdr.cch_tag;
 
 	if (rpc_priv->crp_flags & CRT_RPC_FLAG_COLL) {
 		is_coll_req = true;
@@ -896,11 +890,13 @@ crt_rpc_handler_common(hg_handle_t hg_hdl)
 
 	rpc_priv->crp_opc_info = opc_info;
 	rpc_pub->cr_opc = rpc_tmp.crp_pub.cr_opc;
+	rpc_pub->cr_ep.ep_rank = rpc_priv->crp_req_hdr.cch_rank;
+	rpc_pub->cr_ep.ep_tag = rpc_priv->crp_req_hdr.cch_tag;
 
 	RPC_TRACE(DB_TRACE, rpc_priv,
-		"(opc: %#x rpc_pub: %p) allocated per RPC request received.\n",
-		rpc_priv->crp_opc_info->coi_opc,
-		&rpc_priv->crp_pub);
+		  "(opc: %#x rpc_pub: %p) allocated per RPC request received.\n",
+		  rpc_priv->crp_opc_info->coi_opc,
+		  &rpc_priv->crp_pub);
 
 	rc = crt_rpc_priv_init(rpc_priv, crt_ctx, true /* srv_flag */);
 	if (rc != 0) {

--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -852,10 +852,15 @@ crt_rpc_handler_common(hg_handle_t hg_hdl)
 	D_ASSERT(proc != NULL);
 	opc = rpc_tmp.crp_req_hdr.cch_opc;
 
-	/* Set the opcode in the temp RPC so that it can be correctly logged on
-	 * failure
+	/**
+	 * Set the opcode, rank and tag in the temp RPC so that it can be
+	 * correctly logged.
 	 */
 	rpc_tmp.crp_pub.cr_opc = opc;
+	rpc_tmp.crp_pub.cr_ep.ep_rank = rpc_tmp.crp_req_hdr.cch_rank;
+	rpc_tmp.crp_pub.cr_ep.ep_tag = rpc_tmp.crp_req_hdr.cch_tag;
+	RPC_TRACE(DB_TRACE, &rpc_tmp, "received.\n");
+
 
 	opc_info = crt_opc_lookup(crt_gdata.cg_opc_map, opc, CRT_UNLOCK);
 	if (opc_info == NULL) {
@@ -891,10 +896,10 @@ crt_rpc_handler_common(hg_handle_t hg_hdl)
 	rpc_priv->crp_opc_info = opc_info;
 	rpc_pub->cr_opc = rpc_tmp.crp_pub.cr_opc;
 
-	RPC_TRACE(DB_TRACE, rpc_priv,
-		  "(opc: %#x rpc_pub: %p) allocated per RPC request received.\n",
-		  rpc_priv->crp_opc_info->coi_opc,
-		  &rpc_priv->crp_pub);
+	D_DEBUG(DB_TRACE, rpc_priv,
+		"(opc: %#x rpc_pub: %p) allocated per RPC request received.\n",
+		rpc_priv->crp_opc_info->coi_opc,
+		&rpc_priv->crp_pub);
 
 	rc = crt_rpc_priv_init(rpc_priv, crt_ctx, true /* srv_flag */);
 	if (rc != 0) {

--- a/src/cart/crt_internal.h
+++ b/src/cart/crt_internal.h
@@ -65,24 +65,24 @@
 /* A wrapper around D_TRACE_DEBUG that ensures the ptr option is a RPC */
 #define RPC_TRACE(mask, rpc, fmt, ...)					\
 	do {								\
-		D_TRACE_DEBUG(mask, rpc,				\
-			" [opc=0x%x rank:xid=%d:0x%x tag=%d] " fmt,	\
-			rpc->crp_pub.cr_opc,				\
-			rpc->crp_pub.cr_ep.ep_rank,			\
-			rpc->crp_req_hdr.cch_xid,			\
-			rpc->crp_pub.cr_ep.ep_tag,			\
+		D_TRACE_DEBUG(mask, (rpc),				\
+			" [opc=0x%x xid=0x%x rank:tag=%d:%d] " fmt,	\
+			(rpc)->crp_pub.cr_opc,				\
+			(rpc)->crp_req_hdr.cch_xid,			\
+			(rpc)->crp_pub.cr_ep.ep_rank,			\
+			(rpc)->crp_pub.cr_ep.ep_tag,			\
 			## __VA_ARGS__);				\
 	} while (0)
 
 /* Log an error with a RPC descriptor */
 #define RPC_ERROR(rpc, fmt, ...)					\
 	do {								\
-		D_TRACE_ERROR(rpc,					\
-			" [opc=0x%x rank:xid=%d:0x%x tag=%d] " fmt,	\
-			rpc->crp_pub.cr_opc,				\
-			rpc->crp_pub.cr_ep.ep_rank,			\
-			rpc->crp_req_hdr.cch_xid,			\
-			rpc->crp_pub.cr_ep.ep_tag,			\
+		D_TRACE_ERROR((rpc),					\
+			" [opc=0x%x xid=0x%x rank:tag=%d:%d] " fmt,	\
+			(rpc)->crp_pub.cr_opc,				\
+			(rpc)->crp_req_hdr.cch_xid,			\
+			(rpc)->crp_pub.cr_ep.ep_rank,			\
+			(rpc)->crp_pub.cr_ep.ep_tag,			\
 			## __VA_ARGS__);				\
 	} while (0)
 

--- a/test/util/cart_logtest.py
+++ b/test/util/cart_logtest.py
@@ -307,7 +307,7 @@ class LogTest():
             print('DEBUG not enabled, No log consistency checking possible')
 
         total_lines = trace_lines + non_trace_lines
-        p_trace = trace_lines / total_lines * 100
+        p_trace = trace_lines * 1.0 / total_lines * 100
 
         print("Pid {}, {} lines total, {} trace ({:.2f}%)".format(pid,
                                                                   total_lines,


### PR DESCRIPTION
- fix an issue in the RPC_TRACE macro to make it work with arguments
  like &rpc_priv_temp

- change the tracing message format so that following the trace of an
  RPC in the log file is easier. Now the RPC trace message format is:
      [opc=0xa010001 xid=0x15bf rank:tag=3:7]
  where 0x15bf is the unique sequence ID, 3:7 is the
  target_rank:target_tag.