### PR TITLE
CART-818 corpc: Fix -DER_OOGs from crt_corpc_info_init

### DIFF
--- a/src/cart/crt_corpc.c
+++ b/src/cart/crt_corpc.c
@@ -51,9 +51,7 @@ crt_corpc_info_init(struct crt_rpc_priv *rpc_priv,
 {
 	struct crt_corpc_info	*co_info;
 	struct crt_corpc_hdr	*co_hdr;
-	int			 rc = 0;
-	d_rank_list_t		*membs;
-	uint32_t		 nr;
+	int			 rc;
 
 	D_ASSERT(rpc_priv != NULL);
 	D_ASSERT(grp_priv != NULL);
@@ -72,19 +70,6 @@ crt_corpc_info_init(struct crt_rpc_priv *rpc_priv,
 		crt_grp_priv_addref(grp_priv);
 	co_info->co_grp_ref_taken = 1;
 	co_info->co_grp_priv = grp_priv;
-
-	if (co_info->co_filter_ranks != NULL) {
-		membs = grp_priv_get_membs(grp_priv);
-		nr = co_info->co_filter_ranks->rl_nr;
-		d_rank_list_filter(membs, co_info->co_filter_ranks,
-				   false /* exclude */);
-		if ((flags & CRT_RPC_FLAG_EXCLUSIVE) &&
-		    (co_info->co_filter_ranks->rl_nr != nr)) {
-			D_ERROR("%u/%u exclusive ranks out of group\n",
-				nr - co_info->co_filter_ranks->rl_nr, nr);
-			D_GOTO(out, rc = -DER_OOG);
-		}
-	}
 
 	co_info->co_grp_ver = grp_ver;
 	co_info->co_tree_topo = tree_topo;

--- a/src/cart/crt_corpc.c
+++ b/src/cart/crt_corpc.c
@@ -99,6 +99,7 @@ crt_corpc_info_init(struct crt_rpc_priv *rpc_priv,
 		co_hdr->coh_tree_topo = tree_topo;
 		co_hdr->coh_root = grp_root;
 	}
+
 	co_hdr->coh_bulk_hdl = co_bulk_hdl;
 
 	rpc_priv->crp_corpc_info = co_info;


### PR DESCRIPTION
If rank 0, whose local primary group comprising {0, 1, 2}, sends a
CRT_RPC_FLAG_EXCLUSIVE CoRPC to {0, 1, 2}, and if rank 1 receives the
request but has a stale local primary group comprising only {1}, then
rank 1 will return -DER_OOG in crt_corpc_info_init. The user does not
immediately know whether the -DER_OOG is due to his {0, 1, 2} exclusive
rank list being incorrect or one of the remote ranks possessing a
mismatching group membership. Moreover, accessing the group membership
in crt_corpc_info_init in order to perform the -DER_OOG check happens
before the CoRPC's pre_forward callback gets a chance to run, violating
the pre_forward semantics. This patch removes the -DER_OOG check in
crt_corpc_info_init and defers it to crt_get_filtered_grp_rank_list,
called after performing the group version check. Consequently, the case
above will return the clearer -DER_MISMATCH, whereas an incorrect
exclusive rank list on the root rank will still get -DER_OOG.

Signed-off-by: Li Wei <wei.g.li@intel.com>