### PR TITLE
CART-89 fix: Protect returned number of contexts

### DIFF
--- a/src/cart/crt_ctl.c
+++ b/src/cart/crt_ctl.c
@@ -255,7 +255,6 @@ crt_hdlr_ctl_ls(crt_rpc_t *rpc_req)
 	addr_buf_len = 0;
 
 	D_RWLOCK_RDLOCK(&crt_gdata.cg_rwlock);
-	D_DEBUG(DB_TRACE, "out_args->cel_ctx_num %d\n", crt_gdata.cg_ctx_num);
 	out_args->cel_ctx_num = crt_gdata.cg_ctx_num;
 
 	d_list_for_each_entry(ctx, &crt_gdata.cg_ctx_list, cc_link) {
@@ -304,6 +303,7 @@ crt_hdlr_ctl_ls(crt_rpc_t *rpc_req)
 	D_RWLOCK_UNLOCK(&crt_gdata.cg_rwlock);
 	D_ASSERT(count <= addr_buf_len);
 
+	D_DEBUG(DB_TRACE, "out_args->cel_ctx_num %d\n", out_args->cel_ctx_num);
 	d_iov_set(&out_args->cel_addr_str, addr_buf, count);
 
 out:

--- a/src/cart/crt_ctl.c
+++ b/src/cart/crt_ctl.c
@@ -252,12 +252,11 @@ crt_hdlr_ctl_ls(crt_rpc_t *rpc_req)
 	if (rc != 0)
 		D_GOTO(out, rc);
 
-
-	out_args->cel_ctx_num = crt_gdata.cg_ctx_num;
-	D_DEBUG(DB_TRACE, "out_args->cel_ctx_num %d\n", crt_gdata.cg_ctx_num);
 	addr_buf_len = 0;
 
 	D_RWLOCK_RDLOCK(&crt_gdata.cg_rwlock);
+	D_DEBUG(DB_TRACE, "out_args->cel_ctx_num %d\n", crt_gdata.cg_ctx_num);
+	out_args->cel_ctx_num = crt_gdata.cg_ctx_num;
 
 	d_list_for_each_entry(ctx, &crt_gdata.cg_ctx_list, cc_link) {
 		str_size = CRT_ADDR_STR_MAX_LEN;


### PR DESCRIPTION
Number of contexts returned was not being protected by the lock, which could result in a mismatch between num_ctx returned and the list of context addresses

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>