### PR TITLE
DAOS-1822 iv: Add ivo_pre_sync

### DIFF
--- a/src/cart/crt_iv.c
+++ b/src/cart/crt_iv.c
@@ -1799,6 +1799,90 @@ crt_iv_sync_corpc_aggregate(crt_rpc_t *source, crt_rpc_t *result, void *arg)
 	return 0;
 }
 
+static int
+call_pre_sync_cb(struct crt_ivns_internal *ivns_internal,
+		 struct crt_iv_sync_in *input, crt_rpc_t *rpc_req)
+{
+	struct crt_iv_ops	*iv_ops;
+	d_sg_list_t		 iv_value;
+	d_sg_list_t		 tmp_iv;
+	void			*user_priv;
+	bool			 need_put = false;
+	int			 rc;
+
+	iv_ops = crt_iv_ops_get(ivns_internal, input->ivs_class_id);
+	D_ASSERT(iv_ops != NULL);
+
+	rc = iv_ops->ivo_on_get(ivns_internal, &input->ivs_key, 0,
+				CRT_IV_PERM_WRITE, &iv_value,
+				&user_priv);
+	tmp_iv = iv_value;
+	if (rc != 0) {
+		D_ERROR("ivo_on_get() failed; rc=%d\n", rc);
+		D_GOTO(exit, rc);
+	}
+	need_put = true;
+
+	rc = crt_bulk_access(rpc_req->cr_co_bulk_hdl, &tmp_iv);
+	if (rc != 0) {
+		D_ERROR("crt_bulk_access() failed; rc=%d\n", rc);
+		D_GOTO(exit, rc);
+	}
+
+	D_DEBUG(DB_TRACE, "Executing ivo_pre_sync\n");
+	rc = iv_ops->ivo_pre_sync(ivns_internal, &input->ivs_key, 0,
+				  &iv_value, user_priv);
+	if (rc != 0)
+		D_ERROR("ivo_pre_sync() failed; rc=%d\n", rc);
+
+exit:
+	if (need_put)
+		iv_ops->ivo_on_put(ivns_internal, &iv_value, user_priv);
+	return rc;
+}
+
+int
+crt_iv_sync_corpc_pre_forward(crt_rpc_t *rpc, void *arg)
+{
+	struct crt_iv_sync_in		*input;
+	struct crt_ivns_internal	*ivns_internal;
+	struct crt_iv_ops		*iv_ops;
+	struct crt_ivns_id		 ivns_id;
+	crt_iv_sync_t			*sync_type;
+	int				 rc = 0;
+
+	/* This is an internal call. All errors are fatal */
+	input = crt_req_get(rpc);
+	D_ASSERT(input != NULL);
+
+	ivns_id.ii_group_name = input->ivs_ivns_group;
+	ivns_id.ii_nsid = input->ivs_ivns_id;
+	sync_type = (crt_iv_sync_t *)input->ivs_sync_type.iov_buf;
+
+	ivns_internal = crt_ivns_internal_lookup(&ivns_id);
+
+	/* In some use-cases sync can arrive to a node that hasn't attached
+	* iv namespace yet. Treat such errors as fatal if the flag is set.
+	**/
+	if (ivns_internal == NULL) {
+		D_ERROR("ivns_internal was NULL. ivns_id=%s:%d\n",
+			ivns_id.ii_group_name, ivns_id.ii_nsid);
+
+		D_ASSERT(!(sync_type->ivs_flags &
+			   CRT_IV_SYNC_FLAG_NS_ERRORS_FATAL));
+		return -DER_NONEXIST;
+	}
+
+	iv_ops = crt_iv_ops_get(ivns_internal, input->ivs_class_id);
+	D_ASSERT(iv_ops != NULL);
+
+	if (iv_ops->ivo_pre_sync != NULL)
+		rc = call_pre_sync_cb(ivns_internal, input, rpc);
+
+	IVNS_DECREF(ivns_internal);
+	return rc;
+}
+
 /* Calback structure for iv sync RPC */
 struct iv_sync_cb_info {
 	/* Local bulk handle to free in callback */

--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -149,7 +149,7 @@ CRT_RPC_DEFINE(crt_iv_sync, CRT_ISEQ_IV_SYNC, CRT_OSEQ_IV_SYNC)
 
 static struct crt_corpc_ops crt_iv_sync_co_ops = {
 	.co_aggregate = crt_iv_sync_corpc_aggregate,
-	.co_pre_forward = NULL,
+	.co_pre_forward = crt_iv_sync_corpc_pre_forward,
 };
 
 /* barrier */

--- a/src/cart/crt_rpc.h
+++ b/src/cart/crt_rpc.h
@@ -711,6 +711,7 @@ void crt_hdlr_iv_update(crt_rpc_t *rpc_req);
 void crt_hdlr_iv_sync(crt_rpc_t *rpc_req);
 int crt_iv_sync_corpc_aggregate(crt_rpc_t *source, crt_rpc_t *result,
 				void *arg);
+int crt_iv_sync_corpc_pre_forward(crt_rpc_t *rpc, void *arg);
 
 /* crt_register.c */
 int

--- a/src/include/cart/iv.h
+++ b/src/include/cart/iv.h
@@ -343,6 +343,23 @@ typedef int (*crt_iv_on_put_cb_t)(crt_iv_namespace_t ivns,
 typedef bool (*crt_iv_keys_match_cb_t)(crt_iv_namespace_t ivns,
 				crt_iv_key_t *key1, crt_iv_key_t *key2);
 
+/**
+ * If provided, this callback will be called before the
+ * synchronization/notification is propagated (flowing down from root to leaf)
+ * to the child nodes, if any.
+ *
+ * \param[in] ivns		the local handle of the IV namespace
+ * \param[in] iv_key		key of the IV
+ * \param[in] iv_ver		version of the IV
+ * \param[in] iv_value		IV value to be refresh
+ * \param[in] arg		private user data
+ *
+ * \return			DER_SUCCESS on success, negative value if error
+ */
+typedef int (*crt_iv_pre_sync_cb_t)(crt_iv_namespace_t ivns,
+				    crt_iv_key_t *iv_key, crt_iv_ver_t iv_ver,
+				    d_sg_list_t *iv_value, void *arg);
+
 struct crt_iv_ops {
 	crt_iv_pre_fetch_cb_t	ivo_pre_fetch;
 	crt_iv_on_fetch_cb_t	ivo_on_fetch;
@@ -354,6 +371,7 @@ struct crt_iv_ops {
 	crt_iv_on_get_cb_t	ivo_on_get;
 	crt_iv_on_put_cb_t	ivo_on_put;
 	crt_iv_keys_match_cb_t	ivo_keys_match;
+	crt_iv_pre_sync_cb_t	ivo_pre_sync;
 };
 
 /**


### PR DESCRIPTION
Add a new IV callback, ivo_pre_sync, which will be called before
forwarding IV_SYNC requests to children (if any), in order to update a
special IV whose value defines the IV NS's group membership.

Signed-off-by: Li Wei <wei.g.li@intel.com>