### PR TITLE
CART-872 swim: Provide ability to change SWIM parameters during runtime

### DIFF
--- a/src/cart/crt_context.c
+++ b/src/cart/crt_context.c
@@ -425,6 +425,8 @@ out:
 	return rc;
 }
 
+extern uint32_t crt_swim_rpc_timeout;
+
 int
 crt_context_destroy(crt_context_t crt_ctx, int force)
 {
@@ -463,10 +465,10 @@ crt_context_destroy(crt_context_t crt_ctx, int force)
 			"d_hash_table_traverse failed rc: %d.\n",
 			ctx->cc_idx, force, rc);
 		/* Flush SWIM RPC already sent */
-		rc = crt_context_flush(crt_ctx, CRT_SWIM_RPC_TIMEOUT);
+		rc = crt_context_flush(crt_ctx, crt_swim_rpc_timeout);
 		if (rc)
 			/* give a chance to other threads to complete */
-			sleep(CRT_SWIM_RPC_TIMEOUT);
+			sleep(crt_swim_rpc_timeout);
 		D_MUTEX_LOCK(&ctx->cc_mutex);
 	}
 

--- a/src/cart/crt_context.c
+++ b/src/cart/crt_context.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2016-2019 Intel Corporation
+/* Copyright (C) 2016-2020 Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/cart/crt_swim.c
+++ b/src/cart/crt_swim.c
@@ -76,6 +76,17 @@ CRT_RPC_DEFINE(crt_rpc_swim,  CRT_ISEQ_RPC_SWIM, /* empty */)
 CRT_RPC_DECLARE(crt_rpc_swim_wack, CRT_ISEQ_RPC_SWIM, CRT_OSEQ_RPC_SWIM)
 CRT_RPC_DEFINE(crt_rpc_swim_wack,  CRT_ISEQ_RPC_SWIM, CRT_OSEQ_RPC_SWIM)
 
