### PR TITLE
CART-89 verbs: Remove legacy ofi+verbs support/mention

### DIFF
--- a/README.env
+++ b/README.env
@@ -4,11 +4,10 @@ This file lists the enviornment variables used in CaRT.
    It determines which mercury NA plugin to be used:
    1: set it as "ofi+sockets" to use OFI sockets provider
    2: set it as "ofi+verbs;ofi_rxm" to use OFI verbs;ofi_rxm provider
-   3: set it as "ofi+verbs" to use OFI verbs provider
-   4: set it as "ofi+psm2" to use OFI psm2 provider
-   5: set it as "ofi+gni" to use OFI gni provider
-   6: set it as "sm" to use SM plugin which only works within single node
-   7: by default (not set or set as any other value) it will use ofi sockets
+   3: set it as "ofi+psm2" to use OFI psm2 provider
+   4: set it as "ofi+gni" to use OFI gni provider
+   5: set it as "sm" to use SM plugin which only works within single node
+   6: by default (not set or set as any other value) it will use ofi sockets
       provider.
 
  . D_LOG_FILE

--- a/SConstruct
+++ b/SConstruct
@@ -53,7 +53,7 @@ DESIRED_FLAGS = ['-Wno-gnu-designator',
                  '-Wno-gnu-zero-variadic-macro-arguments',
                  '-Wno-tautological-constant-out-of-range-compare']
 
-CART_VERSION = "4.3.0"
+CART_VERSION = "4.3.1"
 
 def save_build_info(env, prereqs, platform):
     """Save the build information"""

--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -60,6 +60,7 @@ struct crt_na_dict crt_na_dict[] = {
 		.nad_str	= "ofi+verbs;ofi_rxm",
 		.nad_port_bind	= true,
 	}, {
+	/* verbs is not supported. Keep entry in order to print warning */
 		.nad_type	= CRT_NA_OFI_VERBS,
 		.nad_str	= "ofi+verbs",
 		.nad_port_bind	= true,

--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -317,10 +317,10 @@ crt_init_opt(crt_group_id_t grpid, uint32_t flags, crt_init_options_t *opt)
 do_init:
 		/* Print notice that "ofi+verbs" is legacy */
 		if (crt_gdata.cg_na_plugin == CRT_NA_OFI_VERBS) {
-			D_ERROR("\"ofi+verbs\" provider is no longer supported. "
+			D_ERROR("\"ofi+verbs\" is no longer supported. "
 				"Use \"ofi+verbs;ofi_rxm\" instead for %s env",
 				CRT_PHY_ADDR_ENV);
-			D_GOTO(out,rc = -DER_INVAL);
+			D_GOTO(out, rc = -DER_INVAL);
 		}
 
 		/* the verbs provider only works with regular EP */

--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -315,6 +315,14 @@ crt_init_opt(crt_group_id_t grpid, uint32_t flags, crt_init_options_t *opt)
 			D_GOTO(out, rc = -DER_NONEXIST);
 		}
 do_init:
+		/* Print notice that "ofi+verbs" is legacy */
+		if (crt_gdata.cg_na_plugin == CRT_NA_OFI_VERBS) {
+			D_ERROR("\"ofi+verbs\" provider is no longer supported. "
+				"Use \"ofi+verbs;ofi_rxm\" instead for %s env",
+				CRT_PHY_ADDR_ENV);
+			D_GOTO(out,rc = -DER_INVAL);
+		}
+
 		/* the verbs provider only works with regular EP */
 		if ((crt_gdata.cg_na_plugin == CRT_NA_OFI_VERBS_RXM ||
 		     crt_gdata.cg_na_plugin == CRT_NA_OFI_VERBS) &&

--- a/utils/rpms/cart.spec
+++ b/utils/rpms/cart.spec
@@ -1,7 +1,7 @@
 %define carthome %{_exec_prefix}/lib/%{name}
 
 Name:          cart
-Version:       4.3.0
+Version:       4.3.1
 Release:       1%{?relval}%{?dist}
 Summary:       CaRT
 
@@ -136,6 +136,10 @@ ln %{?buildroot}%{carthome}/{TESTING/.build_vars,.build_vars-Linux}.sh
 %{carthome}/.build_vars-Linux.sh
 
 %changelog
+* Thu Dec 26 2019 Alexander Oganezov <alexander.a.oganezov@intel.com> - 4.3.1-1
+- Libcart version 4.3.1-1
+- ofi+verbs provider no longer supported; 'ofi+verbs;ofi_rxm' to be used instead
+
 * Mon Dec 16 2019 Alexander Oganezov <alexander.a.oganezov@intel.com> - 4.3.0-1
 - Libcart version 4.3.0-1
 

--- a/utils/rpms/debian/changelog
+++ b/utils/rpms/debian/changelog
@@ -1,3 +1,11 @@
+cart (4.3.1-1) unstable; urgency=medium
+
+  [ Alexander Oganezov ]
+  * 4.3.1-1 version of CaRT
+  * ofi+verbs support removed. 'ofi+verbs;ofi_rxm' to be used instead
+
+ -- Alexander Oganezov <alexander.a.oganezov@intel.com>  Thu, 26 Dec 2019 16:53:01 +0000
+
 cart (4.3.0-1) unstable; urgency=medium
 
   [ Alexander Oganezov ]


### PR DESCRIPTION
- Legacy ofi+verbs support is now removed; instead ofi+verbs;ofi_rxm
should be used. Appropriate error message added

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>