### PR TITLE
CART-890 mem: Enable memory pinning workaround for MR cache

### DIFF
--- a/README.env
+++ b/README.env
@@ -111,3 +111,6 @@ This file lists the enviornment variables used in CaRT.
  . D_FI_CONFIG
    Sepcifies the fault injection configuration file. If this variable is not set
    or set to empty, fault injection is disabled.
+
+ . CRT_DISABLE_MEM_PIN
+   Disables server-side memory pinning for CART-890 workaround

--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -39,6 +39,9 @@
  * This file is part of CaRT. It implements CaRT init and finalize related
  * APIs/handling.
  */
+/* Headers for mem_pin_workaround() function */
+#include <sys/mman.h>
+#include <malloc.h>
 
 #include "crt_internal.h"
 
@@ -56,7 +59,7 @@ dump_envariables(void)
 		"DD_STDERR", "DD_SUBSYS", "CRT_TIMEOUT", "CRT_ATTACH_INFO_PATH",
 		"OFI_PORT", "OFI_INTERFACE", "OFI_DOMAIN", "CRT_CREDIT_EP_CTX",
 		"CRT_CTX_SHARE_ADDR", "CRT_CTX_NUM", "D_FI_CONFIG",
-		"FI_UNIVERSE_SIZE"};
+		"FI_UNIVERSE_SIZE", "CRT_DISABLE_MEM_PIN"};
 
 	D_DEBUG(DB_ALL, "-- ENVARS: --\n");
 	for (i = 0; i < ARRAY_SIZE(envars); i++) {
@@ -65,14 +68,41 @@ dump_envariables(void)
 	}
 }
 
+/* Workaround for CART-890 */
+static int
+mem_pin_workaround(void)
+{
+	int crt_rc = 0;
+	int rc;
+
+	/* Prevent malloc from releasing memory via sbrk syscall */
+	rc = mallopt(M_TRIM_THRESHOLD, -1);
+	if (rc != 1) {
+		D_ERROR("Failed to disable malloc trim: %d\n", errno);
+		D_GOTO(exit, crt_rc = -DER_MISC);
+	}
+
+	/** Disable fastbins */
+	rc = mallopt(M_MXFAST, 0);
+	if (rc != 1) {
+		D_ERROR("Failed to disable malloc fastbins: %d\n", errno);
+		D_GOTO(exit, crt_rc = -DER_MISC);
+	}
+
+	D_DEBUG(DB_ALL, "Memory pinning workaround enabled\n");
+exit:
+	return crt_rc;
+}
+
 /* first step init - for initializing crt_gdata */
-static int data_init(crt_init_options_t *opt)
+static int data_init(int server, crt_init_options_t *opt)
 {
 	uint32_t	timeout;
 	uint32_t	credits;
 	bool		share_addr = false;
 	uint32_t	ctx_num = 1;
 	uint32_t	fi_univ_size = 0;
+	uint32_t	mem_pin_disable = 0;
 	int		rc = 0;
 
 	D_DEBUG(DB_ALL, "initializing crt_gdata...\n");
@@ -99,6 +129,16 @@ static int data_init(crt_init_options_t *opt)
 	crt_gdata.cg_addr = NULL;
 	crt_gdata.cg_na_plugin = CRT_NA_OFI_SOCKETS;
 	crt_gdata.cg_share_na = false;
+
+	/* Apply CART-890 workaround for server side only */
+	if (server) {
+		d_getenv_int("CRT_DISABLE_MEM_PIN", &mem_pin_disable);
+		if (mem_pin_disable == 0) {
+			rc = mem_pin_workaround();
+			if (rc != 0)
+				D_GOTO(exit, rc);
+		}
+	}
 
 	timeout = 0;
 
@@ -225,7 +265,6 @@ crt_init_opt(crt_group_id_t grpid, uint32_t flags, crt_init_options_t *opt)
 
 	server = flags & CRT_FLAG_BIT_SERVER;
 
-
 	/* d_log_init is reference counted */
 	rc = d_log_init();
 	if (rc != 0) {
@@ -259,7 +298,7 @@ crt_init_opt(crt_group_id_t grpid, uint32_t flags, crt_init_options_t *opt)
 	}
 
 	if (gdata_init_flag == 0) {
-		rc = data_init(opt);
+		rc = data_init(server, opt);
 		if (rc != 0) {
 			D_ERROR("data_init failed, rc(%d) - %s.\n",
 				rc, strerror(rc));

--- a/utils/rpms/cart.spec
+++ b/utils/rpms/cart.spec
@@ -4,7 +4,7 @@
 
 Name:          cart
 Version:       4.6.1
-Release:       1%{?relval}%{?dist}
+Release:       2%{?relval}%{?dist}
 Summary:       CaRT
 
 License:       Apache
@@ -148,6 +148,10 @@ ln %{?buildroot}%{carthome}/{TESTING/.build_vars,.build_vars-Linux}.sh
 
 
 %changelog
+* Wed Apr 29 2020 Alexander Oganezov <alexander.a.oganezov@intel.com> - 4.6.1-2
+- Add memory pinning workaround on server for CART-890.
+  New CRT_DISABLE_MEM_PIN envariable added to disable the workaround when set
+
 * Sun Apr 12 2020 Alexander Oganezov <alexander.a.oganezov@intel.com> - 4.6.1-1
 - Update version to 4.6.1
 


### PR DESCRIPTION
- Due to issues in MR caching, a workaround to pin memory on the
server side in order to avoid buffer corruptions during
the situation when multiple clients rdma close to each other.

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>