### PR TITLE
CART-819 grp: Group versioning over secondary groups

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -52,7 +52,7 @@ DESIRED_FLAGS = ['-Wno-gnu-designator',
                  '-Wno-gnu-zero-variadic-macro-arguments',
                  '-Wno-tautological-constant-out-of-range-compare']
 
-CART_VERSION = "3.0.0"
+CART_VERSION = "3.1.0"
 
 def save_build_info(env, prereqs, platform):
     """Save the build information"""

--- a/src/cart/crt_corpc.c
+++ b/src/cart/crt_corpc.c
@@ -357,7 +357,6 @@ crt_corpc_req_create(crt_context_t crt_ctx, crt_group_t *grp,
 		     int tree_topo, crt_rpc_t **req)
 {
 	struct crt_grp_priv	*grp_priv = NULL;
-	struct crt_grp_priv	*default_grp_priv;
 	struct crt_grp_gdata	*grp_gdata;
 	struct crt_rpc_priv	*rpc_priv = NULL;
 	d_rank_list_t		*tobe_filter_ranks = NULL;
@@ -383,9 +382,6 @@ crt_corpc_req_create(crt_context_t crt_ctx, crt_group_t *grp,
 		D_ERROR("invalid parameter of tree_topo: %#x.\n", tree_topo);
 		D_GOTO(out, rc = -DER_INVAL);
 	}
-
-	default_grp_priv = crt_grp_pub2priv(NULL);
-	D_ASSERT(default_grp_priv != NULL);
 
 	grp_gdata = crt_gdata.cg_grp;
 	D_ASSERT(grp_gdata != NULL);
@@ -450,7 +446,7 @@ crt_corpc_req_create(crt_context_t crt_ctx, crt_group_t *grp,
 	}
 
 	D_RWLOCK_RDLOCK(grp_priv->gp_rwlock_ft);
-	grp_ver = default_grp_priv->gp_membs_ver;
+	grp_ver = grp_priv->gp_membs_ver;
 	D_RWLOCK_UNLOCK(grp_priv->gp_rwlock_ft);
 
 	rc = crt_corpc_info_init(rpc_priv, grp_priv, false, tobe_filter_ranks,

--- a/src/cart/crt_group.c
+++ b/src/cart/crt_group.c
@@ -2103,6 +2103,31 @@ out:
 	return rc;
 }
 
+int
+crt_group_version_set(crt_group_t *grp, uint32_t version)
+{
+	struct crt_grp_priv	*grp_priv;
+	int			 rc = 0;
+
+	if (!crt_initialized()) {
+		D_ERROR("CRT not initialized.\n");
+		D_GOTO(out, rc = -DER_UNINIT);
+	}
+
+	grp_priv = crt_grp_pub2priv(grp);
+	if (!grp_priv) {
+		D_ERROR("Invalid group\n");
+		D_GOTO(out, rc = -DER_INVAL);
+	}
+
+	D_RWLOCK_RDLOCK(grp_priv->gp_rwlock_ft);
+	grp_priv->gp_membs_ver = version;
+	D_RWLOCK_UNLOCK(grp_priv->gp_rwlock_ft);
+
+out:
+	return rc;
+}
+
 static int
 crt_primary_grp_init(crt_group_id_t grpid)
 {

--- a/src/cart/crt_tree.c
+++ b/src/cart/crt_tree.c
@@ -227,20 +227,16 @@ crt_tree_get_children(struct crt_grp_priv *grp_priv, uint32_t grp_ver,
 	uint32_t		 grp_size, nchildren;
 	uint32_t		 *tree_children;
 	struct crt_topo_ops	*tops;
-	struct crt_grp_priv	*default_grp_priv;
 	int			 i, rc = 0;
 
 
-	default_grp_priv = crt_grp_pub2priv(NULL);
-	D_ASSERT(default_grp_priv != NULL);
-
 	D_RWLOCK_RDLOCK(grp_priv->gp_rwlock_ft);
 	if (ver_match != NULL) {
-		*ver_match = (bool)(grp_ver == default_grp_priv->gp_membs_ver);
+		*ver_match = (bool)(grp_ver == grp_priv->gp_membs_ver);
 
 		if (*ver_match == false) {
 			D_ERROR("Version mismatch. Passed: %u current:%u\n",
-				grp_ver, default_grp_priv->gp_membs_ver);
+				grp_ver, grp_priv->gp_membs_ver);
 			D_GOTO(out, rc = -DER_MISMATCH);
 		}
 	}

--- a/src/include/cart/api.h
+++ b/src/include/cart/api.h
@@ -1340,6 +1340,18 @@ int
 crt_group_version(crt_group_t *grp, uint32_t *version);
 
 /**
+ * Set the group membership version
+ *
+ * \param[in] grp              CRT group handle, NULL means the local
+ *                             primary/global group
+ * \param[in] version          New group membership version
+ *
+ * \return                     DER_SUCCESS on success, negative value on error
+ */
+int
+crt_group_version_set(crt_group_t *grp, uint32_t version);
+
+/**
  * Query number of group members.
  *
  * \param[in] grp              CRT group handle, NULL mean the local

--- a/src/test/SConscript
+++ b/src/test/SConscript
@@ -57,7 +57,8 @@ TEST_RPC_ERR_SRC = 'test_rpc_error.c'
 CRT_RPC_TESTS = ['rpc_test_cli.c', 'rpc_test_srv.c', 'rpc_test_srv2.c']
 SWIM_TESTS = ['test_swim.c', 'test_swim_net.c']
 HLC_TESTS = ['test_hlc_net.c']
-TEST_GROUP_NP_TESTS = ['test_group_np_srv.c', 'test_group_np_cli.c']
+TEST_GROUP_NP_TESTS = ['test_group_np_srv.c', 'test_group_np_cli.c',
+                       'no_pmix_group_version.c']
 
 def scons():
     """scons function"""

--- a/src/test/no_pmix_group_version.c
+++ b/src/test/no_pmix_group_version.c
@@ -1,0 +1,577 @@
+/* Copyright (C) 2018-2019 Intel Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted for any purpose (including commercial purposes)
+ * provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions, and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions, and the following disclaimer in the
+ *    documentation and/or materials provided with the distribution.
+ *
+ * 3. In addition, redistributions of modified forms of the source or binary
+ *    code must carry prominent notices stating that the original code was
+ *    changed and the date of the change.
+ *
+ *  4. All publications or advertising materials mentioning features or use of
+ *     this software are asked, but not required, to acknowledge that it was
+ *     developed by Intel Corporation and credit the contributors.
+ *
+ * 5. Neither the name of Intel Corporation, nor the name of any Contributor
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/**
+ * Dynamic group testing for primary and secondary groups
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <assert.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <semaphore.h>
+#include <cart/api.h>
+
+#include "tests_common.h"
+
+static int g_do_shutdown;
+
+#define MY_BASE 0x010000000
+#define MY_VER  0
+
+#define NUM_SERVER_CTX 8
+
+#define RPC_DECLARE(name)						\
+	CRT_RPC_DECLARE(name, CRT_ISEQ_##name, CRT_OSEQ_##name)		\
+	CRT_RPC_DEFINE(name, CRT_ISEQ_##name, CRT_OSEQ_##name)
+
+enum {
+	RPC_SET_VERSION = CRT_PROTO_OPC(MY_BASE, MY_VER, 0),
+	CORPC_TEST,
+	RPC_SHUTDOWN
+} rpc_id_t;
+
+
+#define CRT_ISEQ_RPC_SET_VERSION	/* input fields */	\
+	((d_string_t)		(grp)		CRT_VAR)	\
+	((uint32_t)		(version)	CRT_VAR)	\
+	((uint32_t)		(pad1)		CRT_VAR)
+
+#define CRT_OSEQ_RPC_SET_VERSION	/* output fields */	\
+	((uint64_t)		(field)			CRT_VAR)
+
+#define CRT_ISEQ_RPC_SHUTDOWN	/* input fields */		 \
+	((uint64_t)		(field)			CRT_VAR)
+
+#define CRT_OSEQ_RPC_SHUTDOWN	/* output fields */		 \
+	((uint64_t)		(field)			CRT_VAR)
+
+#define CRT_ISEQ_CORPC_TEST \
+	((uint64_t)		(field)			CRT_VAR)
+
+#define CRT_OSEQ_CORPC_TEST \
+	((uint64_t)		(field)			CRT_VAR)
+
+
+RPC_DECLARE(RPC_SET_VERSION);
+RPC_DECLARE(RPC_SHUTDOWN);
+RPC_DECLARE(CORPC_TEST);
+
+static int
+handler_corpc_test(crt_rpc_t *rpc)
+{
+	DBG_PRINT("CORPC_HANDLER called\n");
+	crt_reply_send(rpc);
+	return 0;
+}
+
+static int
+handler_set_version(crt_rpc_t *rpc)
+{
+	struct RPC_SET_VERSION_in	*input;
+	crt_group_t			*grp;
+	int				rc;
+
+	input = crt_req_get(rpc);
+
+	grp = crt_group_lookup(input->grp);
+
+	if (grp == NULL) {
+		D_ERROR("Unknown group '%s'\n", input->grp);
+		assert(0);
+	}
+
+	rc = crt_group_version_set(grp, input->version);
+	if (rc != 0) {
+		D_ERROR("Failed to set version %d on group '%s'; rc=%d\n",
+			input->version, input->grp, rc);
+		assert(0);
+	}
+
+	crt_reply_send(rpc);
+	return 0;
+}
+
+static int
+handler_shutdown(crt_rpc_t *rpc)
+{
+	DBG_PRINT("Shutdown handler called!\n");
+	crt_reply_send(rpc);
+
+	g_do_shutdown = true;
+	return 0;
+}
+static int
+corpc_aggregate(crt_rpc_t *src, crt_rpc_t *result, void *priv)
+{
+	struct CORPC_TEST_out	*output_src;
+	struct CORPC_TEST_out	*output_result;
+
+
+	output_src = crt_reply_get(src);
+	output_result = crt_reply_get(result);
+
+	output_result->field = output_src->field;
+	return 0;
+}
+
+struct crt_corpc_ops corpc_test_ops = {
+	.co_aggregate = corpc_aggregate,
+	.co_pre_forward = NULL,
+};
+
+struct crt_proto_rpc_format my_proto_rpc_fmt[] = {
+	{
+		.prf_flags	= 0,
+		.prf_req_fmt	= &CQF_RPC_SET_VERSION,
+		.prf_hdlr	= (void *)handler_set_version,
+		.prf_co_ops	= NULL,
+	}, {
+		.prf_flags	= 0,
+		.prf_req_fmt	= &CQF_CORPC_TEST,
+		.prf_hdlr	= (void *)handler_corpc_test,
+		.prf_co_ops	= &corpc_test_ops,
+	}, {
+		.prf_flags	= 0,
+		.prf_req_fmt	= &CQF_RPC_SHUTDOWN,
+		.prf_hdlr	= (void *)handler_shutdown,
+		.prf_co_ops	= NULL,
+	}
+};
+
+struct crt_proto_format my_proto_fmt = {
+	.cpf_name = "my-proto",
+	.cpf_ver = MY_VER,
+	.cpf_count = ARRAY_SIZE(my_proto_rpc_fmt),
+	.cpf_prf = &my_proto_rpc_fmt[0],
+	.cpf_base = MY_BASE,
+};
+
+
+static void *
+progress_function(void *data)
+{
+	int i;
+	crt_context_t *p_ctx = (crt_context_t *)data;
+
+	while (g_do_shutdown == 0)
+		crt_progress(*p_ctx, 1000, NULL, NULL);
+
+	/* Progress contexts for a while after shutdown to send response */
+	for (i = 0; i < 1000; i++)
+		crt_progress(*p_ctx, 1000, NULL, NULL);
+
+	crt_context_destroy(*p_ctx, 1);
+
+	return NULL;
+}
+
+
+struct corpc_wait_info {
+	sem_t	sem;
+	int	rc;
+};
+
+static void
+rpc_handle_reply(const struct crt_cb_info *info)
+{
+	struct corpc_wait_info *wait_info;
+
+	wait_info = (struct corpc_wait_info *)info->cci_arg;
+
+	wait_info->rc = info->cci_rc;
+	sem_post(&wait_info->sem);
+}
+
+static void
+verify_corpc(crt_context_t ctx, crt_group_t *grp, int exp_rc)
+{
+	struct corpc_wait_info	wait_info;
+	crt_rpc_t		*rpc;
+	int			rc;
+
+	DBG_PRINT(">>> Sending test to %s, expected_rc=%d\n",
+		grp->cg_grpid, exp_rc);
+
+	rc = sem_init(&wait_info.sem, 0, 0);
+	if (rc != 0) {
+		D_ERROR("sem_init() failed; rc=%d\n", rc);
+		assert(0);
+	}
+
+	rc = crt_corpc_req_create(ctx, grp, NULL, CORPC_TEST,
+			NULL, 0, 0, crt_tree_topo(CRT_TREE_KNOMIAL, 2),
+			&rpc);
+	if (rc != 0) {
+		D_ERROR("crt_copc_req_create() failed; rc=%d\n", rc);
+		assert(0);
+	}
+
+	rc = crt_req_send(rpc, rpc_handle_reply, &wait_info);
+	if (rc != 0) {
+		D_ERROR("crt_req_send() failed; rc=%d\n", rc);
+		assert(0);
+	}
+
+	tc_sem_timedwait(&wait_info.sem, 10, __LINE__);
+
+	if (wait_info.rc != exp_rc) {
+		D_ERROR("Expected %d got %d\n", exp_rc, wait_info.rc);
+		assert(0);
+	}
+	DBG_PRINT("<<< Test finished successfully\n");
+}
+
+static void
+set_group_version(crt_context_t ctx, crt_group_t *grp,
+		int rank, uint32_t version)
+{
+	struct RPC_SET_VERSION_in	*input;
+	crt_rpc_t			*rpc;
+	crt_endpoint_t			server_ep;
+	struct corpc_wait_info		wait_info;
+	int				rc;
+
+	rc = sem_init(&wait_info.sem, 0, 0);
+	if (rc != 0) {
+		D_ERROR("sem_init() failed; rc=%d\n", rc);
+		assert(0);
+	}
+
+	server_ep.ep_grp = grp;
+	server_ep.ep_rank = rank;
+	server_ep.ep_tag = 0;
+
+	rc = crt_req_create(ctx, &server_ep, RPC_SET_VERSION, &rpc);
+	if (rc != 0) {
+		D_ERROR("SET_VERSION rpc failed; rc=%d\n", rc);
+		assert(0);
+	}
+
+	input = crt_req_get(rpc);
+	input->version = version;
+	input->grp = grp->cg_grpid;
+
+	rc = crt_req_send(rpc, rpc_handle_reply, &wait_info);
+	if (rc != 0) {
+		D_ERROR("crt_req_send() failed; rc=%d\n", rc);
+		assert(0);
+	}
+
+	tc_sem_timedwait(&wait_info.sem, 10, __LINE__);
+}
+
+
+int main(int argc, char **argv)
+{
+	crt_group_t		*grp;
+	crt_context_t		crt_ctx[NUM_SERVER_CTX];
+	pthread_t		progress_thread[NUM_SERVER_CTX];
+	int			i;
+	char			*my_uri;
+	char			*env_self_rank;
+	d_rank_t		my_rank;
+	char			*grp_cfg_file;
+	uint32_t		grp_size;
+	crt_group_t		*sec_grp1;
+	d_rank_list_t		*rank_list;
+	d_rank_list_t		*p_list, *s_list;
+	crt_endpoint_t		server_ep;
+	d_rank_t		rank;
+	crt_rpc_t		*rpc;
+	sem_t			sem;
+	int			rc;
+
+	env_self_rank = getenv("CRT_L_RANK");
+	my_rank = atoi(env_self_rank);
+
+	/* rank, num_attach_retries, is_server, assert_on_error */
+	tc_test_init(my_rank, 20, true, true);
+
+	rc = d_log_init();
+	assert(rc == 0);
+
+	DBG_PRINT("Server starting up\n");
+	rc = crt_init(NULL, CRT_FLAG_BIT_SERVER |
+		CRT_FLAG_BIT_PMIX_DISABLE | CRT_FLAG_BIT_LM_DISABLE);
+	if (rc != 0) {
+		D_ERROR("crt_init() failed; rc=%d\n", rc);
+		assert(0);
+	}
+
+	rc = crt_proto_register(&my_proto_fmt);
+	if (rc != 0) {
+		D_ERROR("crt_proto_register() failed; rc=%d\n", rc);
+		assert(0);
+	}
+
+	grp = crt_group_lookup(NULL);
+	if (!grp) {
+		D_ERROR("Failed to lookup group\n");
+		assert(0);
+	}
+
+	for (i = 0; i < NUM_SERVER_CTX; i++) {
+		rc = crt_context_create(&crt_ctx[i]);
+		if (rc != 0) {
+			D_ERROR("crt_context_create() failed; rc=%d\n", rc);
+			assert(0);
+		}
+
+		rc = pthread_create(&progress_thread[i], 0,
+				progress_function, &crt_ctx[i]);
+		assert(rc == 0);
+	}
+
+	grp_cfg_file = getenv("CRT_L_GRP_CFG");
+
+	rc = crt_rank_self_set(my_rank);
+	if (rc != 0) {
+		D_ERROR("crt_rank_self_set(%d) failed; rc=%d\n",
+			my_rank, rc);
+		assert(0);
+	}
+
+	rc = crt_rank_uri_get(grp, my_rank, 0, &my_uri);
+	if (rc != 0) {
+		D_ERROR("crt_rank_uri_get() failed; rc=%d\n", rc);
+		assert(0);
+	}
+
+	/* load group info from a config file and delete file upon return */
+	rc = tc_load_group_from_file(grp_cfg_file, crt_ctx[0], grp, my_rank,
+					true);
+	if (rc != 0) {
+		D_ERROR("tc_load_group_from_file() failed; rc=%d\n", rc);
+		assert(0);
+	}
+
+	DBG_PRINT("self_rank=%d uri=%s grp_cfg_file=%s\n", my_rank,
+			my_uri, grp_cfg_file);
+	D_FREE(my_uri);
+
+	rc = crt_group_size(NULL, &grp_size);
+	if (rc != 0) {
+		D_ERROR("crt_group_size() failed; rc=%d\n", rc);
+		assert(0);
+	}
+
+	if (grp_size != 8) {
+		D_ERROR("This test expects 8 instances of servers; got=%d\n",
+			grp_size);
+		assert(0);
+	}
+
+	DBG_PRINT("--------------------------------------------------------\n");
+	rc = crt_group_secondary_create("sec_group1", grp, NULL,
+					&sec_grp1);
+	if (rc != 0) {
+		D_ERROR("crt_group_secondary_create() failed; rc=%d\n", rc);
+		assert(0);
+	}
+
+	rc = crt_group_size(sec_grp1, &grp_size);
+	if (rc != 0) {
+		D_ERROR("crt_group_size() failed; rc=%d\n", rc);
+		assert(0);
+	}
+
+	if (grp_size != 0) {
+		D_ERROR("Expected group_size=0 got=%d\n", grp_size);
+		assert(0);
+	}
+
+	d_rank_t real_ranks[] = {0, 1, 2, 3, 4, 5,  6,  7};
+	d_rank_t sec_ranks[] = {10, 9, 8, 7, 6, 41, 42, 43};
+
+	/* Populate secondary group with 1 rank at a time */
+	for (i = 0 ; i < 8; i++) {
+		rc = crt_group_secondary_rank_add(sec_grp1,
+					sec_ranks[i], real_ranks[i]);
+		if (rc != 0) {
+			D_ERROR("Rank addition failed; rc=%d\n", rc);
+			assert(0);
+		}
+	}
+
+	if (my_rank != 0)
+		D_GOTO(join, 0);
+
+	/* Wait for all servers to load up */
+	/* TODO: This will be replaced by proper sync when CART-715 is done */
+	sleep(2);
+
+	rc = crt_group_ranks_get(grp, &rank_list);
+	if (rc != 0) {
+		D_ERROR("crt_group_ranks_get() failed; rc=%d\n", rc);
+		assert(0);
+	}
+
+	rc = tc_wait_for_ranks(crt_ctx[0], grp, rank_list, 0,
+			NUM_SERVER_CTX, 10, 100.0);
+	if (rc != 0) {
+		D_ERROR("wait_for_ranks() failed; rc=%d\n", rc);
+		assert(0);
+	}
+
+	d_rank_list_free(rank_list);
+	rank_list = NULL;
+
+	rc = sem_init(&sem, 0, 0);
+	if (rc != 0) {
+		D_ERROR("sem_init() failed; rc=%d\n", rc);
+		assert(0);
+	}
+
+	rc = crt_group_ranks_get(grp, &p_list);
+	if (rc != 0) {
+		D_ERROR("crt_group_ranks_get() failed; rc=%d\n", rc);
+		assert(0);
+	}
+
+	rc = crt_group_ranks_get(sec_grp1, &s_list);
+	if (rc != 0) {
+		D_ERROR("crt_group_ranks_get() failed; rc=%d\n", rc);
+		assert(0);
+	}
+
+	/* TEST1: Set all ranks sec_grp1 and grp to version 0x1 */
+	for (i = 0; i < s_list->rl_nr; i++) {
+		set_group_version(crt_ctx[1], grp,
+				p_list->rl_ranks[i], 0x1);
+		set_group_version(crt_ctx[1], sec_grp1,
+				s_list->rl_ranks[i], 0x1);
+	}
+	verify_corpc(crt_ctx[1], sec_grp1, DER_SUCCESS);
+	verify_corpc(crt_ctx[1], grp, DER_SUCCESS);
+
+	/* TEST2: Set local sec_grp1 to version 0x123 */
+	crt_group_version_set(sec_grp1, 0x123);
+	verify_corpc(crt_ctx[1], sec_grp1, -DER_MISMATCH);
+
+
+	/* TEST3: Verify primary group 'grp' is still matching versions */
+	verify_corpc(crt_ctx[1], grp, DER_SUCCESS);
+
+	/* TEST4: Set 'sec_grp1' versions on all nodes to 0x123 */
+	for (i = 0; i < s_list->rl_nr; i++) {
+		set_group_version(crt_ctx[1], sec_grp1,
+				s_list->rl_ranks[i], 0x123);
+	}
+	verify_corpc(crt_ctx[1], sec_grp1, DER_SUCCESS);
+
+	/* TEST5: Set 'sec_grp1' rank 5 to version 0x124 */
+	set_group_version(crt_ctx[1], sec_grp1,
+			s_list->rl_ranks[5], 0x124);
+	verify_corpc(crt_ctx[1], sec_grp1, -DER_MISMATCH);
+
+	/* TEST6: Set all ranks 'grp' to version 0x2; 7th rank to 0x3 */
+	for (i = 0; i < p_list->rl_nr; i++) {
+		set_group_version(crt_ctx[1], grp,
+				p_list->rl_ranks[i], 0x2);
+	}
+	set_group_version(crt_ctx[1], grp, p_list->rl_ranks[7], 0x3);
+	verify_corpc(crt_ctx[1], grp, -DER_MISMATCH);
+
+
+	/* Send shutdown RPC to all nodes except for self */
+	DBG_PRINT("Senidng shutdown to all nodes\n");
+
+	/* Note rank at i=0 corresponds to 'self' */
+	for (i = 0; i < s_list->rl_nr; i++) {
+		rank = s_list->rl_ranks[i];
+
+		if (i == 0)
+			continue;
+
+		server_ep.ep_rank = rank;
+		server_ep.ep_tag = 0;
+		server_ep.ep_grp = sec_grp1;
+
+		rc = crt_req_create(crt_ctx[1],
+				&server_ep, RPC_SHUTDOWN,
+				&rpc);
+		if (rc != 0) {
+			D_ERROR("crt_req_create() failed; rc=%d\n", rc);
+			assert(0);
+		}
+
+		rc = crt_req_send(rpc, rpc_handle_reply, &sem);
+		if (rc != 0) {
+			D_ERROR("crt_req_send() failed; rc=%d\n", rc);
+			assert(0);
+		}
+		tc_sem_timedwait(&sem, 10, __LINE__);
+	}
+
+	d_rank_list_free(s_list);
+	d_rank_list_free(p_list);
+
+	g_do_shutdown = 1;
+	sem_destroy(&sem);
+
+	DBG_PRINT("All tesst succeeded\n");
+join:
+
+	/* Wait until shutdown is issued and progress threads exit */
+	for (i = 0; i < NUM_SERVER_CTX; i++)
+		pthread_join(progress_thread[i], NULL);
+
+	DBG_PRINT("Finished waiting for contexts\n");
+
+	rc = crt_group_secondary_destroy(sec_grp1);
+	if (rc != 0) {
+		D_ERROR("Failed to destroy a secondary group\n");
+		assert(0);
+	}
+
+	DBG_PRINT("Destroyed secondary group\n");
+
+	rc = crt_finalize();
+	if (rc != 0) {
+		D_ERROR("crt_finalize() failed with rc=%d\n", rc);
+		assert(0);
+	}
+
+	DBG_PRINT("Finalized\n");
+	d_log_fini();
+
+	return 0;
+}
+

--- a/test/corpc/cart_corpc_five_node.yaml
+++ b/test/corpc/cart_corpc_five_node.yaml
@@ -28,9 +28,9 @@ tests: !mux
     srv_arg: "--name service_group --is_service"
     srv_env: ""
     srv_ppn: "5"
-  corpc_version:
-    name: corpc_version
-    srv_bin: tests/test_corpc_version
-    srv_arg: "--name service_group --is_service"
-    srv_env: ""
-    srv_ppn: "5"
+  #corpc_version:
+    #name: corpc_version
+    #srv_bin: tests/test_corpc_version
+    #srv_arg: "--name service_group --is_service"
+    #srv_env: ""
+    #srv_ppn: "5"

--- a/test/corpc/cart_corpc_one_node.yaml
+++ b/test/corpc/cart_corpc_one_node.yaml
@@ -27,12 +27,12 @@ tests: !mux
     srv_arg: "--name service_group --is_service"
     srv_env: ""
     srv_ppn: "5"
-  corpc_version:
-    name: corpc_version
-    srv_bin: tests/test_corpc_version
-    srv_arg: "--name service_group --is_service"
-    srv_env: ""
-    srv_ppn: "5"
+  #corpc_version:
+    #name: corpc_version
+    #srv_bin: tests/test_corpc_version
+    #srv_arg: "--name service_group --is_service"
+    #srv_env: ""
+    #srv_ppn: "5"
   corpc_exclusive:
     name: corpc_exclusive
     srv_bin: tests/test_corpc_exclusive

--- a/test/corpc/cart_corpc_two_node.yaml
+++ b/test/corpc/cart_corpc_two_node.yaml
@@ -28,9 +28,9 @@ tests: !mux
     srv_arg: "--name service_group --is_service"
     srv_env: ""
     srv_ppn: "5"
-  corpc_version:
-    name: corpc_version
-    srv_bin: tests/test_corpc_version
-    srv_arg: "--name service_group --is_service"
-    srv_env: ""
-    srv_ppn: "5"
+  #corpc_version:
+    #name: corpc_version
+    #srv_bin: tests/test_corpc_version
+    #srv_arg: "--name service_group --is_service"
+    #srv_env: ""
+    #srv_ppn: "5"

--- a/test/group_test/group_test.py
+++ b/test/group_test/group_test.py
@@ -39,7 +39,7 @@ class GroupTest(Test):
     """
     Runs GroupTests for primary and secondary resizeable groups
 
-    :avocado: tags=all,group_test,one_node
+    :avocado: tags=all,group_test,one_node,no_pmix
     """
     def setUp(self):
         """ Test setup """

--- a/test/group_test/group_test.yaml
+++ b/test/group_test/group_test.yaml
@@ -17,3 +17,7 @@ tests: !mux
     srv_bin: ../bin/crt_launch
     srv_arg: "-e tests/no_pmix_group_test"
     srv_ppn: "8"
+    name: group_version_test
+    srv_bin: ../bin/crt_launch
+    srv_arg: "-e tests/no_pmix_group_version"
+    srv_ppn: "8"

--- a/utils/rpms/cart.spec
+++ b/utils/rpms/cart.spec
@@ -1,7 +1,7 @@
 %define carthome %{_exec_prefix}/lib/%{name}
 
 Name:          cart
-Version:       3.0.0
+Version:       3.1.0
 Release:       1%{?relval}%{?dist}
 Summary:       CaRT
 
@@ -138,6 +138,10 @@ ln %{?buildroot}%{carthome}/{TESTING/.build_vars,.build_vars-Linux}.sh
 %{carthome}/.build_vars-Linux.sh
 
 %changelog
+* Tue Nov 19 2019 Alexander Oganezov <alexander.a.oganezov@intel.com> - 3.1.0-1
+- Libcart version 3.1.0-1
+- New crt_group_version_set() API added
+
 * Wed Nov 13 2019 Alexander Oganezov <alexander.a.oganezov@intel.com> - 3.0.0-1
 - Libcart version 3.0.0-1
 - IV namespace APIs changed

--- a/utils/rpms/debian/changelog
+++ b/utils/rpms/debian/changelog
@@ -1,3 +1,11 @@
+cart (3.1.0-1) unstable; urgency=medium
+
+  [ Alexander Oganezov ]
+  * 3.1.0-1 version of CaRT
+  * New crt_group_version_set() API added
+
+ -- Alexander Oganezov <alexander.a.oganezov@intel.com>  Tue, 19 Nov 2019 19:27:01 +0000
+
 cart (3.0.0-1) unstable; urgency=medium
 
   [ Alexander Oganezov ]


### PR DESCRIPTION
- CORPCs are now passed proper associated group versions instead of
the primary groups versions.

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>