### PR TITLE
DAOS-4423 grp: Fix setting of gp_self for secondary groups

### DIFF
--- a/src/cart/crt_corpc.c
+++ b/src/cart/crt_corpc.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2016-2019 Intel Corporation
+/* Copyright (C) 2016-2020 Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -404,6 +404,11 @@ crt_corpc_req_create(crt_context_t crt_ctx, crt_group_t *grp,
 	/* grp_root is logical rank number in this group */
 
 	grp_root = grp_priv->gp_self;
+	if (grp_root == CRT_NO_RANK) {
+		D_DEBUG(DB_NET, "%s: self rank not known yet\n",
+			grp_priv->gp_pub.cg_grpid);
+		D_GOTO(out, rc = -DER_GRPVER);
+	}
 	pri_root = crt_grp_priv_get_primary_rank(grp_priv, grp_root);
 
 	tobe_filter_ranks = filter_ranks;
@@ -772,7 +777,6 @@ crt_corpc_req_hdlr(struct crt_rpc_priv *rpc_priv)
 {
 	struct crt_corpc_info	*co_info;
 	d_rank_list_t		*children_rank_list = NULL;
-	d_rank_t		 grp_rank;
 	struct crt_rpc_priv	*child_rpc_priv;
 	struct crt_opc_info	*opc_info;
 	struct crt_corpc_ops	*co_ops;
@@ -781,8 +785,6 @@ crt_corpc_req_hdlr(struct crt_rpc_priv *rpc_priv)
 
 	co_info = rpc_priv->crp_corpc_info;
 	D_ASSERT(co_info != NULL);
-
-	grp_rank = co_info->co_grp_priv->gp_self;
 
 	/* corresponds to decref in crt_corpc_complete */
 	RPC_ADDREF(rpc_priv);
@@ -802,6 +804,18 @@ crt_corpc_req_hdlr(struct crt_rpc_priv *rpc_priv)
 			crt_corpc_fail_parent_rpc(rpc_priv, rc);
 			D_GOTO(forward_done, rc);
 		}
