### PR TITLE
CART-89 fix: Fix bug in crt_group_config_save()

### DIFF
--- a/src/cart/crt_group.c
+++ b/src/cart/crt_group.c
@@ -3207,7 +3207,7 @@ done:
 out:
 	/* For pmix disabled case. Lock taken above before loop start */
 	if (grp_priv && locked)
-		D_RWLOCK_RDLOCK(&grp_priv->gp_rwlock);
+		D_RWLOCK_RDUNLOCK(&grp_priv->gp_rwlock);
 
 	D_FREE(filename);
 	if (tmp_name != NULL) {

--- a/src/cart/crt_group.c
+++ b/src/cart/crt_group.c
@@ -3080,7 +3080,7 @@ crt_group_config_save(crt_group_t *grp, bool forall)
 
 	grp_priv = crt_grp_pub2priv(grp);
 	if (!grp_priv->gp_service || !grp_priv->gp_primary) {
-		D_ERROR("can-only save config info for primary service grp.\n");
+		D_ERROR("Can only save config info for primary service grp.\n");
 		D_GOTO(out, rc = -DER_INVAL);
 	}
 	if (grp_priv->gp_local) {

--- a/src/cart/crt_group.c
+++ b/src/cart/crt_group.c
@@ -3207,7 +3207,7 @@ done:
 out:
 	/* For pmix disabled case. Lock taken above before loop start */
 	if (grp_priv && locked)
-		D_RWLOCK_RDUNLOCK(&grp_priv->gp_rwlock);
+		D_RWLOCK_UNLOCK(&grp_priv->gp_rwlock);
 
 	D_FREE(filename);
 	if (tmp_name != NULL) {
@@ -4076,11 +4076,6 @@ crt_rank_uri_get(crt_group_t *group, d_rank_t rank, int tag, char **uri_str)
 	struct crt_grp_priv	*grp_priv;
 	crt_phy_addr_t		uri;
 	hg_addr_t		hg_addr;
-
-	if (group == NULL) {
-		D_ERROR("Passed group is NULL\n");
-		D_GOTO(out, rc = -DER_INVAL);
-	}
 
 	if (uri_str == NULL) {
 		D_ERROR("Passed uri_str is NULL\n");


### PR DESCRIPTION
Fixed a bug in crt_group_config_save() for non-pmix case, where
incorrect ranks were used for uri retrieval.

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>