### PR TITLE
CART-89 build: Prepend rather than Append mpi path

### DIFF
--- a/src/crt_launch/SConscript
+++ b/src/crt_launch/SConscript
@@ -54,7 +54,7 @@ def scons():
             tenv.ParseConfig("pkg-config --cflags --libs $MPI_PKG")
         else:
             print("Appending")
-            tenv.AppendENVPath("PATH", os.path.dirname(mpicc))
+            tenv.PrependENVPath("PATH", os.path.dirname(mpicc))
             tenv.Replace(CC='mpicc')
             tenv.Replace(LINK='mpicc')
     else:


### PR DESCRIPTION
Otherwise, it can pick up an mpicc in the standard path

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>