### PR TITLE
CART-89 cache: Cache workaround

### DIFF
--- a/src/cart/crt_group.c
+++ b/src/cart/crt_group.c
@@ -648,6 +648,7 @@ crt_grp_lc_uri_insert(struct crt_grp_priv *passed_grp_priv, int ctx_idx,
 {
 	struct crt_grp_priv	*grp_priv;
 	int			 rc = 0;
+	int			 i;
 
 	D_ASSERT(ctx_idx >= 0 && ctx_idx < CRT_SRV_CONTEXT_NUM);
 	if (tag >= CRT_SRV_CONTEXT_NUM) {
@@ -664,8 +665,11 @@ crt_grp_lc_uri_insert(struct crt_grp_priv *passed_grp_priv, int ctx_idx,
 	}
 
 	D_RWLOCK_WRLOCK(&grp_priv->gp_rwlock);
-	rc = grp_lc_uri_insert_internal_locked(grp_priv, ctx_idx, rank, tag,
+	for (i = 0; i < CRT_SRV_CONTEXT_NUM; i++) {
+		ctx_idx = i;
+		rc = grp_lc_uri_insert_internal_locked(grp_priv, ctx_idx, rank, tag,
 						uri);
+	}
 	D_RWLOCK_UNLOCK(&grp_priv->gp_rwlock);
 
 	return rc;

--- a/src/cart/crt_group.c
+++ b/src/cart/crt_group.c
@@ -667,9 +667,15 @@ crt_grp_lc_uri_insert(struct crt_grp_priv *passed_grp_priv, int ctx_idx,
 	D_RWLOCK_WRLOCK(&grp_priv->gp_rwlock);
 	for (i = 0; i < CRT_SRV_CONTEXT_NUM; i++) {
 		ctx_idx = i;
-		rc = grp_lc_uri_insert_internal_locked(grp_priv, ctx_idx, rank, tag,
-						uri);
+		rc = grp_lc_uri_insert_internal_locked(grp_priv, ctx_idx, rank,
+						tag, uri);
+		if (rc != 0) {
+			D_ERROR("Insertion failed for ctx_idx=%d\n", ctx_idx);
+			D_GOTO(unlock, rc);
+		}
 	}
+
+unlock:
 	D_RWLOCK_UNLOCK(&grp_priv->gp_rwlock);
 
 	return rc;


### PR DESCRIPTION
When uri is inserted today, it creates a corresponding entry
in hg_addr cache. Previously code in cart would insert uri only
for a context on which call was performed, leaving hg_addr entries
for other contexts not created.

This creates a problem due to current mechanic of lc_lookup() internal
call which goes through hg_addr cache first in order to then access
uri cache.

As such if for example uri was added on ctx=2, and later looked up
on ctx=0, the ctx=0 lookup might fail due to not having associated
hg_addr tracking entry (which points to uri cache).

This current workaround makes uri's being inserted into all contexts
thus creating hg_addr tracking entries for every one fo them

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>