### PR TITLE
CART-805 groups: Remove restriction on number of secondary groups

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -109,6 +109,8 @@ def scons():
     env.Append(CCFLAGS=['-g3', '-Wshadow', '-Wall', '-Werror', '-fpic',
                         '-D_GNU_SOURCE'])
     env.Append(CCFLAGS=['-O2', '-pthread'])
+    env.Append(CCFLAGS=['-DCART_VERSION=\\"' + CART_VERSION + '\\"'])
+
     env.Append(CFLAGS=['-std=gnu99'])
     if not GetOption('clean'):
         env.AppendIfSupported(CCFLAGS=DESIRED_FLAGS)

--- a/src/cart/crt_barrier.c
+++ b/src/cart/crt_barrier.c
@@ -115,7 +115,7 @@ crt_barrier_update_master(struct crt_grp_priv *grp_priv)
 
 	D_MUTEX_LOCK(&info->bi_lock);
 
-	D_RWLOCK_RDLOCK(&primary_grp->gp_rwlock_ft);
+	D_RWLOCK_RDLOCK(&primary_grp->gp_rwlock);
 
 	membs = grp_priv_get_membs(grp_priv);
 
@@ -149,7 +149,7 @@ crt_barrier_update_master(struct crt_grp_priv *grp_priv)
 	}
 
 out:
-	D_RWLOCK_UNLOCK(&primary_grp->gp_rwlock_ft);
+	D_RWLOCK_UNLOCK(&primary_grp->gp_rwlock);
 	D_MUTEX_UNLOCK(&info->bi_lock);
 
 	return new_master;

--- a/src/cart/crt_corpc.c
+++ b/src/cart/crt_corpc.c
@@ -436,9 +436,9 @@ crt_corpc_req_create(crt_context_t crt_ctx, crt_group_t *grp,
 		}
 	}
 
-	D_RWLOCK_RDLOCK(&grp_priv->gp_rwlock_ft);
+	D_RWLOCK_RDLOCK(&grp_priv->gp_rwlock);
 	grp_ver = grp_priv->gp_membs_ver;
