### PR TITLE
CART-89 err: New DER_GRPVER error code added

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -52,7 +52,7 @@ DESIRED_FLAGS = ['-Wno-gnu-designator',
                  '-Wno-gnu-zero-variadic-macro-arguments',
                  '-Wno-tautological-constant-out-of-range-compare']
 
-CART_VERSION = "3.1.0"
+CART_VERSION = "3.2.0"
 
 def save_build_info(env, prereqs, platform):
     """Save the build information"""

--- a/src/cart/crt_corpc.c
+++ b/src/cart/crt_corpc.c
@@ -859,7 +859,7 @@ crt_corpc_req_hdlr(struct crt_rpc_priv *rpc_priv)
 
 	if (!ver_match) {
 		D_INFO("parent version and local version mismatch.\n");
-		rc = -DER_MISMATCH;
+		rc = -DER_GRPVER;
 		co_info->co_child_num = 0;
 		crt_corpc_fail_parent_rpc(rpc_priv, rc);
 		D_GOTO(forward_done, rc);

--- a/src/cart/crt_tree.c
+++ b/src/cart/crt_tree.c
@@ -237,7 +237,7 @@ crt_tree_get_children(struct crt_grp_priv *grp_priv, uint32_t grp_ver,
 		if (*ver_match == false) {
 			D_ERROR("Version mismatch. Passed: %u current:%u\n",
 				grp_ver, grp_priv->gp_membs_ver);
-			D_GOTO(out, rc = -DER_MISMATCH);
+			D_GOTO(out, rc = -DER_GRPVER);
 		}
 	}
 

--- a/src/include/gurt/errno.h
+++ b/src/include/gurt/errno.h
@@ -123,7 +123,9 @@
 	/** denial-of-service */					\
 	ACTION(DER_DOS,			(DER_ERR_GURT_BASE + 34))       \
 	/** Incorrect target for the RPC  */				\
-	ACTION(DER_BAD_TARGET,		(DER_ERR_GURT_BASE + 35))
+	ACTION(DER_BAD_TARGET,		(DER_ERR_GURT_BASE + 35))	\
+	/** Group versioning mismatch */				\
+	ACTION(DER_GRPVER,		(DER_ERR_GURT_BASE + 36))
 	/** TODO: add more error numbers */
 
 #define D_FOREACH_DAOS_ERR(ACTION)					\

--- a/src/test/no_pmix_group_version.c
+++ b/src/test/no_pmix_group_version.c
@@ -483,8 +483,7 @@ int main(int argc, char **argv)
 
 	/* TEST2: Set local sec_grp1 to version 0x123 */
 	crt_group_version_set(sec_grp1, 0x123);
-	verify_corpc(crt_ctx[1], sec_grp1, -DER_MISMATCH);
-
+	verify_corpc(crt_ctx[1], sec_grp1, -DER_GRPVER);
 
 	/* TEST3: Verify primary group 'grp' is still matching versions */
 	verify_corpc(crt_ctx[1], grp, DER_SUCCESS);
@@ -499,7 +498,7 @@ int main(int argc, char **argv)
 	/* TEST5: Set 'sec_grp1' rank 5 to version 0x124 */
 	set_group_version(crt_ctx[1], sec_grp1,
 			s_list->rl_ranks[5], 0x124);
-	verify_corpc(crt_ctx[1], sec_grp1, -DER_MISMATCH);
+	verify_corpc(crt_ctx[1], sec_grp1, -DER_GRPVER);
 
 	/* TEST6: Set all ranks 'grp' to version 0x2; 7th rank to 0x3 */
 	for (i = 0; i < p_list->rl_nr; i++) {
@@ -507,7 +506,7 @@ int main(int argc, char **argv)
 				p_list->rl_ranks[i], 0x2);
 	}
 	set_group_version(crt_ctx[1], grp, p_list->rl_ranks[7], 0x3);
-	verify_corpc(crt_ctx[1], grp, -DER_MISMATCH);
+	verify_corpc(crt_ctx[1], grp, -DER_GRPVER);
 
 
 	/* Send shutdown RPC to all nodes except for self */

--- a/src/test/test_corpc_version.c
+++ b/src/test/test_corpc_version.c
@@ -495,7 +495,7 @@ client_cb(const struct crt_cb_info *cb_info)
  * rank is hit first, we might bet back -DER_NONEXIST instead
  * if rank updated membership list but group version hasnt changed yet
  */
-		D_ASSERTF((cb_info->cci_rc == -DER_MISMATCH ||
+		D_ASSERTF((cb_info->cci_rc == -DER_GRPVER ||
 			cb_info->cci_rc == -DER_NONEXIST),
 			"cb_info->cci_rc %d\n", cb_info->cci_rc);
 		corpc_ver_mismatch_cb(rpc_req);

--- a/utils/rpms/cart.spec
+++ b/utils/rpms/cart.spec
@@ -138,6 +138,10 @@ ln %{?buildroot}%{carthome}/{TESTING/.build_vars,.build_vars-Linux}.sh
 %{carthome}/.build_vars-Linux.sh
 
 %changelog
+* Thu Nov 21 2019 Alexander Oganezov <alexander.a.oganezov@intel.com> - 3.2.0-1
+- Libcart version 3.2.0-1
+- New DER_GRPVER error code added
+
 * Tue Nov 19 2019 Alexander Oganezov <alexander.a.oganezov@intel.com> - 3.1.0-1
 - Libcart version 3.1.0-1
 - New crt_group_version_set() API added

--- a/utils/rpms/debian/changelog
+++ b/utils/rpms/debian/changelog
@@ -1,3 +1,11 @@
+cart (3.2.0-1) unstable; urgency=medium
+
+  [ Alexander Oganezov ]
+  * 3.2.0-1 version of CaRT
+  * New DER_GRPVER error code added
+
+ -- Alexander Oganezov <alexander.a.oganezov@intel.com>  Thu, 21 Nov 2019 19:27:01 +0000
+
 cart (3.1.0-1) unstable; urgency=medium
 
   [ Alexander Oganezov ]


### PR DESCRIPTION
- New DER_GRPVER error code added to replace DER_MISMATCH
- Libcart rolled to 3.2.0-1

Singed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>