### PR TITLE
CART-797 iv: Fix crt_hdlr_iv_sync NS ref leaks

### DIFF
--- a/src/cart/crt_iv.c
+++ b/src/cart/crt_iv.c
@@ -1834,13 +1834,12 @@ crt_hdlr_iv_sync(crt_rpc_t *rpc_req)
 		crt_hdlr_iv_sync_aux(rpc_req);
 	}
 
+	IVNS_DECREF(ivns_internal);
 	return;
-exit:
 
+exit:
 	output->rc = rc;
 	crt_reply_send(rpc_req);
-
-	IVNS_DECREF(ivns_internal);
 }
 
 /* Results aggregate function for sync CORPC */


### PR DESCRIPTION
crt_hdlr_iv_sync leaks one ivns_internal reference on the common path.
On the error path, it drops a nonexistent reference by mistake.

Signed-off-by: Li Wei <wei.g.li@intel.com>