### PR TITLE
DAOS-2822 tree: Use DER_GRPVER instead of DER_MISMATCH

### DIFF
--- a/src/cart/crt_corpc.c
+++ b/src/cart/crt_corpc.c
@@ -863,7 +863,7 @@ crt_corpc_req_hdlr(struct crt_rpc_priv *rpc_priv)
 
 	if (!ver_match) {
 		D_INFO("parent version and local version mismatch.\n");
-		rc = -DER_MISMATCH;
+		rc = -DER_GRPVER;
 		co_info->co_child_num = 0;
 		crt_corpc_fail_parent_rpc(rpc_priv, rc);
 		D_GOTO(forward_done, rc);

--- a/src/cart/crt_tree.c
+++ b/src/cart/crt_tree.c
@@ -241,7 +241,7 @@ crt_tree_get_children(struct crt_grp_priv *grp_priv, uint32_t grp_ver,
 		if (*ver_match == false) {
 			D_ERROR("Version mismatch. Passed: %u current:%u\n",
 				grp_ver, default_grp_priv->gp_membs_ver);
-			D_GOTO(out, rc = -DER_MISMATCH);
+			D_GOTO(out, rc = -DER_GRPVER);
 		}
 	}
 

--- a/src/include/gurt/errno.h
+++ b/src/include/gurt/errno.h
@@ -123,7 +123,9 @@
 	/** denial-of-service */					\
 	ACTION(DER_DOS,			(DER_ERR_GURT_BASE + 34))       \
 	/** Incorrect target for the RPC  */				\
-	ACTION(DER_BAD_TARGET,		(DER_ERR_GURT_BASE + 35))
+	ACTION(DER_BAD_TARGET,		(DER_ERR_GURT_BASE + 35))	\
+	/** group version mismatch */					\
+	ACTION(DER_GRPVER,		(DER_ERR_GURT_BASE + 36))
 	/** TODO: add more error numbers */
 
 #define D_FOREACH_DAOS_ERR(ACTION)					\

--- a/src/test/test_corpc_version.c
+++ b/src/test/test_corpc_version.c
@@ -495,7 +495,7 @@ client_cb(const struct crt_cb_info *cb_info)
  * rank is hit first, we might bet back -DER_NONEXIST instead
  * if rank updated membership list but group version hasnt changed yet
  */
-		D_ASSERTF((cb_info->cci_rc == -DER_MISMATCH ||
+		D_ASSERTF((cb_info->cci_rc == -DER_GRPVER ||
 			cb_info->cci_rc == -DER_NONEXIST),
 			"cb_info->cci_rc %d\n", cb_info->cci_rc);
 		corpc_ver_mismatch_cb(rpc_req);


### PR DESCRIPTION
Since DER_MISMATCH has been used by DAOS for several other purposes, use
DER_GRPVER instead for CaRT group version mismatches.

Signed-off-by: Li Wei <wei.g.li@intel.com>