### PR TITLE
CART-833 Make master-endpoint arg mandatory in selftest

### DIFF
--- a/src/self_test/self_test.c
+++ b/src/self_test/self_test.c
@@ -1812,9 +1812,10 @@ int main(int argc, char *argv[])
 		printf("--group-name argument not specified or is invalid\n");
 		D_GOTO(cleanup, ret = -DER_INVAL);
 	}
-	if (ms_endpts == NULL)
-		printf("Warning: No --master-endpoint specified; using this"
-		       " command line application as the master endpoint\n");
+	if (ms_endpts == NULL || num_ms_endpts == 0) {
+		printf("No master endpoints specified\n");
+		D_GOTO(cleanup, ret = -DER_INVAL);
+	}
 	if (endpts == NULL || num_endpts == 0) {
 		printf("No endpoints specified\n");
 		D_GOTO(cleanup, ret = -DER_INVAL);

--- a/test/selftest/cart_selftest_three_node.py
+++ b/test/selftest/cart_selftest_three_node.py
@@ -37,7 +37,7 @@ class CartSelfTwoNodeTest(Test):
     """
     Runs basic CaRT self test
 
-    :avocado: tags=all,selftest,two_node
+    :avocado: tags=all,selftest,three_node
     """
     def setUp(self):
         """ Test setup """
@@ -53,7 +53,7 @@ class CartSelfTwoNodeTest(Test):
         """
         Test CaRT Self Test
 
-        :avocado: tags=all,selftest,two_node
+        :avocado: tags=all,selftest,three_node
         """
 
         srvcmd = self.utils.build_cmd(self, self.env, "srv", True)

--- a/test/selftest/cart_selftest_three_node.yaml
+++ b/test/selftest/cart_selftest_three_node.yaml
@@ -22,10 +22,11 @@ hosts: !mux
     config: two_node
     srv:
       - boro-A
-    cli1:
       - boro-B
+    cli1:
+      - boro-C
     cli2:
-      - boro-A
+      - boro-C
 tests: !mux
   self_np:
     name: self_test_np
@@ -35,7 +36,7 @@ tests: !mux
     srv_ppn: "1"
 
     cli1_bin: ../bin/self_test
-    cli1_arg: "--group-name selftest_srv_grp --endpoint 0:0 --message-sizes \"b2000,b2000 0,0 b2000,b2000 i1000,i1000 b2000,i1000,i1000 0,0 i1000,1,0\" --max-inflight-rpcs 16 --repetitions 100 -t -n -p ."
+    cli1_arg: "--group-name selftest_srv_grp --endpoint 0:0 --master-endpoint 0-1:0 --message-sizes \"b2000,b2000 0,0 b2000,b2000 i1000,i1000 b2000,i1000,i1000 0,0 i1000,1,0\" --max-inflight-rpcs 16 --repetitions 100 -t -n -p ."
     cli1_env: ""
     cli1_ppn: "1"
 

--- a/test/selftest/cart_selftest_three_node.yaml
+++ b/test/selftest/cart_selftest_three_node.yaml
@@ -36,7 +36,7 @@ tests: !mux
     srv_ppn: "1"
 
     cli1_bin: ../bin/self_test
-    cli1_arg: "--group-name selftest_srv_grp --endpoint 0:0 --master-endpoint 0-1:0 --message-sizes \"b2000,b2000 0,0 b2000,b2000 i1000,i1000 b2000,i1000,i1000 0,0 i1000,1,0\" --max-inflight-rpcs 16 --repetitions 100 -t -n -p ."
+    cli1_arg: "--group-name selftest_srv_grp --endpoint 0-1:0 --master-endpoint 0-1:0 --message-sizes \"b2000,b2000 0,0 b2000,b2000 i1000,i1000 b2000,i1000,i1000 0,0 i1000,1,0\" --max-inflight-rpcs 16 --repetitions 100 -t -n -p ."
     cli1_env: ""
     cli1_ppn: "1"
 


### PR DESCRIPTION
master-endpoint must be specified for selftest to work correctly