### PR TITLE
DAOS-4012 corpc: refcount issue

### DIFF
--- a/src/cart/crt_corpc.c
+++ b/src/cart/crt_corpc.c
@@ -553,7 +553,6 @@ crt_corpc_complete(struct crt_rpc_priv *rpc_priv)
 	am_root = (myrank == co_info->co_root);
 	if (am_root) {
 		crt_rpc_complete(rpc_priv, co_info->co_rc);
-		RPC_DECREF(rpc_priv); /* destroy */
 	} else {
 		if (co_info->co_rc != 0)
 			crt_corpc_fail_parent_rpc(rpc_priv, co_info->co_rc);


### PR DESCRIPTION
Fix refcount issue on corpcs during handlign of error condition

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>