### PR TITLE
CART-89 build: Fix some build issues with orterun removal

### DIFF
--- a/utils/rpms/cart.spec
+++ b/utils/rpms/cart.spec
@@ -56,10 +56,7 @@ Requires: boost-devel
 Requires: mercury-devel = 1.0.1-21%{?dist}
 Requires: openpa-devel
 Requires: libfabric-devel
-# can't do this until we can land ompi@PR-10 and
-# scons_local@bmurrell/ompi-env-module
-#Requires: ompi-devel
-Requires: openmpi-devel
+Requires: openmpi3-devel
 Requires: hwloc-devel
 %if %{defined sha1}
 Provides: %{name}-devel-%{sha1}


### PR DESCRIPTION
Updates scons_local to get an env_modules fix with python3
Removes dependence on openmpi-devel from cart rpm spec

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>