### PR TITLE
CART-89 providers: Enable ofi+tcp;ofi_rxm provider

### DIFF
--- a/README.env
+++ b/README.env
@@ -2,13 +2,16 @@ This file lists the enviornment variables used in CaRT.
 
  . CRT_PHY_ADDR_STR
    It determines which mercury NA plugin to be used:
-   1: set it as "ofi+sockets" to use OFI sockets provider
+   1: set it as "ofi+tcp;ofi_rxm" to use OFI tcp;ofi_rxm provider
    2: set it as "ofi+verbs;ofi_rxm" to use OFI verbs;ofi_rxm provider
    3: set it as "ofi+psm2" to use OFI psm2 provider
    4: set it as "ofi+gni" to use OFI gni provider
    5: set it as "sm" to use SM plugin which only works within single node
    6: by default (not set or set as any other value) it will use ofi sockets
       provider.
+
+   Note: "ofi+sockets" provider is now deprecated. If specified ofi+tcp;ofi_rxm
+   will be automatically used instead.
 
  . D_LOG_FILE
    Set it as a file path (for example "/tmp/crt.xxx.log") to make GURT log debug

--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -73,6 +73,10 @@ struct crt_na_dict crt_na_dict[] = {
 		.nad_str	= "ofi+psm2",
 		.nad_port_bind	= true,
 	}, {
+		.nad_type	= CRT_NA_OFI_TCP,
+		.nad_str	= "ofi+tcp;ofi_rxm",
+		.nad_port_bind	= true,
+	}, {
 		.nad_str	= NULL,
 	}
 };

--- a/src/cart/crt_hg.h
+++ b/src/cart/crt_hg.h
@@ -71,14 +71,16 @@ enum crt_na_type {
 	CRT_NA_OFI_VERBS_RXM	= 2,
 	CRT_NA_OFI_VERBS	= 3,
 	CRT_NA_OFI_GNI		= 4,
-	CRT_NA_OFI_PSM2		= 5
+	CRT_NA_OFI_PSM2		= 5,
+	CRT_NA_OFI_TCP		= 6,
+	CRT_NA_OFI_COUNT
 };
 
 static inline bool
 crt_na_type_is_ofi(int na_type)
 {
 	return (na_type >= CRT_NA_OFI_SOCKETS) &&
-	       (na_type <= CRT_NA_OFI_PSM2);
+	       (na_type < CRT_NA_OFI_COUNT);
 }
 
 struct crt_na_dict {

--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -298,6 +298,11 @@ crt_init_opt(crt_group_id_t grpid, uint32_t flags, crt_init_options_t *opt)
 				addr_env);
 		}
 
+		if (strcmp(addr_env, "ofi+sockets") == 0) {
+			D_WARN("Automatically switchting to ofi+tcp;ofi_rxm\n");
+			addr_env = "ofi+tcp;ofi_rxm";
+		}
+
 		provider_found = false;
 		for (plugin_idx = 0; crt_na_dict[plugin_idx].nad_str != NULL;
 		     plugin_idx++) {
@@ -324,11 +329,10 @@ do_init:
 		}
 
 		/* the verbs provider only works with regular EP */
-		if ((crt_gdata.cg_na_plugin == CRT_NA_OFI_VERBS_RXM ||
-		     crt_gdata.cg_na_plugin == CRT_NA_OFI_VERBS) &&
+		if ((crt_gdata.cg_na_plugin != CRT_NA_OFI_PSM2) &&
 		    crt_gdata.cg_share_na) {
 			D_WARN("set CRT_CTX_SHARE_ADDR as 1 is invalid "
-			       "for verbs provider, ignore it.\n");
+			       "for selected provider, ignore it.\n");
 			crt_gdata.cg_share_na = false;
 		}
 		if (crt_na_type_is_ofi(crt_gdata.cg_na_plugin)) {


### PR DESCRIPTION
- Enabling ofi+tcp;ofi_rxm provider for experiment

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>