### PR TITLE
CART-790 rpc: Add new APIs to get src/dst rank

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -52,7 +52,7 @@ DESIRED_FLAGS = ['-Wno-gnu-designator',
                  '-Wno-gnu-zero-variadic-macro-arguments',
                  '-Wno-tautological-constant-out-of-range-compare']
 
-CART_VERSION = "1.4.0"
+CART_VERSION = "1.4.1"
 
 def save_build_info(env, prereqs, platform):
     """Save the build information"""

--- a/SConstruct
+++ b/SConstruct
@@ -52,7 +52,7 @@ DESIRED_FLAGS = ['-Wno-gnu-designator',
                  '-Wno-gnu-zero-variadic-macro-arguments',
                  '-Wno-tautological-constant-out-of-range-compare']
 
-CART_VERSION = "1.4.1"
+CART_VERSION = "1.5.0"
 
 def save_build_info(env, prereqs, platform):
     """Save the build information"""

--- a/cart.spec
+++ b/cart.spec
@@ -1,7 +1,7 @@
 %define carthome %{_exec_prefix}/lib/%{name}
 
 Name:          cart
-Version:       1.4.1
+Version:       1.5.0
 Release:       1%{?relval}%{?dist}
 Summary:       CaRT
 
@@ -123,7 +123,7 @@ ln %{?buildroot}%{carthome}/{TESTING/.build_vars,.build_vars-Linux}.sh
 
 %changelog
 * Thu Oct 17 2019 Alexander Oganezov <alexander.a.oganezov@intel.com>
-- Libcart version 1.4.1
+- Libcart version 1.5.0
 
 * Wed Oct 16 2019 Alexander Oganezov <alexander.a.oganezov@intel.com>
 - Libcart version 1.4.0-2

--- a/cart.spec
+++ b/cart.spec
@@ -1,8 +1,8 @@
 %define carthome %{_exec_prefix}/lib/%{name}
 
 Name:          cart
-Version:       1.4.0
-Release:       2%{?relval}%{?dist}
+Version:       1.4.1
+Release:       1%{?relval}%{?dist}
 Summary:       CaRT
 
 License:       Apache
@@ -122,11 +122,13 @@ ln %{?buildroot}%{carthome}/{TESTING/.build_vars,.build_vars-Linux}.sh
 %{carthome}/.build_vars-Linux.sh
 
 %changelog
+* Thu Oct 17 2019 Alexander Oganezov <alexander.a.oganezov@intel.com>
+- Libcart version 1.4.1
+
 * Wed Oct 16 2019 Alexander Oganezov <alexander.a.oganezov@intel.com>
 - Libcart version 1.4.0-2
 
 * Mon Oct 07 2019 Ryon Jensen  <ryon.jensen@intel.com>
-
 - Libcart version 1.4.0
 
 * Wed Sep 25 2019 Dmitry Eremin <dmitry.eremin@intel.com>

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+cart (1.4.1-1) unstable; urgency=medium
+
+  [ Alexander Oganezov ]
+  * 1.4.1 version of CaRT
+
+ -- Alexander Oganezov <alexander.a.oganezov@intel.com>  Thu, 17 Oct 2019 16:22:44 +0000
+
 cart (1.4.0-2) unstable; urgency=medium
 
   [ Alexander Oganezov ]

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,7 +1,7 @@
-cart (1.4.1-1) unstable; urgency=medium
+cart (1.5.0-1) unstable; urgency=medium
 
   [ Alexander Oganezov ]
-  * 1.4.1 version of CaRT
+  * 1.5.0 version of CaRT
 
  -- Alexander Oganezov <alexander.a.oganezov@intel.com>  Thu, 17 Oct 2019 16:22:44 +0000
 

--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -890,8 +890,8 @@ crt_rpc_handler_common(hg_handle_t hg_hdl)
 
 	rpc_priv->crp_opc_info = opc_info;
 	rpc_pub->cr_opc = rpc_tmp.crp_pub.cr_opc;
