### PR TITLE
CART-770 test: corpc_exclusive hangs over verbs (with lm disabled)

### DIFF
--- a/src/test/test_corpc_exclusive.c
+++ b/src/test/test_corpc_exclusive.c
@@ -46,8 +46,7 @@
 #include <unistd.h>
 #include <assert.h>
 #include <sys/stat.h>
-#include <gurt/common.h>
-#include <cart/api.h>
+#include "tests_common.h"
 
 static int	g_do_shutdown;
 static d_rank_t my_rank;
@@ -128,7 +127,6 @@ int main(void)
 	d_rank_t	memb_ranks[] = {1, 2, 4};
 	crt_rpc_t	*rpc;
 	uint32_t	grp_size;
-	int		i;
 
 	membs.rl_nr = 3;
 	membs.rl_ranks = memb_ranks;
@@ -172,19 +170,15 @@ int main(void)
 	}
 
 	/* rank=3 is not sent shutdown sequence */
-	if (my_rank == 3) {
-		sleep(5);
+	if (my_rank == 3)
 		g_do_shutdown = 1;
-	}
 
 	while (!g_do_shutdown)
 		crt_progress(g_main_ctx, 1000, NULL, NULL);
 
 	D_DEBUG(DB_TEST, "Shutting down\n");
 
-	/* Progress for a while to make sure we forward to all children */
-	for (i = 0; i < 1000; i++)
-		crt_progress(g_main_ctx, 1000, NULL, NULL);
+	tc_drain_queue(g_main_ctx);
 
 	rc = crt_context_destroy(g_main_ctx, true);
 	assert(rc == 0);

--- a/src/test/test_corpc_prefwd.c
+++ b/src/test/test_corpc_prefwd.c
@@ -46,8 +46,7 @@
 #include <unistd.h>
 #include <assert.h>
 #include <sys/stat.h>
-#include <gurt/common.h>
-#include <cart/api.h>
+#include "tests_common.h"
 
 static bool pre_forward_called;
 static bool hdlr_called;
@@ -151,7 +150,6 @@ int main(void)
 	d_rank_t	excluded_ranks = {0};
 	crt_rpc_t	*rpc;
 	d_rank_t	my_rank;
-	int		i;
 
 	excluded_membs.rl_nr = 1;
 	excluded_membs.rl_ranks = &excluded_ranks;
@@ -190,9 +188,7 @@ int main(void)
 
 	D_DEBUG(DB_TEST, "Shutting down\n");
 
-	/* Progress for a while to make sure we forward to all children */
-	for (i = 0; i < 1000; i++)
-		crt_progress(g_main_ctx, 1000, NULL, NULL);
+	tc_drain_queue(g_main_ctx);
 
 	rc = crt_context_destroy(g_main_ctx, true);
 	assert(rc == 0);

--- a/src/test/tests_common.h
+++ b/src/test/tests_common.h
@@ -47,7 +47,7 @@
 
 int g_shutdown;
 
-static inline int drain_queue(crt_context_t ctx)
+static inline int tc_drain_queue(crt_context_t ctx)
 {
 	int	rc;
 	/* Drain the queue. Progress until 1 second timeout.  We need
@@ -56,7 +56,7 @@ static inline int drain_queue(crt_context_t ctx)
 	do {
 		rc = crt_progress(ctx, 1000000, NULL, NULL);
 		if (rc != 0 && rc != -DER_TIMEDOUT) {
-			printf("crt_progress failed rc: %d.\n", rc);
+			D_ERROR("crt_progress failed rc: %d.\n", rc);
 			return rc;
 		}
 
@@ -64,7 +64,7 @@ static inline int drain_queue(crt_context_t ctx)
 			break;
 	} while (1);
 
-	printf("Done draining queue\n");
+	D_DEBUG(DB_TEST, "Done draining queue\n");
 	return 0;
 }
 
@@ -78,9 +78,9 @@ progress_fn(void *data)
 	while (g_shutdown == 0)
 		crt_progress(*p_ctx, 1000, NULL, NULL);
 
-	rc = drain_queue(*p_ctx);
+	rc = tc_drain_queue(*p_ctx);
 	if (rc != 0) {
-		D_ERROR("drain_queue() failed with rc=%d\n", rc);
+		D_ERROR("tc_drain_queue() failed with rc=%d\n", rc);
 		assert(0);
 	}
 


### PR DESCRIPTION
- test_corpc_exclusive and prefwd changed to use tc_drain_queue()
in order to drain queue before exiting, instead of doing a loop of
context progress

- minor cleanup in naming of drain_queue and regular prints changed
to ERROR/DEBUG macros.

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>