### PR TITLE
CART-870 swim: add swim index to cart init opt

### DIFF
--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -385,7 +385,8 @@ do_init:
 		crt_gdata.cg_inited = 1;
 
 		if (crt_is_service() && crt_gdata.cg_auto_swim_disable == 0) {
-			rc = crt_swim_init(CRT_DEFAULT_PROGRESS_CTX_IDX);
+			rc = crt_swim_init(opt ? opt->cio_swim_crt_idx :
+						 CRT_DEFAULT_PROGRESS_CTX_IDX);
 			if (rc) {
 				D_ERROR("crt_swim_init() failed rc: %d.\n", rc);
 				D_GOTO(cleanup, rc);

--- a/src/include/cart/types.h
+++ b/src/include/cart/types.h
@@ -92,6 +92,8 @@ typedef struct crt_init_options {
 
 			/** Used with cio_use_credits to set credit limit */
 	int		cio_ep_credits;
+			/** swim crt index */
+	int		cio_swim_crt_idx;
 } crt_init_options_t;
 
 typedef int		crt_status_t;


### PR DESCRIPTION
Add Swim index into cart init opt, so it can
assign swim to specified xstream.

Signed-off-by: Di Wang <di.wang@intel.com>