### PR TITLE
CART-89 logs: Test log changes

### DIFF
--- a/src/cart/crt_group.c
+++ b/src/cart/crt_group.c
@@ -2581,6 +2581,8 @@ crt_rank_self_set(d_rank_t rank)
 
 	default_grp_priv = crt_gdata.cg_grp->gg_primary_grp;
 
+	D_DEBUG(DB_ALL, "Setting default group primary rank=%d\n", rank);
+
 	if (!crt_is_service()) {
 		D_WARN("Setting self rank is not supported on client\n");
 		return 0;
@@ -2593,7 +2595,6 @@ crt_rank_self_set(d_rank_t rank)
 	}
 
 	D_RWLOCK_WRLOCK(&default_grp_priv->gp_rwlock);
-
 	default_grp_priv->gp_self = rank;
 	rc = grp_add_to_membs_list(default_grp_priv, rank);
 	D_RWLOCK_UNLOCK(&default_grp_priv->gp_rwlock);

--- a/src/test/tests_common.h
+++ b/src/test/tests_common.h
@@ -47,6 +47,7 @@
 
 #define DBG_PRINT(x...)                                                 \
 	do {                                                            \
+		D_INFO(x);						\
 		if (opts.is_server)                                     \
 			fprintf(stderr, "SRV [rank=%d pid=%d]\t",       \
 			opts.self_rank,                                 \

--- a/test/util/cart_utils.py
+++ b/test/util/cart_utils.py
@@ -143,13 +143,12 @@ class CartUtils():
         host_cfg = cartobj.params.get("config", "/run/hosts/*/")
 
         if env_CCSA is not None:
-            log_dir = "{}-{}-{}-{}".format(test_name, host_cfg, cartobj.id(),
-                                           env_CCSA)
+            log_dir = "{}-{}".format(test_name, env_CCSA)
         else:
-            log_dir = "{}-{}-{}".format(test_name, host_cfg, cartobj.id())
+            log_dir = "{}".format(test_name)
 
         log_path = os.path.join("testLogs", log_dir)
-        log_file = os.path.join(log_path, "output.log")
+        log_file = os.path.join(log_path, "cart.log")
 
         log_mask = cartobj.params.get("D_LOG_MASK", "/run/defaultENV/")
         crt_phy_addr = cartobj.params.get("CRT_PHY_ADDR_STR",
@@ -161,6 +160,7 @@ class CartUtils():
         env = " --output-filename {!s}".format(log_path)
 
         env += " -x D_LOG_FILE={!s}".format(log_file)
+        env += " -x D_LOG_FILE_APPEND_PID=1"
 
         if log_mask is not None:
             env += " -x D_LOG_MASK={!s}".format(log_mask)


### PR DESCRIPTION
- Each tests binary now logs into its own cart.log[pid] file
- DBG_PRINT echoes also into cart log
- reduced paths in log dirs to increase readability.

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>