### PR TITLE
CART-89 log: D_LOG_TRUNCATE env added

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (C) 2016-2019 Intel Corporation
+Copyright (C) 2016-2020 Intel Corporation
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.env
+++ b/README.env
@@ -20,8 +20,8 @@ This file lists the enviornment variables used in CaRT.
    in D_LOG_FILE. If not defined or setting to zero value will result in this
    feature being disabled.
 
- . D_LOG_TRUNCACE
-   Set this to trunace log file to size=0 before writing to it. Otherwise log
+ . D_LOG_TRUNCATE
+   Set this to truncate log file to size=0 before writing to it. Otherwise log
    file will be appended.
 
  . D_LOG_MASK

--- a/README.env
+++ b/README.env
@@ -20,6 +20,10 @@ This file lists the enviornment variables used in CaRT.
    in D_LOG_FILE. If not defined or setting to zero value will result in this
    feature being disabled.
 
+ . D_LOG_TRUNCACE
+   Set this to trunace log file to size=0  before writing to it. Otherwise log
+   file will be appended.
+
  . D_LOG_MASK
    Can set different log levels for different subsystem.
    GURT defined several debug subsystem(log facility): MISC, MEM, RPC, CORPC,

--- a/README.env
+++ b/README.env
@@ -21,7 +21,7 @@ This file lists the enviornment variables used in CaRT.
    feature being disabled.
 
  . D_LOG_TRUNCATE
-   Set this to truncate log file to size=0 before writing to it. Otherwise log
+   Set this to truncate log file to size = 0 before writing to it. Otherwise log
    file will be appended. Log file is specified by D_LOG_FILE envariable.
 
  . D_LOG_MASK

--- a/README.env
+++ b/README.env
@@ -21,7 +21,7 @@ This file lists the enviornment variables used in CaRT.
    feature being disabled.
 
  . D_LOG_TRUNCATE
-   Set this to truncate log file to size = 0 before writing to it. Otherwise log
+   Set this to truncate log file to size=0 before writing to it. Otherwise log
    file will be appended. Log file is specified by D_LOG_FILE envariable.
 
  . D_LOG_MASK

--- a/README.env
+++ b/README.env
@@ -21,7 +21,7 @@ This file lists the enviornment variables used in CaRT.
    feature being disabled.
 
  . D_LOG_TRUNCACE
-   Set this to trunace log file to size=0  before writing to it. Otherwise log
+   Set this to trunace log file to size=0 before writing to it. Otherwise log
    file will be appended.
 
  . D_LOG_MASK

--- a/README.env
+++ b/README.env
@@ -22,7 +22,7 @@ This file lists the enviornment variables used in CaRT.
 
  . D_LOG_TRUNCATE
    Set this to truncate log file to size=0 before writing to it. Otherwise log
-   file will be appended.
+   file will be appended. Log file is specified by D_LOG_FILE envariable.
 
  . D_LOG_MASK
    Can set different log levels for different subsystem.

--- a/src/cart/_structures_from_macros_.h
+++ b/src/cart/_structures_from_macros_.h
@@ -1,7 +1,7 @@
 /* Automatically generated with structures
  * expanded from CRT_RPC_DECLARE() macros
  *
- * Copyright (C) 2016-2020 Intel Corporation
+ * Copyright (C) 2016-2019 Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/cart/_structures_from_macros_.h
+++ b/src/cart/_structures_from_macros_.h
@@ -1,7 +1,7 @@
 /* Automatically generated with structures
  * expanded from CRT_RPC_DECLARE() macros
  *
- * Copyright (C) 2016-2019 Intel Corporation
+ * Copyright (C) 2016-2020 Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/include/gurt/debug.h
+++ b/src/include/gurt/debug.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2017-2019 Intel Corporation
+/* Copyright (C) 2017-2020 Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -80,6 +80,8 @@ extern void (*d_alt_assert)(const int, const char*, const char*, const int);
 
 /**< Env to specify log file pid append to filename*/
 #define D_LOG_FILE_APPEND_PID_ENV	"D_LOG_FILE_APPEND_PID"
+
+#define D_LOG_TRUNCATE_ENV		"D_LOG_TRUNCATE"
 
 /* Enable shadow warning where users use same variable name in nested
  * scope.   This enables use of a variable in the macro below and is

--- a/utils/rpms/cart.spec
+++ b/utils/rpms/cart.spec
@@ -3,8 +3,8 @@
 %global mercury_version 1.0.1-21%{?dist}
 
 Name:          cart
-Version:       4.5.0
-Release:       2%{?relval}%{?dist}
+Version:       4.5.1
+Release:       1%{?relval}%{?dist}
 Summary:       CaRT
 
 License:       Apache
@@ -143,6 +143,10 @@ ln %{?buildroot}%{carthome}/{TESTING/.build_vars,.build_vars-Linux}.sh
 %{carthome}/.build_vars-Linux.sh
 
 %changelog
+* Mon Jan 27 2020 Alexander Oganezov <alexander.a.oganezov@intel.com> - 4.5.1-1
+- Libcart version 4.5.1-1
+- New D_LOG_TRUNCATE environment variable added
+
 * Thu Jan 23 2020 Brian J. Murrell <brian.murrell@intel.com> - 4.5.0-2
 - Add Requires: mercury-$version until we can get an upstream stable release
 

--- a/utils/rpms/debian/changelog
+++ b/utils/rpms/debian/changelog
@@ -1,3 +1,10 @@
+cart (4.5.1-1) unstable; urgency=medium
+ [ Alexander Oganezov ]
+ * 4.5.1-1 version of CaRT
+ * Added support ofr D_LOG_TRUNCATE environment variable
+
+ -- Alexander Oganezov <alexander.a.oganezov@intel.com>  Mon, 27 Jan 2020 16:53:01 +0000
+
 cart (4.5.0-1) unstable; urgency=medium
   [ Alexander Oganezov ]
   * 4.5.0-1 version of CaRT


### PR DESCRIPTION
- Added new D_LOG_TRUNCATE environment variable to set log file size
to 0 when set.

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>