+	}
+
+	/*
+	 * Check the self rank after calling the pre-forward callback, which
+	 * might have changed the self rank from CRT_NO_RANK to a valid value.
+	 */
+	if (co_info->co_grp_priv->gp_self == CRT_NO_RANK) {
+		RPC_TRACE(DB_NET, rpc_priv, "%s: self rank not known yet\n",
+			  co_info->co_grp_priv->gp_pub.cg_grpid);
+		rc = -DER_GRPVER;
+		crt_corpc_fail_parent_rpc(rpc_priv, rc);
+		D_GOTO(forward_done, rc);
 	}
 
 	rc = crt_tree_get_children(co_info->co_grp_priv, co_info->co_grp_ver,
@@ -825,8 +839,8 @@ crt_corpc_req_hdlr(struct crt_rpc_priv *rpc_priv)
 	co_info->co_child_ack_num = 0;
 
 	D_DEBUG(DB_TRACE, "group %s grp_rank %d, co_info->co_child_num: %d.\n",
-		co_info->co_grp_priv->gp_pub.cg_grpid, grp_rank,
-		co_info->co_child_num);
+		co_info->co_grp_priv->gp_pub.cg_grpid,
+		co_info->co_grp_priv->gp_self, co_info->co_child_num);
 
 	if (!ver_match) {
 		D_INFO("parent version and local version mismatch.\n");

--- a/src/cart/crt_group.c
+++ b/src/cart/crt_group.c
@@ -2521,7 +2521,8 @@ grp_add_to_membs_list(struct crt_grp_priv *grp_priv, d_rank_t rank)
 
 	D_ASSERT(index >= 0);
 
-	if (grp_priv->gp_primary && crt_is_service()) {
+	/* Do not populate swim entries for views and secondary groups */
+	if (grp_priv->gp_primary && !grp_priv->gp_view) {
 		rc = crt_swim_rank_add(grp_priv, rank);
 		if (rc) {
 			D_ERROR("crt_swim_rank_add() failed: rc=%d\n", rc);
@@ -2825,7 +2826,7 @@ crt_group_rank_remove(crt_group_t *group, d_rank_t rank)
 	D_RWLOCK_UNLOCK(&grp_priv->gp_rwlock);
 
 out:
-	if (rc == 0 && grp_priv->gp_primary)
+	if (rc == 0 && grp_priv->gp_primary && !grp_priv->gp_view)
 		crt_swim_rank_del(grp_priv, rank);
 
 	return rc;
@@ -2894,6 +2895,8 @@ crt_group_view_create(crt_group_id_t srv_grpid,
 		D_ERROR("grp_priv_init_membs() failed; rc=%d\n", rc);
 		D_GOTO(out, rc);
 	}
+
+	grp_priv->gp_view = 1;
 
 	rc = crt_grp_lc_create(grp_priv);
 	if (rc != 0) {

--- a/src/cart/crt_group.c
+++ b/src/cart/crt_group.c
@@ -2521,7 +2521,7 @@ grp_add_to_membs_list(struct crt_grp_priv *grp_priv, d_rank_t rank)
 
 	D_ASSERT(index >= 0);
 
-	if (grp_priv->gp_primary) {
+	if (grp_priv->gp_primary && crt_is_service()) {
 		rc = crt_swim_rank_add(grp_priv, rank);
 		if (rc) {
 			D_ERROR("crt_swim_rank_add() failed: rc=%d\n", rc);

--- a/src/cart/crt_group.c
+++ b/src/cart/crt_group.c
@@ -2887,7 +2887,7 @@ crt_group_view_create(crt_group_id_t srv_grpid,
 	}
 
 	grp_priv->gp_size = 0;
-	grp_priv->gp_self = 0;
+	grp_priv->gp_self = CRT_NO_RANK;
 
 	rc = grp_priv_init_membs(grp_priv, grp_priv->gp_size);
 	if (rc != 0) {
@@ -3002,7 +3002,7 @@ crt_group_secondary_create(crt_group_id_t grp_name, crt_group_t *primary_grp,
 	}
 
 	grp_priv->gp_size = 0;
-	grp_priv->gp_self = 0;
+	grp_priv->gp_self = CRT_NO_RANK;
 
 	rc = grp_priv_init_membs(grp_priv, grp_priv->gp_size);
 	if (rc != 0) {
@@ -3175,6 +3175,12 @@ crt_group_secondary_rank_add_internal(struct crt_grp_priv *grp_priv,
 		D_GOTO(out, rc = -DER_OOG);
 	}
 
+	/*
+	 * Set the self rank based on my primary group rank. For simplicity,
+	 * assert that my primary group rank must have been set already, since
+	 * this is always the case with daos_io_server today.
+	 */
+	D_ASSERT(grp_priv->gp_priv_prim->gp_self != CRT_NO_RANK);
 	if (prim_rank == grp_priv->gp_priv_prim->gp_self) {
 		D_DEBUG(DB_ALL, "Setting rank %d as self rank for grp %s\n",
 			sec_rank, grp_priv->gp_pub.cg_grpid);

--- a/src/cart/crt_group.h
+++ b/src/cart/crt_group.h
@@ -136,7 +136,8 @@ struct crt_grp_priv {
 	struct d_hash_table	 gp_s2p_table;
 
 	/* set of variables only valid in primary service groups */
-	uint32_t		 gp_primary:1; /* flag of primary group */
+	uint32_t		 gp_primary:1, /* flag of primary group */
+				 gp_view:1; /* flag to indicate it is a view */
 
 	/* group reference count */
 	uint32_t		 gp_refcount;

--- a/src/cart/crt_group.h
+++ b/src/cart/crt_group.h
@@ -115,6 +115,8 @@ struct crt_grp_priv {
 	 * logical self rank in this group, only valid for local group.
 	 * the gp_membs->rl_ranks[gp_self] is its rank number in primary group.
 	 * For primary group, gp_self == gp_membs->rl_ranks[gp_self].
+	 * If gp_self is CRT_NO_RANK, it usually means the group version is not
+	 * up to date.
 	 */
 	d_rank_t		 gp_self;
 	/* PSR rank in attached group */

--- a/src/cart/crt_iv.c
+++ b/src/cart/crt_iv.c
@@ -1289,9 +1289,16 @@ static int
 crt_iv_parent_get(struct crt_ivns_internal *ivns_internal,
 		  d_rank_t root_node, d_rank_t *ret_node)
 {
-	return crt_iv_ranks_parent_get(ivns_internal,
-				       ivns_internal->cii_grp_priv->gp_self,
-				       root_node, ret_node);
+	d_rank_t self = ivns_internal->cii_grp_priv->gp_self;
+
+	if (self == CRT_NO_RANK) {
+		D_DEBUG(DB_TRACE, "%s: self rank not known yet\n",
+			ivns_internal->cii_grp_priv->gp_pub.cg_grpid);
+		return -DER_GRPVER;
+	}
+
+	return crt_iv_ranks_parent_get(ivns_internal, self, root_node,
+				       ret_node);
 }
 
 static void
@@ -3086,6 +3093,12 @@ crt_iv_update_internal(crt_iv_namespace_t ivns, uint32_t class_id,
 		D_GOTO(exit, rc = -DER_NONEXIST);
 	}
 
+	if (ivns_internal->cii_grp_priv->gp_self == CRT_NO_RANK) {
+		IV_DBG(iv_key, "%s: self rank not known yet\n",
+		       ivns_internal->cii_grp_priv->gp_pub.cg_grpid);
+		D_GOTO(exit, rc = -DER_GRPVER);
+	}
+
 	iv_ops = crt_iv_ops_get(ivns_internal, class_id);
 	if (iv_ops == NULL) {
 		D_ERROR("Invalid class_id specified\n");
@@ -3239,6 +3252,11 @@ crt_iv_get_nchildren(crt_iv_namespace_t ivns, uint32_t class_id,
 	}
 
 	self_rank = ivns_internal->cii_grp_priv->gp_self;
+	if (self_rank == CRT_NO_RANK) {
+		D_DEBUG(DB_TRACE, "%s: self rank not known yet\n",
+			ivns_internal->cii_grp_priv->gp_pub.cg_grpid);
+		D_GOTO(exit, rc = -DER_GRPVER);
+	}
 
 	iv_ops = crt_iv_ops_get(ivns_internal, class_id);
 	if (iv_ops == NULL) {

--- a/src/cart/crt_tree.c
+++ b/src/cart/crt_tree.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2016-2018 Intel Corporation
+/* Copyright (C) 2016-2020 Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -125,6 +125,8 @@ out:
 		D_ASSERT(tree_type == CRT_TREE_FLAT ||			\
 			 (tree_ratio >= CRT_TREE_MIN_RATIO &&		\
 			  tree_ratio <= CRT_TREE_MAX_RATIO));		\
+		D_ASSERT(root != CRT_NO_RANK);				\
+		D_ASSERT(self != CRT_NO_RANK);				\
 	} while (0)
 
 /*


### PR DESCRIPTION
Secondary groups were being previously intialized incorrectly with
gp_self field set to 0 instead of CRT_NO_RANK.

additional checks added to fail early if group is detected as
not being fully initialized (having CRT_NO_RANK for gp_self)

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>