### PR TITLE
CART-89 cart: New error code 'DER_CORRUPT_DATA'

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -52,7 +52,7 @@ DESIRED_FLAGS = ['-Wno-gnu-designator',
                  '-Wno-gnu-zero-variadic-macro-arguments',
                  '-Wno-tautological-constant-out-of-range-compare']
 
-CART_VERSION = "1.3.0"
+CART_VERSION = "1.4.0"
 
 def save_build_info(env, prereqs, platform):
     """Save the build information"""

--- a/cart.spec
+++ b/cart.spec
@@ -1,7 +1,7 @@
 %define carthome %{_exec_prefix}/lib/%{name}
 
 Name:          cart
-Version:       1.3.0
+Version:       1.4.0
 Release:       1%{?relval}%{?dist}
 Summary:       CaRT
 
@@ -122,6 +122,9 @@ ln %{?buildroot}%{carthome}/{TESTING/.build_vars,.build_vars-Linux}.sh
 %{carthome}/.build_vars-Linux.sh
 
 %changelog
+* Mon Oct 07 2019 Ryon Jensen  <ryon.jensen@intel.com>
+- Libcart version 1.4.0
+
 * Wed Sep 25 2019 Dmitry Eremin <dmitry.eremin@intel.com>
 - Libcart version 1.3.0
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+cart (1.4.0-1) unstable; urgency=medium
+
+  [ Ryon Jensen ]
+  * 1.4.0 version of CaRT
+
+ -- Ryon Jensen <ryon.jensen@intel.com>  Mon, 07 Oct 2019 16:22:44 +0000
+
 cart (1.3.0-1) unstable; urgency=medium
 
   [ Dmitry Eremin ]

--- a/src/include/gurt/errno.h
+++ b/src/include/gurt/errno.h
@@ -166,7 +166,9 @@
 	/** Not applicable. */						\
 	ACTION(DER_NOTAPPLICABLE,	(DER_ERR_DAOS_BASE + 19))	\
 	/** Not a service replica */					\
-	ACTION(DER_NOTREPLICA,		(DER_ERR_DAOS_BASE + 20))
+	ACTION(DER_NOTREPLICA,		(DER_ERR_DAOS_BASE + 20))	\
+	/** Data corruption found */					\
+	ACTION(DER_CORRUPT_DATA,	(DER_ERR_DAOS_BASE + 21))
 
 #define D_FOREACH_ERR_RANGE(ACTION)	\
 	ACTION(GURT,	1000)		\

--- a/src/include/gurt/errno.h
+++ b/src/include/gurt/errno.h
@@ -167,7 +167,7 @@
 	ACTION(DER_NOTAPPLICABLE,	(DER_ERR_DAOS_BASE + 19))	\
 	/** Not a service replica */					\
 	ACTION(DER_NOTREPLICA,		(DER_ERR_DAOS_BASE + 20))	\
-	/** Data corruption found */					\
+	/** Checksum error */						\
 	ACTION(DER_CSUM,		(DER_ERR_DAOS_BASE + 21))
 
 #define D_FOREACH_ERR_RANGE(ACTION)	\

--- a/src/include/gurt/errno.h
+++ b/src/include/gurt/errno.h
@@ -168,7 +168,7 @@
 	/** Not a service replica */					\
 	ACTION(DER_NOTREPLICA,		(DER_ERR_DAOS_BASE + 20))	\
 	/** Data corruption found */					\
-	ACTION(DER_CORRUPT_DATA,	(DER_ERR_DAOS_BASE + 21))
+	ACTION(DER_CSUM,		(DER_ERR_DAOS_BASE + 21))
 
 #define D_FOREACH_ERR_RANGE(ACTION)	\
 	ACTION(GURT,	1000)		\


### PR DESCRIPTION
Add a new error code for use when verifying data with checksums. If
the data checksums don't match then the data or checksums have been
corrupted.