### PR TITLE
CART-89 debug: D_ASSERT should print to log before calling assert

### DIFF
--- a/src/include/gurt/debug.h
+++ b/src/include/gurt/debug.h
@@ -320,6 +320,8 @@ int d_register_alt_assert(void (*alt_assert)(const int, const char*,
 
 #define D_ASSERT(e)							\
 	do {								\
+		if (!(e))						\
+			D_FATAL("Assertion failed " #e "\n");		\
 		if (d_alt_assert != NULL)				\
 			d_alt_assert((int64_t)(e), #e, __FILE__, __LINE__);\
 		assert(e);						\


### PR DESCRIPTION
The gurt log should reflect that an assertion triggered.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>