### PR TITLE
CART-89 mercury: Disable mercury patch

### DIFF
--- a/utils/build.config
+++ b/utils/build.config
@@ -6,6 +6,3 @@ OFI = 955f3a07dd011fb1dbfa6b6c772ada03d5af320e
 OPENPA = v1.0.4
 MERCURY = c2c262813811c3ede28ee32fdebbffd417a7cb80
 PSM2 = PSM2_11.2.78
-
-[patch_versions]
-MERCURY = https://raw.githubusercontent.com/daos-stack/mercury/master/c2c262813811c3ede28ee32fdebbffd417a7cb80..6cbd9d4402db6a34dfb7e9dbf2e826ee90c6a64a.patch

--- a/utils/rpms/cart.spec
+++ b/utils/rpms/cart.spec
@@ -1,10 +1,10 @@
 %global carthome %{_exec_prefix}/lib/%{name}
 
-%global mercury_version 2.0.0a1-0.2.git.c2c2628%{?dist}
+%global mercury_version 2.0.0a1-0.3.git.c2c2628%{?dist}
 
 Name:          cart
 Version:       4.5.1
-Release:       1%{?relval}%{?dist}
+Release:       2%{?relval}%{?dist}
 Summary:       CaRT
 
 License:       Apache
@@ -143,6 +143,10 @@ ln %{?buildroot}%{carthome}/{TESTING/.build_vars,.build_vars-Linux}.sh
 %{carthome}/.build_vars-Linux.sh
 
 %changelog
+* Tue Feb 11 2020 Alexander Oganezov <alexander.a.oganezov@intel.com> - 4.5.1-2
+- Libcart version 4.5.1-2
+- mercury_version 2.0.0a1-0.3.git.c2c2628 - unrolled nameserver patch
+
 * Mon Jan 27 2020 Alexander Oganezov <alexander.a.oganezov@intel.com> - 4.5.1-1
 - Libcart version 4.5.1-1
 - New D_LOG_TRUNCATE environment variable added

--- a/utils/rpms/cart.spec
+++ b/utils/rpms/cart.spec
@@ -145,7 +145,8 @@ ln %{?buildroot}%{carthome}/{TESTING/.build_vars,.build_vars-Linux}.sh
 %changelog
 * Tue Feb 11 2020 Alexander Oganezov <alexander.a.oganezov@intel.com> - 4.5.1-2
 - Libcart version 4.5.1-2
-- mercury_version 2.0.0a1-0.3.git.c2c2628 - unrolled nameserver patch
+- mercury_version 2.0.0a1-0.3.git.c2c2628 - unrolled nameserver patch due to
+  verbs instability
 
 * Mon Jan 27 2020 Alexander Oganezov <alexander.a.oganezov@intel.com> - 4.5.1-1
 - Libcart version 4.5.1-1


### PR DESCRIPTION
Disable/remove mercury patch for now as it is causing segfaults
when running multiple servers with verbs

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>