### PR TITLE
DAOS-4222 fix: Print full microseconds

### DIFF
--- a/src/gurt/dlog.c
+++ b/src/gurt/dlog.c
@@ -419,7 +419,7 @@ void d_vlog(int flags, const char *fmt, va_list ap)
 			 "%02d/%02d-%02d:%02d:%02d.%02ld %s ",
 			 tm->tm_mon + 1, tm->tm_mday,
 			 tm->tm_hour, tm->tm_min, tm->tm_sec,
-			 (long int) tv.tv_usec / 10000, mst.uts.nodename);
+			 (long int) tv.tv_usec, mst.uts.nodename);
 
 	if (mst.oflags & DLOG_FLV_TAG) {
 		if (mst.oflags & DLOG_FLV_LOGPID) {


### PR DESCRIPTION
The CaRT logging facility currently only prints in
hundredths of seconds, which leaves many log entries
with the same timestamp.  Microsecond granularity is
available from the timespec, let's use it.

Before:
02/25-12:44:08.58 hl-d102 DAOS[14202/14202] mem ...

After:
02/25-13:03:06.610936 hl-d102 DAOS[24902/24902] mem

Signed-off-by: Patrick Farrell <paf@cray.com>