### PR TITLE
DAOS-2822 iv: Add ivo_pre_sync

### DIFF
--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -149,7 +149,7 @@ CRT_RPC_DEFINE(crt_iv_sync, CRT_ISEQ_IV_SYNC, CRT_OSEQ_IV_SYNC)
 
 static struct crt_corpc_ops crt_iv_sync_co_ops = {
 	.co_aggregate = crt_iv_sync_corpc_aggregate,
-	.co_pre_forward = NULL,
+	.co_pre_forward = crt_iv_sync_corpc_pre_forward,
 };
 
 /* barrier */

--- a/src/cart/crt_rpc.h
+++ b/src/cart/crt_rpc.h
@@ -701,6 +701,7 @@ void crt_hdlr_iv_update(crt_rpc_t *rpc_req);
 void crt_hdlr_iv_sync(crt_rpc_t *rpc_req);
 int crt_iv_sync_corpc_aggregate(crt_rpc_t *source, crt_rpc_t *result,
 				void *arg);
+int crt_iv_sync_corpc_pre_forward(crt_rpc_t *rpc, void *arg);
 
 /* crt_register.c */
 int

--- a/src/include/cart/iv.h
+++ b/src/include/cart/iv.h
@@ -343,6 +343,23 @@ typedef int (*crt_iv_on_put_cb_t)(crt_iv_namespace_t ivns,
 typedef bool (*crt_iv_keys_match_cb_t)(crt_iv_namespace_t ivns,
 				crt_iv_key_t *key1, crt_iv_key_t *key2);
 
+/**
+ * If provided, this callback will be called before the
+ * synchronization/notification is propagated (flowing down from root to leaf)
+ * to the child nodes, if any.
+ *
+ * \param[in] ivns		the local handle of the IV namespace
+ * \param[in] iv_key		key of the IV
+ * \param[in] iv_ver		version of the IV
+ * \param[in] iv_value		IV value to be refresh
+ * \param[in] arg		private user data
+ *
+ * \return			DER_SUCCESS on success, negative value if error
+ */
+typedef int (*crt_iv_pre_sync_cb_t)(crt_iv_namespace_t ivns,
+				    crt_iv_key_t *iv_key, crt_iv_ver_t iv_ver,
+				    d_sg_list_t *iv_value, void *arg);
+
 struct crt_iv_ops {
 	crt_iv_pre_fetch_cb_t	ivo_pre_fetch;
 	crt_iv_on_fetch_cb_t	ivo_on_fetch;
@@ -354,6 +371,7 @@ struct crt_iv_ops {
 	crt_iv_on_get_cb_t	ivo_on_get;
 	crt_iv_on_put_cb_t	ivo_on_put;
 	crt_iv_keys_match_cb_t	ivo_keys_match;
+	crt_iv_pre_sync_cb_t	ivo_pre_sync;
 };
 
 /**


### PR DESCRIPTION
Add a new IV callback, ivo_pre_sync, which will be called before
forwarding IV_SYNC requests to children (if any), in order to update a
special IV whose value defines the IV NS's group membership.

Signed-off-by: Li Wei <wei.g.li@intel.com>