### PR TITLE
CART-792 iv: Fix iv_server test

### DIFF
--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -281,6 +281,8 @@ crt_init_opt(crt_group_id_t grpid, uint32_t flags, crt_init_options_t *opt)
 
 		crt_gdata.cg_server = server;
 
+		D_DEBUG(DB_ALL, "Server bit set to %d\n", server);
+
 		if ((flags & CRT_FLAG_BIT_SINGLETON) != 0)
 			crt_gdata.cg_singleton = true;
 

--- a/src/include/gurt/common.h
+++ b/src/include/gurt/common.h
@@ -153,32 +153,33 @@ extern "C" {
  */
 #define D_REALLOC_COMMON(newptr, oldptr, size, cnt)			\
 	do {								\
-		int _esz = (int)(size);					\
-		int _sz = (int)(size) * (cnt);				\
+		size_t _esz = (size_t)(size);				\
+		size_t _sz = (size_t)(size) * (cnt);			\
+		size_t _cnt = (size_t)(cnt);				\
 		/* Compiler check to ensure type match */		\
 		__typeof__(newptr) optr = oldptr;			\
 		D_ASSERT((void *)&(newptr) != &(oldptr));		\
 		(newptr) =  realloc(optr, (_sz));			\
 		if ((newptr) != NULL) {					\
-			if ((cnt) <= 1)					\
+			if ((_cnt) <= 1)				\
 				D_DEBUG(DB_MEM,				\
-					"realloc '" #newptr "': %i at %p (old '" #oldptr "':%p).\n", \
+					"realloc '" #newptr "': %zu at %p (old '" #oldptr "':%p).\n", \
 					_esz, (newptr), (oldptr));	\
 			else						\
 				D_DEBUG(DB_MEM,				\
-					"realloc '" #newptr "': %i * '" #cnt "':%i at %p (old '" #oldptr "':%p).\n", \
-					_esz, (cnt), (newptr), (oldptr));	\
+					"realloc '" #newptr "': %zu * '" #cnt "':%zu at %p (old '" #oldptr "':%p).\n", \
+					_esz, (_cnt), (newptr), (oldptr));	\
 			(oldptr) = NULL;				\
 			break;						\
 		}							\
-		if ((cnt) <= 1)						\
+		if ((_cnt) <= 1)					\
 			D_ERROR("out of memory (tried to realloc "	\
-				"'" #newptr "': size=%i)\n",		\
+				"'" #newptr "': size=%zu)\n",		\
 				_esz);					\
 		else							\
 			D_ERROR("out of memory (tried to realloc "	\
-				"'" #newptr "': size=%i count=%d)\n",	\
-				_esz, (cnt));				\
+				"'" #newptr "': size=%zu count=%zu)\n",	\
+				_esz, (_cnt));				\
 	} while (0)
 
 

--- a/test/iv/cart_iv_one_node.yaml
+++ b/test/iv/cart_iv_one_node.yaml
@@ -7,8 +7,8 @@ defaultENV:
   D_LOG_MASK: "DEBUG,MEM=ERR"
   CRT_PHY_ADDR_STR: "ofi+sockets"
   OFI_INTERFACE: "eth0"
-  srv_CRT_CTX_NUM: "16"
-  cli_CRT_CTX_NUM: "16"
+  srv_CRT_CTX_NUM: "2"
+  cli_CRT_CTX_NUM: "2"
 env_CRT_CTX_SHARE_ADDR: !mux
   sep:
     env: sep
@@ -28,10 +28,10 @@ tests: !mux
     name: iv_basic
     srv_bin: crt_launch
     srv_arg: "-e tests/iv_server -v 3"
-    srv_env: "-x CRT_ALLOW_SINGLETON=1"
-    srv_ppn: "2"
+    srv_env: ""
+    srv_ppn: "5"
 
     cli_bin: tests/iv_client
     cli_arg: ""
-    cli_env: "-x CRT_ALLOW_SINGLETON=1"
+    cli_env: ""
     cli_ppn: "1"

--- a/test/iv/cart_iv_two_node.yaml
+++ b/test/iv/cart_iv_two_node.yaml
@@ -7,8 +7,8 @@ defaultENV:
   D_LOG_MASK: "DEBUG,MEM=ERR"
   CRT_PHY_ADDR_STR: "ofi+sockets"
   OFI_INTERFACE: "eth0"
-  srv_CRT_CTX_NUM: "16"
-  cli_CRT_CTX_NUM: "16"
+  srv_CRT_CTX_NUM: "2"
+  cli_CRT_CTX_NUM: "2"
 env_CRT_CTX_SHARE_ADDR: !mux
   sep:
     env: sep
@@ -29,10 +29,10 @@ tests: !mux
     name: iv_basic
     srv_bin: crt_launch
     srv_arg: "-e tests/iv_server -v 3"
-    srv_env: "-x CRT_ALLOW_SINGLETON=1"
-    srv_ppn: "1"
+    srv_env: ""
+    srv_ppn: "5"
 
     cli_bin: tests/iv_client
     cli_arg: ""
-    cli_env: "-x CRT_ALLOW_SINGLETON=1"
+    cli_env: ""
     cli_ppn: "1"


### PR DESCRIPTION
- iv_server test fixed to wait for ranks before doing namespace attach
- only rank0 now saves iv group info
- yaml files changed to launch 5 servers; server/clients set to have 2
  contexts via CRT_CTX_NUM
- unused -x CRT_ALLOW_SINGLETON=1 removed
- D_REALLOC_COMMON macro modified to print sizes and counts as size_t/zu.
  This also fixes CART-793.
- Debug print added to print server bit at startup

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>