### PR TITLE
CART-802 iv: crt_iv_update leaks NS references

### DIFF
--- a/src/cart/crt_iv.c
+++ b/src/cart/crt_iv.c
@@ -2856,6 +2856,7 @@ crt_iv_update_internal(crt_iv_namespace_t ivns, uint32_t class_id,
 
 		if (rc != 0) {
 			D_ERROR("crt_ivu_rpc_issue() failed; rc=%d\n", rc);
+			IVNS_DECREF(cb_info->uci_ivns_internal);
 			D_FREE_PTR(cb_info);
 			D_GOTO(put, rc);
 		}

--- a/src/cart/crt_iv.c
+++ b/src/cart/crt_iv.c
@@ -1920,10 +1920,14 @@ handle_ivsync_response(const struct crt_cb_info *cb_info)
 		iv_ops->ivo_on_put(iv_sync->isc_ivns_internal, NULL,
 					iv_sync->isc_user_priv);
 		D_FREE(iv_sync->isc_iv_key.iov_buf);
-	}
 
-	if (iv_sync->isc_ivns_internal != NULL)
+		/* If isc_do_callback is false decref is done in
+		 * crt_ivsync_rpc_issue()
+		 */
 		IVNS_DECREF(iv_sync->isc_ivns_internal);
+	} else {
+		D_ASSERT(iv_sync->isc_ivns_internal == NULL);
+	}
 
 	D_FREE(iv_sync);
 }


### PR DESCRIPTION
crt_iv_update may leak NS references on certain code paths, as shown by
daos_test -c.

Signed-off-by: Li Wei <wei.g.li@intel.com>