-	rpc_pub->cr_ep.ep_rank = rpc_priv->crp_req_hdr.cch_rank;
-	rpc_pub->cr_ep.ep_tag = rpc_priv->crp_req_hdr.cch_tag;
+	rpc_pub->cr_ep.ep_rank = rpc_priv->crp_req_hdr.cch_dst_rank;
+	rpc_pub->cr_ep.ep_tag = rpc_priv->crp_req_hdr.cch_dst_tag;
 
 	RPC_TRACE(DB_TRACE, rpc_priv,
 		  "(opc: %#x rpc_pub: %p) allocated per RPC request received.\n",

--- a/src/cart/crt_hg_proc.c
+++ b/src/cart/crt_hg_proc.c
@@ -626,11 +626,20 @@ crt_proc_in_common(crt_proc_t proc, crt_rpc_input_t *data)
 			hdr = &rpc_priv->crp_req_hdr;
 
 			hdr->cch_flags = rpc_priv->crp_flags;
-			hdr->cch_rank = crt_grp_priv_get_primary_rank(
+			hdr->cch_dst_rank = crt_grp_priv_get_primary_rank(
 						rpc_priv->crp_grp_priv,
 						rpc_priv->crp_pub.cr_ep.ep_rank
 						);
-			hdr->cch_tag = rpc_priv->crp_pub.cr_ep.ep_tag;
+			hdr->cch_dst_tag = rpc_priv->crp_pub.cr_ep.ep_tag;
+
+			if (crt_is_service())
+				hdr->cch_src_rank = crt_grp_priv_get_primary_rank(
+						rpc_priv->crp_grp_priv,
+						rpc_priv->crp_grp_priv->gp_self
+						);
+			else
+				hdr->cch_src_rank = CRT_NO_RANK;
+
 			hdr->cch_hlc = crt_hlc_get();
 		}
 		rc = crt_proc_common_hdr(proc, &rpc_priv->crp_req_hdr);

--- a/src/cart/crt_hg_proc.c
+++ b/src/cart/crt_hg_proc.c
@@ -633,7 +633,8 @@ crt_proc_in_common(crt_proc_t proc, crt_rpc_input_t *data)
 			hdr->cch_dst_tag = rpc_priv->crp_pub.cr_ep.ep_tag;
 
 			if (crt_is_service())
-				hdr->cch_src_rank = crt_grp_priv_get_primary_rank(
+				hdr->cch_src_rank = 
+					crt_grp_priv_get_primary_rank(
 						rpc_priv->crp_grp_priv,
 						rpc_priv->crp_grp_priv->gp_self
 						);

--- a/src/cart/crt_hg_proc.c
+++ b/src/cart/crt_hg_proc.c
@@ -633,7 +633,7 @@ crt_proc_in_common(crt_proc_t proc, crt_rpc_input_t *data)
 			hdr->cch_dst_tag = rpc_priv->crp_pub.cr_ep.ep_tag;
 
 			if (crt_is_service())
-				hdr->cch_src_rank = 
+				hdr->cch_src_rank =
 					crt_grp_priv_get_primary_rank(
 						rpc_priv->crp_grp_priv,
 						rpc_priv->crp_grp_priv->gp_self

--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -1410,16 +1410,7 @@ crt_rpc_inout_buff_init(struct crt_rpc_priv *rpc_priv)
 static inline void
 crt_common_hdr_init(struct crt_rpc_priv *rpc_priv, crt_opcode_t opc)
 {
-	d_rank_t	rank;
 	uint32_t	xid;
-	int		rc;
-
-	if (crt_is_service()) {
-		rc = crt_group_rank(0, &rank);
-		D_ASSERT(rc == 0);
-	} else {
-		rank = 0; /* Client rank */
-	}
 
 	xid = atomic_fetch_add(&crt_gdata.cg_xid, 1);
 
@@ -1622,7 +1613,6 @@ struct d_binheap_ops crt_timeout_bh_ops = {
 	.hop_compare	= timeout_bp_node_cmp
 };
 
-
 int
 crt_req_src_rank_get(crt_rpc_t *rpc, d_rank_t *rank)
 {
@@ -1638,7 +1628,6 @@ crt_req_src_rank_get(crt_rpc_t *rpc, d_rank_t *rank)
 		D_ERROR("NULL rank passed\n");
 		D_GOTO(out, rc = -DER_INVAL);
 	}
-
 
 	rpc_priv = container_of(rpc, struct crt_rpc_priv, crp_pub);
 
@@ -1663,7 +1652,6 @@ crt_req_dst_rank_get(crt_rpc_t *rpc, d_rank_t *rank)
 		D_ERROR("NULL rank passed\n");
 		D_GOTO(out, rc = -DER_INVAL);
 	}
-
 
 	rpc_priv = container_of(rpc, struct crt_rpc_priv, crp_pub);
 

--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -1427,7 +1427,6 @@ crt_common_hdr_init(struct crt_rpc_priv *rpc_priv, crt_opcode_t opc)
 	rpc_priv->crp_req_hdr.cch_xid = xid;
 
 	rpc_priv->crp_reply_hdr.cch_opc = opc;
-	rpc_priv->crp_reply_hdr.cch_rank = rank;
 	rpc_priv->crp_reply_hdr.cch_xid = xid;
 }
 
@@ -1536,16 +1535,16 @@ crt_rpc_common_hdlr(struct crt_rpc_priv *rpc_priv)
 			skip_check = true;
 	}
 
-	if ((self_rank != rpc_priv->crp_req_hdr.cch_rank) ||
-		(crt_ctx->cc_idx != rpc_priv->crp_req_hdr.cch_tag)) {
+	if ((self_rank != rpc_priv->crp_req_hdr.cch_dst_rank) ||
+		(crt_ctx->cc_idx != rpc_priv->crp_req_hdr.cch_dst_tag)) {
 
 		if (!skip_check) {
 			D_DEBUG(DB_TRACE, "Mismatch rpc: %p opc: %x rank:%d "
 			"tag:%d self:%d cc_idx:%d ep_rank:%d ep_tag:%d\n",
 				rpc_priv,
 				rpc_priv->crp_pub.cr_opc,
-				rpc_priv->crp_req_hdr.cch_rank,
-				rpc_priv->crp_req_hdr.cch_tag,
+				rpc_priv->crp_req_hdr.cch_dst_rank,
+				rpc_priv->crp_req_hdr.cch_dst_tag,
 				crt_gdata.cg_grp->gg_srv_pri_grp->gp_self,
 				crt_ctx->cc_idx,
 				rpc_priv->crp_pub.cr_ep.ep_rank,
@@ -1622,3 +1621,79 @@ struct d_binheap_ops crt_timeout_bh_ops = {
 	.hop_exit	= timeout_bp_node_exit,
 	.hop_compare	= timeout_bp_node_cmp
 };
+
+
+int
+crt_req_src_rank_get(crt_rpc_t *rpc, d_rank_t *rank)
+{
+	struct crt_rpc_priv	*rpc_priv = NULL;
+	int			rc = 0;
+
+	if (rpc == NULL) {
+		D_ERROR("NULL rpc passed\n");
+		D_GOTO(out, rc = -DER_INVAL);
+	}
+
+	if (rank == NULL) {
+		D_ERROR("NULL rank passed\n");
+		D_GOTO(out, rc = -DER_INVAL);
+	}
+
+
+	rpc_priv = container_of(rpc, struct crt_rpc_priv, crp_pub);
+
+	*rank = rpc_priv->crp_req_hdr.cch_src_rank;
+
+out:
+	return rc;
+}
+
+int
+crt_req_dst_rank_get(crt_rpc_t *rpc, d_rank_t *rank)
+{
+	struct crt_rpc_priv	*rpc_priv = NULL;
+	int			rc = 0;
+
+	if (rpc == NULL) {
+		D_ERROR("NULL rpc passed\n");
+		D_GOTO(out, rc = -DER_INVAL);
+	}
+
+	if (rank == NULL) {
+		D_ERROR("NULL rank passed\n");
+		D_GOTO(out, rc = -DER_INVAL);
+	}
+
+
+	rpc_priv = container_of(rpc, struct crt_rpc_priv, crp_pub);
+
+	*rank = rpc_priv->crp_req_hdr.cch_dst_rank;
+
+out:
+	return rc;
+}
+
+int
+crt_req_dst_tag_get(crt_rpc_t *rpc, uint32_t *tag)
+{
+	struct crt_rpc_priv	*rpc_priv = NULL;
+	int			rc = 0;
+
+	if (rpc == NULL) {
+		D_ERROR("NULL rpc passed\n");
+		D_GOTO(out, rc = -DER_INVAL);
+	}
+
+	if (tag == NULL) {
+		D_ERROR("NULL tag passed\n");
+		D_GOTO(out, rc = -DER_INVAL);
+	}
+
+
+	rpc_priv = container_of(rpc, struct crt_rpc_priv, crp_pub);
+
+	*tag = rpc_priv->crp_req_hdr.cch_dst_tag;
+
+out:
+	return rc;
+}

--- a/src/cart/crt_rpc.h
+++ b/src/cart/crt_rpc.h
@@ -92,10 +92,12 @@ struct crt_common_hdr {
 	uint32_t	cch_flags;
 	/* HLC timestamp */
 	uint64_t	cch_hlc;
-	/* gid and rank identify the rpc request sender */
-	d_rank_t	cch_rank;
+	/* destination rank in default primary group */
+	d_rank_t	cch_dst_rank;
+	/* originator rank in default primary group */
+	d_rank_t	cch_src_rank;
 	/* tag to which rpc request was sent to */
-	d_rank_t	cch_tag;
+	uint32_t	cch_dst_tag;
 	/* Transfer id */
 	uint32_t	cch_xid;
 	/* used in crp_reply_hdr to propagate rpc failure back to sender */

--- a/src/include/cart/api.h
+++ b/src/include/cart/api.h
@@ -396,6 +396,42 @@ crt_req_get(crt_rpc_t *rpc)
 }
 
 /**
+ * Return originator/source rank
+ *
+ * \param[in] req              Pointer to RPC request
+ * \param[out] rank            Returned rank
+ *
+ * \return                     DER_SUCCESS on success or error
+ *                             on failure
+ */
+int
+crt_req_src_rank_get(crt_rpc_t *req, d_rank_t *rank);
+
+/**
+ * Return destination rank
+ *
+ * \param[in] req              Pointer to RPC request
+ * \param[out] rank            Returned rank
+ *
+ * \return                     DER_SUCCESS on success or error
+ *                             on failure
+ */
+int
+crt_req_dst_rank_get(crt_rpc_t *req, d_rank_t *rank);
+
+/**
+ * Return destination tag
+ *
+ * \param[in] req              Pointer to RPC request
+ * \param[out] tag             Returned tag
+ *
+ * \return                     DER_SUCCESS on success or error
+ *                             on failure
+ */
+int
+crt_req_dst_tag_get(crt_rpc_t *req, uint32_t *tag);
+
+/**
  * Return reply buffer
  *
  * \param[in] req              pointer to RPC request


### PR DESCRIPTION
New APIs:
- crt_req_dst_rank_get()
- crt_req_dst_tag_get()
- crt_req_src_rank_get()

Modified no_pmix_group_test and no_pmix_launcher test to use
new APIs.

Fixed no_pmix_group_test's DBG_PRINT

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>