### PR TITLE
CART-873 dlog: change log format to 0600

### DIFF
--- a/src/gurt/dlog.c
+++ b/src/gurt/dlog.c
@@ -642,7 +642,7 @@ d_log_open(char *tag, int maxfac_hint, int default_mask, int stderr_mask,
 			goto error;
 		}
 		mst.logfd =
-		    open(mst.logfile, log_flags, 0666);
+		    open(mst.logfile, log_flags, 0600);
 		if (mst.logfd < 0) {
 			fprintf(stderr, "d_log_open: cannot open %s: %s\n",
 				mst.logfile, strerror(errno));


### PR DESCRIPTION
Change daos log file mode to 0600.

Signed-off-by: Di Wang <di.wang@intel.com>