### PR TITLE
CART-89 build: Add MPI_PKG option for finer control

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -92,7 +92,8 @@ def scons():
     opts = Variables(opts_file)
     prereqs = PreReqComponent(env, opts, arch=platform)
     prereqs.load_definitions(prebuild=['mercury', 'uuid', 'crypto', 'boost'])
-    load_mpi('openmpi')
+    if env.subst("$MPI_PKG") == "":
+        load_mpi('openmpi')
 
     if not env.GetOption('clean'):
         run_checks(env)

--- a/src/crt_launch/SConscript
+++ b/src/crt_launch/SConscript
@@ -1,4 +1,3 @@
-#!python
 # Copyright (C) 2016-2019 Intel Corporation
 # All rights reserved.
 #
@@ -36,9 +35,8 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
 # THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """Build crt_launch"""
-from __future__ import print_function
-
 import os
+import sys
 
 CRT_LAUNCH = 'crt_launch.c'
 
@@ -47,11 +45,13 @@ def scons():
 
     Import('env', 'prereqs', 'cart_lib', 'gurt_lib')
 
-    if not prereqs.check_component('ompi'):
-        print("No MPI installed...skipping crt_launch build");
-        return
-
     tenv = env.Clone()
+
+    if tenv.subst("$MPI_PKG") != "":
+        tenv.ParseConfig("pkg-config --cflags --libs $MPI_PKG")
+    elif not prereqs.check_component('ompi'):
+        sys.stdout.write("No MPI installed...skipping crt_launch build\n")
+        return
 
     tenv.AppendUnique(CPPPATH=['#/src/cart'])
     tenv.AppendUnique(LIBS=['cart', 'gurt', 'pthread', 'm', 'mpi'])


### PR DESCRIPTION
This enables user to set PKG_CONFIG_PATH and use the
pkg-config name to load MPI rather than relying on
cart to find openmpi.   This is primarily to give
developers finer control

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>