### PR TITLE
DAOS-3677 errno: Move DAOS error codes back to DAOS

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -52,7 +52,7 @@ DESIRED_FLAGS = ['-Wno-gnu-designator',
                  '-Wno-gnu-zero-variadic-macro-arguments',
                  '-Wno-tautological-constant-out-of-range-compare']
 
-CART_VERSION = "2.0.0"
+CART_VERSION = "2.1.0"
 
 def save_build_info(env, prereqs, platform):
     """Save the build information"""

--- a/src/utest/test_gurt_v1.c
+++ b/src/utest/test_gurt_v1.c
@@ -40,4 +40,5 @@
  */
 
 #define D_LOG_V1_TEST
+#define TEST_OLD_ERROR
 #include "test_gurt.c"

--- a/utils/rpms/cart.spec
+++ b/utils/rpms/cart.spec
@@ -1,7 +1,7 @@
 %define carthome %{_exec_prefix}/lib/%{name}
 
 Name:          cart
-Version:       2.0.0
+Version:       2.1.0
 Release:       1%{?relval}%{?dist}
 Summary:       CaRT
 
@@ -136,6 +136,10 @@ ln %{?buildroot}%{carthome}/{TESTING/.build_vars,.build_vars-Linux}.sh
 %{carthome}/.build_vars-Linux.sh
 
 %changelog
+* Mon Nov 11 2019 Jeff Olivier <jeffrey.v.olivier@intel.com> - 2.1.0-1
+- Libcart version 2.1.0-1
+- Add support for registering error codes
+
 * Wed Oct 30 2019 Alexander Oganezov <alexander.a.oganezov@intel.com> - 2.0.0-1
 - Libcart version 2.0.0-1
 - crt_group_primary_modify, crt_group_secondary_modify APIs changed

--- a/utils/rpms/debian/changelog
+++ b/utils/rpms/debian/changelog
@@ -1,3 +1,11 @@
+cart (2.1.0-1) unstable; urgency=medium
+
+  [ Jeff Olivier ]
+  * 2.1.0-1 version of CaRT
+  * crt_group_primary_modify, crt_group_secondary_modify APIs changed.
+
+ -- Jeff Olivier <jeffrey.v.olivier@intel.com>  Mon, 11 Nov 2019 19:27:01 +0000
+
 cart (2.0.0-1) unstable; urgency=medium
 
   [ Alexander Oganezov ]

--- a/utils/rpms/debian/changelog
+++ b/utils/rpms/debian/changelog
@@ -2,7 +2,7 @@ cart (2.1.0-1) unstable; urgency=medium
 
   [ Jeff Olivier ]
   * 2.1.0-1 version of CaRT
-  * crt_group_primary_modify, crt_group_secondary_modify APIs changed.
+  * Add interface to register error codes with gurt
 
  -- Jeff Olivier <jeffrey.v.olivier@intel.com>  Mon, 11 Nov 2019 19:27:01 +0000
 


### PR DESCRIPTION
Create an API in gurt to register error strings with gurt.
Remove DAOS error codes under new D_ERRNO_V2 #define

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>