### PR TITLE
CART-89: Pin mercury to < 1.0.1-20 due to incompatiblity

### DIFF
--- a/utils/rpms/cart.spec
+++ b/utils/rpms/cart.spec
@@ -2,7 +2,7 @@
 
 Name:          cart
 Version:       1.6.0
-Release:       2%{?relval}%{?dist}
+Release:       3%{?relval}%{?dist}
 Summary:       CaRT
 
 License:       Apache
@@ -34,6 +34,7 @@ BuildRequires: gcc-c++
 %if %{defined sha1}
 Provides: %{name}-%{sha1}
 %endif
+Requires: mercury < 1.0.1-20
 
 %description
 Collective and RPC Transport (CaRT)
@@ -136,6 +137,9 @@ ln %{?buildroot}%{carthome}/{TESTING/.build_vars,.build_vars-Linux}.sh
 %{carthome}/.build_vars-Linux.sh
 
 %changelog
+* Thu Nov 06 2019 Brian J. Murrell <brian.murrell@intel.com> - 1.6.0-3
+- Pin to mercury < 1.0.1-20 due to incompatibility
+
 * Thu Oct 24 2019 Brian J. Murrell <brian.murrell@intel.com> - 1.6.0-2
 - Add BRs to prefer packages that have choices
 - Add BR for scons >= 2.4 and gcc-c++

--- a/utils/rpms/debian/control
+++ b/utils/rpms/debian/control
@@ -11,7 +11,7 @@ Build-Depends: debhelper (>= 10),
                libpmix-dev,
                libssl-dev,
                libyaml-dev,
-               libmercury-dev (>= 1.0.1-19),
+               libmercury-dev (= 1.0.1-19),
                scons,
                uuid-dev
 Standards-Version: 4.1.2
@@ -52,7 +52,7 @@ Package: libcart1
 Section: libs
 Architecture: any
 Multi-Arch: same
-Depends: libmercury1, libpmix2, libyaml-0-2, libuuid1,
+Depends: libmercury1 (= 1.0.1-19), libpmix2, libyaml-0-2, libuuid1,
          ${shlibs:Depends}, ${misc:Depends}
 Description: Collective and RPC Transport
  CaRT is an open-source RPC transport layer for Big Data and Exascale


### PR DESCRIPTION
mercury-1.0.1-20 was causing IOR and mdtest to fail in DAOS testing.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>