+uint32_t crt_swim_rpc_timeout;
+
+static inline uint32_t
+crt_swim_rpc_timeout_default(void)
+{
+	unsigned int val = CRT_SWIM_RPC_TIMEOUT;
+
+	d_getenv_int("CRT_SWIM_RPC_TIMEOUT", &val);
+	return val;
+}
+
 static void crt_swim_srv_cb(crt_rpc_t *rpc_req);
 
 static struct crt_proto_rpc_format crt_swim_proto_rpc_fmt[] = {
@@ -214,7 +225,7 @@ static int crt_swim_send_message(struct swim_context *ctx, swim_id_t to,
 	}
 
 	if (opc_idx == 0) { /* set timeout for one way RPC only */
-		rc = crt_req_set_timeout(rpc_req, CRT_SWIM_RPC_TIMEOUT);
+		rc = crt_req_set_timeout(rpc_req, crt_swim_rpc_timeout);
 		if (rc) {
 			D_TRACE_ERROR(rpc_req,
 				"crt_req_set_timeout() failed rc=%d\n", rc);
@@ -490,6 +501,8 @@ int crt_swim_init(int crt_ctx_idx)
 		D_ERROR("crt_register_progress_cb() failed=%d\n", rc);
 		D_GOTO(cleanup, rc);
 	}
+
+	crt_swim_rpc_timeout = crt_swim_rpc_timeout_default();
 	D_GOTO(out, rc);
 
 cleanup:

--- a/src/swim/swim.c
+++ b/src/swim/swim.c
@@ -1,5 +1,5 @@
 /* Copyright (c) 2016 UChicago Argonne, LLC
- * Copyright (C) 2018-2019 Intel Corporation
+ * Copyright (C) 2018-2020 Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -296,7 +296,7 @@ update:
 				swim_ping_timeout_set(swim_ping_timeout_get() +
 						      SWIM_PING_TIMEOUT);
 				SWIM_INFO("%lu: increase ping timeout to %lu\n",
-					  ctx->sc_self, swim_ping_timeout_get());
+					 ctx->sc_self, swim_ping_timeout_get());
 			}
 			D_FREE(item);
 			break;

--- a/src/swim/swim.c
+++ b/src/swim/swim.c
@@ -41,7 +41,72 @@
 #include "swim_internal.h"
 #include <assert.h>
 
-static uint64_t swim_ping_timeout = SWIM_PING_TIMEOUT;
+static uint64_t swim_prot_period_len;
+static uint64_t swim_suspect_timeout;
+static uint64_t swim_ping_timeout;
+
+static inline uint64_t
+swim_prot_period_len_default(void)
+{
+	unsigned int val = SWIM_PROTOCOL_PERIOD_LEN;
+
+	d_getenv_int("SWIM_PROTOCOL_PERIOD_LEN", &val);
+	return val;
+}
+
+static inline uint64_t
+swim_suspect_timeout_default(void)
+{
+	unsigned int val = SWIM_SUSPECT_TIMEOUT;
+
+	d_getenv_int("SWIM_SUSPECT_TIMEOUT", &val);
+	return val;
+}
+
+static inline uint64_t
+swim_ping_timeout_default(void)
+{
+	unsigned int val = SWIM_PING_TIMEOUT;
+
+	d_getenv_int("SWIM_PING_TIMEOUT", &val);
+	return val;
+}
+
+void
+swim_period_set(uint64_t val)
+{
+	swim_prot_period_len = val;
+}
+
+uint64_t
+swim_period_get(void)
+{
+	return swim_prot_period_len;
+}
+
+void
+swim_suspect_timeout_set(uint64_t val)
+{
+	swim_suspect_timeout = val;
+}
+
+uint64_t
+swim_suspect_timeout_get(void)
+{
+	return swim_suspect_timeout;
+}
+
+void
+swim_ping_timeout_set(uint64_t val)
+{
+	swim_ping_timeout = val;
+}
+
+uint64_t
+swim_ping_timeout_get(void)
+{
+	return swim_ping_timeout;
+}
 
 static inline void
 swim_dump_updates(swim_id_t self_id, swim_id_t from, swim_id_t to,
@@ -52,7 +117,7 @@ swim_dump_updates(swim_id_t self_id, swim_id_t from, swim_id_t to,
 	size_t msg_size, i;
 	int rc;
 
-	if (!D_LOG_ENABLED(DLOG_INFO))
+	if (!D_LOG_ENABLED(DLOG_DBG))
 		return;
 
 	fp = open_memstream(&msg, &msg_size);
@@ -227,10 +292,11 @@ update:
 		if (item->si_id == id) {
 			/* remove this member from suspect list */
 			TAILQ_REMOVE(&ctx->sc_suspects, item, si_link);
-			if (swim_ping_timeout < SWIM_PROTOCOL_PERIOD_LEN) {
-				swim_ping_timeout += SWIM_PING_TIMEOUT;
+			if (swim_ping_timeout_get() < swim_period_get()) {
+				swim_ping_timeout_set(swim_ping_timeout_get() +
+						      SWIM_PING_TIMEOUT);
 				SWIM_INFO("%lu: increase ping timeout to %lu\n",
-					  ctx->sc_self, swim_ping_timeout);
+					  ctx->sc_self, swim_ping_timeout_get());
 			}
 			D_FREE(item);
 			break;
@@ -293,7 +359,7 @@ swim_member_suspect(struct swim_context *ctx, swim_id_t from,
 	int rc;
 
 	/* if there is no suspicion timeout, just kill the member */
-	if (SWIM_SUSPECT_TIMEOUT == 0)
+	if (swim_suspect_timeout_get() == 0)
 		return swim_member_dead(ctx, from, id, nr);
 
 	rc = ctx->sc_ops->get_member_state(ctx, id, &id_state);
@@ -324,7 +390,7 @@ search:
 		D_GOTO(out, rc = -ENOMEM);
 	item->si_id = id;
 	item->si_from = from;
-	item->u.si_deadline = swim_now_ms() + SWIM_SUSPECT_TIMEOUT;
+	item->u.si_deadline = swim_now_ms() + swim_suspect_timeout_get();
 	TAILQ_INSERT_TAIL(&ctx->sc_suspects, item, si_link);
 
 update:
@@ -362,7 +428,7 @@ swim_member_update_suspected(struct swim_context *ctx, uint64_t now)
 				from = item->si_from;
 
 				item->si_from = self_id;
-				item->u.si_deadline += swim_ping_timeout;
+				item->u.si_deadline += swim_ping_timeout_get();
 
 				D_ALLOC_PTR(item);
 				if (item == NULL)
@@ -516,6 +582,12 @@ swim_init(swim_id_t self_id, struct swim_ops *swim_ops, void *data)
 	ctx->sc_piggyback_tx_max = SWIM_PIGGYBACK_TX_COUNT;
 	/* force to choose next target first */
 	ctx->sc_target = SWIM_ID_INVALID;
+
+	/* set global tunable defaults */
+	swim_prot_period_len = swim_prot_period_len_default();
+	swim_suspect_timeout = swim_suspect_timeout_default();
+	swim_ping_timeout    = swim_ping_timeout_default();
+
 out:
 	return ctx;
 }
@@ -633,7 +705,7 @@ swim_progress(struct swim_context *ctx, int64_t timeout)
 		case SCS_BEGIN:
 			if (now > ctx->sc_next_tick_time) {
 				ctx->sc_next_tick_time = now
-						     + SWIM_PROTOCOL_PERIOD_LEN;
+							 + swim_period_get();
 
 				id_target = ctx->sc_target;
 				id_sendto = ctx->sc_target;
@@ -645,7 +717,7 @@ swim_progress(struct swim_context *ctx, int64_t timeout)
 					  target_state.sms_incarnation);
 
 				ctx->sc_dping_deadline = now
-							+ swim_ping_timeout;
+						      + swim_ping_timeout_get();
 				ctx_state = SCS_DPINGED;
 			}
 			break;
@@ -725,7 +797,7 @@ swim_progress(struct swim_context *ctx, int64_t timeout)
 				item = TAILQ_FIRST(&ctx->sc_subgroup);
 				if (item == NULL) {
 					ctx->sc_iping_deadline = now
-							+ 2 * swim_ping_timeout;
+						  + 2 * swim_ping_timeout_get();
 					ctx_state = SCS_IPINGED;
 				}
 				break;
@@ -759,7 +831,7 @@ swim_progress(struct swim_context *ctx, int64_t timeout)
 	}
 	rc = (now > end) ? -ETIMEDOUT : -EINTR;
 out:
