### PR TITLE
CART-89 type: Move CRT_NO_RANK to external header file

### DIFF
--- a/src/cart/crt_group.c
+++ b/src/cart/crt_group.c
@@ -2679,6 +2679,11 @@ crt_rank_self_set(d_rank_t rank)
 
 	default_grp_priv = crt_gdata.cg_grp->gg_primary_grp;
 
+	if (!crt_is_service()) {
+		D_WARN("Setting self rank is not supported on client\n");
+		return 0;
+	}
+
 	if (default_grp_priv->gp_self != CRT_NO_RANK) {
 		D_ERROR("Self rank was already set to %d\n",
 			default_grp_priv->gp_self);
@@ -2743,7 +2748,7 @@ crt_rank_uri_get(crt_group_t *group, d_rank_t rank, int tag, char **uri_str)
 		D_GOTO(out, rc = -DER_INVAL);
 	}
 
-	if (rank == grp_priv->gp_self)
+	if (rank == grp_priv->gp_self && crt_is_service())
 		return crt_self_uri_get(tag, uri_str);
 
 	rc = crt_grp_lc_lookup(grp_priv, 0, rank, tag, &uri, &hg_addr);

--- a/src/cart/crt_group.h
+++ b/src/cart/crt_group.h
@@ -61,7 +61,6 @@ struct crt_rank_map {
 
 
 #define RANK_LIST_REALLOC_SIZE 32
-#define CRT_NO_RANK 0xFFFFFFFF
 
 #define CRT_MAX_SEC_GRPS 10
 

--- a/src/include/cart/types.h
+++ b/src/include/cart/types.h
@@ -112,6 +112,9 @@ typedef d_string_t	crt_group_id_t;
 /** default group ID */
 #define CRT_DEFAULT_GRPID	"crt_default_group"
 
+/** Indicates rank not being set */
+#define CRT_NO_RANK 0xFFFFFFFF
+
 typedef struct crt_group {
 	/** the group ID of this group */
 	crt_group_id_t	cg_grpid;


### PR DESCRIPTION
Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>