### PR TITLE
CART-867 swim: Move most of SWIM messages into debug level

### DIFF
--- a/src/swim/swim.c
+++ b/src/swim/swim.c
@@ -579,15 +579,22 @@ swim_progress(struct swim_context *ctx, int64_t timeout)
 	/* validate input parameters */
 	if (ctx == NULL) {
 		SWIM_ERROR("invalid parameter (ctx is NULL)\n");
-		D_GOTO(out, rc = -EINVAL);
+		D_GOTO(out_err, rc = -EINVAL);
 	}
 
 	if (ctx->sc_self == SWIM_ID_INVALID) /* not initialized yet */
-		D_GOTO(out, rc = 0); /* Ignore this update */
+		D_GOTO(out_err, rc = 0); /* Ignore this update */
 
 	now = swim_now_ms();
 	if (timeout > 0)
 		end = now + timeout;
+
+	if (now > ctx->sc_expect_progress_time &&
+	    0  != ctx->sc_expect_progress_time) {
+		SWIM_ERROR("The progress callback was not called for too long: "
+			   "%lu ms after expected.\n",
+			   now - ctx->sc_expect_progress_time);
+	}
 
 	for (; now <= end || ctx_state == SCS_TIMEDOUT; now = swim_now_ms()) {
 		rc = swim_member_update_suspected(ctx, now);
@@ -743,6 +750,8 @@ swim_progress(struct swim_context *ctx, int64_t timeout)
 	}
 	rc = (now > end) ? -ETIMEDOUT : -EINTR;
 out:
+	ctx->sc_expect_progress_time = now + SWIM_PROTOCOL_PERIOD_LEN / 2;
+out_err:
 	return rc;
 }
 

--- a/src/swim/swim_internal.h
+++ b/src/swim/swim_internal.h
@@ -58,8 +58,8 @@
 #include <gurt/common.h>
 
 /* Use debug capability from CaRT */
-#define SWIM_INFO(fmt, ...)	D_DEBUG(DLOG_INFO, fmt, ##__VA_ARGS__)
-#define SWIM_ERROR(fmt, ...)	D_DEBUG(DLOG_ERR,  fmt, ##__VA_ARGS__)
+#define SWIM_INFO(fmt, ...)	D_DEBUG(DLOG_DBG, fmt, ##__VA_ARGS__)
+#define SWIM_ERROR(fmt, ...)	D_DEBUG(DLOG_ERR, fmt, ##__VA_ARGS__)
 
 #ifdef _USE_ABT_SYNC_
 #define SWIM_MUTEX_T		ABT_mutex
@@ -137,6 +137,7 @@ struct swim_context {
 	swim_id_t		 sc_target;
 	swim_id_t		 sc_self;
 
+	uint64_t		 sc_expect_progress_time;
 	uint64_t		 sc_next_tick_time;
 	uint64_t		 sc_dping_deadline;
 	uint64_t		 sc_iping_deadline;


### PR DESCRIPTION
- Reduce the amount of SWIM messages in INFO debug level
- Add error message about SWIM progress callback was not
  called for too long