### PR TITLE
CART-89 fix: Off by 1 error

### DIFF
--- a/src/cart/crt_group.c
+++ b/src/cart/crt_group.c
@@ -3310,7 +3310,7 @@ crt_grp_config_psr_load(struct crt_grp_priv *grp_priv, d_rank_t psr_rank)
 		D_GOTO(out, rc = d_errno2der(errno));
 	}
 
-	D_ALLOC(grpname, CRT_GROUP_ID_MAX_LEN);
+	D_ALLOC(grpname, CRT_GROUP_ID_MAX_LEN + 1);
 	if (grpname == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 	snprintf(fmt, 64, "%%*s%%%ds", CRT_GROUP_ID_MAX_LEN);


### PR DESCRIPTION
Off by 1 error when filling group id from file. Group name should
account for trailing '\0'

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>