-	ctx->sc_expect_progress_time = now + SWIM_PROTOCOL_PERIOD_LEN / 2;
+	ctx->sc_expect_progress_time = now + swim_period_get() / 2;
 out_err:
 	return rc;
 }
@@ -924,7 +996,7 @@ swim_parse_message(struct swim_context *ctx, swim_id_t from,
 				item->si_id   = to;
 				item->si_from = from;
 				item->u.si_deadline = swim_now_ms()
-						    + swim_ping_timeout;
+						      + swim_ping_timeout_get();
 				TAILQ_INSERT_TAIL(&ctx->sc_ipings, item,
 						  si_link);
 				SWIM_INFO("%lu: iping %lu => %lu\n",

--- a/src/swim/swim_internal.h
+++ b/src/swim/swim_internal.h
@@ -193,6 +193,13 @@ swim_state_set(struct swim_context *ctx, enum swim_context_state state)
 		ctx->sc_state = state;
 }
 
+void     swim_period_set(uint64_t val);
+uint64_t swim_period_get(void);
+void     swim_suspect_timeout_set(uint64_t val);
+uint64_t swim_suspect_timeout_get(void);
+void     swim_ping_timeout_set(uint64_t val);
+uint64_t swim_ping_timeout_get(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/swim/swim_internal.h
+++ b/src/swim/swim_internal.h
@@ -1,5 +1,5 @@
 /* Copyright (c) 2016 UChicago Argonne, LLC
- * Copyright (C) 2018-2019 Intel Corporation
+ * Copyright (C) 2018-2020 Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
This patch allow to tune a SWIM algorithm by setting major SWIM
parameters in environment during runtime (without recompilation).