### PR TITLE
DAOS-3600 gurt: add errno of DER_DF_INVAL/DER_DF_INCOMPT/DER_REC_SIZE

### DIFF
--- a/src/include/gurt/errno.h
+++ b/src/include/gurt/errno.h
@@ -170,7 +170,13 @@
 	/** Not a service replica */					\
 	ACTION(DER_NOTREPLICA,		(DER_ERR_DAOS_BASE + 20))	\
 	/** Checksum error */						\
-	ACTION(DER_CSUM,		(DER_ERR_DAOS_BASE + 21))
+	ACTION(DER_CSUM,		(DER_ERR_DAOS_BASE + 21))	\
+	/** Unsupported durable format */				\
+	ACTION(DER_DF_INVAL,		(DER_ERR_DAOS_BASE + 22))	\
+	/** Incompatible durable format version */			\
+	ACTION(DER_DF_INCOMPT,		(DER_ERR_DAOS_BASE + 23))	\
+	/** Record size error */					\
+	ACTION(DER_REC_SIZE,		(DER_ERR_DAOS_BASE + 24))
 
 #if defined(D_ERRNO_V2)
 /** Defines the gurt error codes */


### PR DESCRIPTION
Just to add 3 DAOS err code DER_DF_INVAL/DER_DF_INCOMPT/DER_REC_SIZE.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>