### PR TITLE
CART-89 build: Remove R: ompi-devel

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,6 +54,7 @@ def cart_rpms = ""
 if (!env.CHANGE_ID &&
     (env.BRANCH_NAME != "weekly-testing" &&
      env.BRANCH_NAME != "master" &&
+     env.BRANCH_NAME != "daos_devel1" &&
      env.BRANCH_NAME != "daos_devel")) {
    currentBuild.result = 'SUCCESS'
    return

--- a/utils/rpms/cart.spec
+++ b/utils/rpms/cart.spec
@@ -2,7 +2,7 @@
 
 Name:          cart
 Version:       2.0.0
-Release:       1%{?relval}%{?dist}
+Release:       2%{?relval}%{?dist}
 Summary:       CaRT
 
 License:       Apache
@@ -55,7 +55,9 @@ Requires: boost-devel
 Requires: mercury-devel
 Requires: openpa-devel
 Requires: libfabric-devel
-Requires: ompi-devel
+# can't do this until we can land ompi@PR-10 and
+# scons_local@bmurrell/ompi-env-module
+#Requires: ompi-devel
 Requires: pmix-devel
 Requires: hwloc-devel
 %if %{defined sha1}
@@ -136,6 +138,12 @@ ln %{?buildroot}%{carthome}/{TESTING/.build_vars,.build_vars-Linux}.sh
 %{carthome}/.build_vars-Linux.sh
 
 %changelog
+* Mon Nov 11 2019 Brian J. Murrell <brian.murrell@intel.com> - 2.0.0-2
+- Don't R: ompi-devel from cart-devel as it breaks the ior
+  build which ends up building with ompi instead of mpich
+  - the correct solution here is to environment-module-ize
+    ompi
+
 * Wed Oct 30 2019 Alexander Oganezov <alexander.a.oganezov@intel.com> - 2.0.0-1
 - Libcart version 2.0.0-1
 - crt_group_primary_modify, crt_group_secondary_modify APIs changed


### PR DESCRIPTION

From cart-devel since it breaks ior building because ior ends up
building with ompi instead of mpich.
The right solution is to build an environment-module-ized ompi.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>