### PR TITLE
CART-863 cart: typo in call_pre_sync_cb

### DIFF
--- a/src/cart/crt_iv.c
+++ b/src/cart/crt_iv.c
@@ -1979,7 +1979,7 @@ call_pre_sync_cb(struct crt_ivns_internal *ivns_internal,
 
 	D_DEBUG(DB_TRACE, "Executing ivo_pre_sync\n");
 	rc = iv_ops->ivo_pre_sync(ivns_internal, &input->ivs_key, 0,
-				  &iv_value, user_priv);
+				  &tmp_iv, user_priv);
 	if (rc != 0)
 		D_ERROR("ivo_pre_sync() failed; rc=%d\n", rc);
 


### PR DESCRIPTION
In call_pre_sync_cb, it should use tmp_iv, which
is gotten from bulk access, instead of iv_value.

Signed-off-by: Di Wang <di.wang@intel.com>