-	D_RWLOCK_UNLOCK(&grp_priv->gp_rwlock_ft);
+	D_RWLOCK_UNLOCK(&grp_priv->gp_rwlock);
 
 	rc = crt_corpc_info_init(rpc_priv, grp_priv, false, tobe_filter_ranks,
 				 grp_ver /* grp_ver */, co_bulk_hdl, priv,

--- a/src/cart/crt_group.c
+++ b/src/cart/crt_group.c
@@ -1120,8 +1120,8 @@ crt_grp_priv_destroy(struct crt_grp_priv *grp_priv)
 		 * crt_group_secondary_create.
 		 */
 		if (grp_priv_prim != NULL) {
-			struct crt_grp_priv_sec *entry;
-			bool found = false;
+			struct crt_grp_priv_sec	*entry;
+			bool 			found = false;
 
 			d_list_for_each_entry(entry,
 					&grp_priv_prim->gp_sec_list,

--- a/src/cart/crt_group.c
+++ b/src/cart/crt_group.c
@@ -1121,7 +1121,7 @@ crt_grp_priv_destroy(struct crt_grp_priv *grp_priv)
 		 */
 		if (grp_priv_prim != NULL) {
 			struct crt_grp_priv_sec	*entry;
-			bool 			found = false;
+			bool			found = false;
 
 			d_list_for_each_entry(entry,
 					&grp_priv_prim->gp_sec_list,

--- a/src/cart/crt_group.c
+++ b/src/cart/crt_group.c
@@ -1123,8 +1123,9 @@ crt_grp_priv_destroy(struct crt_grp_priv *grp_priv)
 			struct crt_grp_priv_sec *entry;
 			bool found = false;
 
-			d_list_for_each_entry(entry, &grp_priv_prim->gp_sec_list,
-						gps_link) {
+			d_list_for_each_entry(entry,
+					&grp_priv_prim->gp_sec_list,
+					gps_link) {
 				if (entry->gps_priv == grp_priv) {
 					found = true;
 					break;

--- a/src/cart/crt_group.h
+++ b/src/cart/crt_group.h
@@ -106,10 +106,7 @@ struct crt_grp_priv {
 	 * correspond to members in gp_membs.
 	 */
 	struct crt_swim_membs	 gp_membs_swim;
-	/*
-	 * protects group modifications
-	 */
-	pthread_rwlock_t	 gp_rwlock_ft;
+
 	/* CaRT context only for sending sub-grp create/destroy RPCs */
 	crt_context_t		 gp_ctx;
 
@@ -402,11 +399,11 @@ crt_rank_present(crt_group_t *grp, d_rank_t rank)
 
 	D_ASSERTF(priv != NULL, "group priv is NULL\n");
 
-	D_RWLOCK_RDLOCK(&priv->gp_rwlock_ft);
+	D_RWLOCK_RDLOCK(&priv->gp_rwlock);
 	membs = grp_priv_get_membs(priv);
 	if (membs)
 		ret = d_rank_in_rank_list(membs, rank);
-	D_RWLOCK_UNLOCK(&priv->gp_rwlock_ft);
+	D_RWLOCK_UNLOCK(&priv->gp_rwlock);
 
 	return ret;
 }

--- a/src/cart/crt_group.h
+++ b/src/cart/crt_group.h
@@ -51,8 +51,6 @@
 
 #define RANK_LIST_REALLOC_SIZE 32
 
-#define CRT_MAX_SEC_GRPS 10
-
 /* Node for keeping info about free index */
 struct free_index {
 	/* Index to store */

--- a/src/cart/crt_group.h
+++ b/src/cart/crt_group.h
@@ -75,6 +75,11 @@ struct crt_grp_membs {
 	d_rank_list_t	*cgm_linear_list;
 };
 
+struct crt_grp_priv_sec {
+	struct crt_grp_priv	*gps_priv;
+	d_list_t		gps_link;
+};
+
 struct crt_grp_priv;
 
 struct crt_grp_priv {
@@ -85,7 +90,7 @@ struct crt_grp_priv {
 	struct crt_grp_priv	*gp_priv_prim;
 
 	/* List of secondary groups associated with this group */
-	struct crt_grp_priv	*gp_priv_sec[CRT_MAX_SEC_GRPS];
+	d_list_t		gp_sec_list;
 
 	/*
 	 * member ranks, should be unique and sorted, each member is the rank

--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -212,6 +212,8 @@ crt_init_opt(crt_group_id_t grpid, uint32_t flags, crt_init_options_t *opt)
 
 	crt_setup_log_fac();
 
+	D_INFO("libcart version %s initializing\n", CART_VERSION);
+
 	/* d_fault_inject_init() is reference counted */
 	rc = d_fault_inject_init();
 	if (rc != DER_SUCCESS) {

--- a/src/cart/crt_tree.c
+++ b/src/cart/crt_tree.c
@@ -147,7 +147,7 @@ crt_tree_get_nchildren(struct crt_grp_priv *grp_priv, uint32_t grp_ver,
 	struct crt_topo_ops	*tops;
 	int			 rc = 0;
 
-	D_RWLOCK_RDLOCK(&grp_priv->gp_rwlock_ft);
+	D_RWLOCK_RDLOCK(&grp_priv->gp_rwlock);
 
 	CRT_TREE_PARAMETER_CHECKING(grp_priv, tree_topo, root, self);
 	if (nchildren == NULL) {
@@ -185,7 +185,7 @@ crt_tree_get_nchildren(struct crt_grp_priv *grp_priv, uint32_t grp_ver,
 			root, self, rc);
 
 out:
-	D_RWLOCK_UNLOCK(&grp_priv->gp_rwlock_ft);
+	D_RWLOCK_UNLOCK(&grp_priv->gp_rwlock);
 	if (allocated)
 		d_rank_list_free(grp_rank_list);
 	return rc;
@@ -215,7 +215,7 @@ crt_tree_get_children(struct crt_grp_priv *grp_priv, uint32_t grp_ver,
 	int			 i, rc = 0;
 
 
-	D_RWLOCK_RDLOCK(&grp_priv->gp_rwlock_ft);
+	D_RWLOCK_RDLOCK(&grp_priv->gp_rwlock);
 	if (ver_match != NULL) {
 		*ver_match = (bool)(grp_ver == grp_priv->gp_membs_ver);
 
@@ -296,7 +296,7 @@ crt_tree_get_children(struct crt_grp_priv *grp_priv, uint32_t grp_ver,
 	*children_rank_list = result_rank_list;
 
 out:
-	D_RWLOCK_UNLOCK(&grp_priv->gp_rwlock_ft);
+	D_RWLOCK_UNLOCK(&grp_priv->gp_rwlock);
 	if (allocated)
 		d_rank_list_free(grp_rank_list);
 	return rc;
@@ -315,7 +315,7 @@ crt_tree_get_parent(struct crt_grp_priv *grp_priv, uint32_t grp_ver,
 	struct crt_topo_ops	*tops;
 	int			 rc = 0;
 
-	D_RWLOCK_RDLOCK(&grp_priv->gp_rwlock_ft);
+	D_RWLOCK_RDLOCK(&grp_priv->gp_rwlock);
 
 	CRT_TREE_PARAMETER_CHECKING(grp_priv, tree_topo, root, self);
 	if (parent_rank == NULL) {
@@ -355,7 +355,7 @@ crt_tree_get_parent(struct crt_grp_priv *grp_priv, uint32_t grp_ver,
 	*parent_rank = grp_rank_list->rl_ranks[tree_parent];
 
 out:
-	D_RWLOCK_UNLOCK(&grp_priv->gp_rwlock_ft);
+	D_RWLOCK_UNLOCK(&grp_priv->gp_rwlock);
 	if (allocated)
 		d_rank_list_free(grp_rank_list);
 	return rc;

--- a/test/group_test/group_test.yaml
+++ b/test/group_test/group_test.yaml
@@ -5,7 +5,7 @@ defaultENV:
   #!filter-only : /run/tests/no_pmix_launcher
   CRT_PHY_ADDR_STR: "ofi+sockets"
   OFI_INTERFACE: "eth0"
-  D_LOG_MASK: "ERR"
+  D_LOG_MASK: "DEBUG"
 hosts: !mux
   hosts_1:
     config: one_node

--- a/test/group_test/group_test.yaml
+++ b/test/group_test/group_test.yaml
@@ -17,6 +17,7 @@ tests: !mux
     srv_bin: ../bin/crt_launch
     srv_arg: "-e tests/no_pmix_group_test"
     srv_ppn: "8"
+  version_test:
     name: group_version_test
     srv_bin: ../bin/crt_launch
     srv_arg: "-e tests/no_pmix_group_version"


### PR DESCRIPTION
- Secondary groups are now stored in linked list inside of primary
  group.
- Group test was missing entry making one of tests not run

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>