### PR TITLE
DAOS-4394 ofi: Update to latest OFI and apply sockets provider patch

### DIFF
--- a/utils/build.config
+++ b/utils/build.config
@@ -2,7 +2,10 @@
 component=cart
 
 [commit_versions]
-OFI = 62f6c937601776dac8a1f97c8bb1b1a6acfbc3c0
+OFI = 8fa7c5bbbfee7df5194b65d9294929a893eb4093
 OPENPA = v1.0.4
 MERCURY = 4871023058887444d47ead4d089c99db979f3d93
 PSM2 = PSM2_11.2.78
+
+[patch_versions]
+OFI = https://raw.githubusercontent.com/daos-stack/libfabric/master/sockets_provider.patch

--- a/utils/rpms/cart.spec
+++ b/utils/rpms/cart.spec
@@ -4,7 +4,7 @@
 
 Name:          cart
 Version:       4.7.0
-Release:       1%{?relval}%{?dist}
+Release:       2%{?relval}%{?dist}
 Summary:       CaRT
 
 License:       Apache
@@ -148,6 +148,10 @@ ln %{?buildroot}%{carthome}/{TESTING/.build_vars,.build_vars-Linux}.sh
 
 
 %changelog
+* Tue May 19 2020 Alexander Oganezov <alexander.a.oganezov@intel.com> - 4.7.0-2
+- Updated OFI to 8fa7c5bbbfee7df5194b65d9294929a893eb4093
+- Added custom sockets_provider.patch to build.config
+
 * Fri May 01 2020 Alexander Oganezov <alexander.a.oganezov@intel.com> - 4.7.0-1
 - Bumped version to 4.7.0, as it was previously missed when new fi function
   was added


### PR DESCRIPTION
- Update to latest OFI in order to pick sockets provider patch
- Apply additional custom sockets provider patch to fix SOAK failures

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>