### PR TITLE
DAOS-4689 ucx: Fix ucx error during runtime

### DIFF
--- a/test/util/cart_utils.py
+++ b/test/util/cart_utils.py
@@ -230,8 +230,7 @@ class CartUtils():
 
         mca_flags = "--mca btl self,tcp "
 
-        if self.provider == "ofi+psm2":
-            mca_flags += "--mca pml ob1 "
+        mca_flags += "--mca pml ob1 "
 
         tst_cmd = "{} {} -N {} --hostfile {} "\
                   .format(orterun_bin, mca_flags, tst_ppn, hostfile)


### PR DESCRIPTION
- Pass --mca pml ob1 for all providers to fix ucx issue instead of
only doing it for psm2

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>