### PR TITLE
DAOS-723 Fault: Allow Fault Injection framework to be compiled out

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -106,6 +106,12 @@ def scons():
         # generate .so on OSX instead of .dylib
         env.Append(SHLIBSUFFIX='.so')
 
+    AddOption('--with-fault-injection',
+          dest='fault-injection',
+          action='store_true',
+          default=False,
+          help='Enable fault injection framework in this build')             
+
     # Compiler options
     env.Append(CCFLAGS=['-g3', '-Wshadow', '-Wall', '-Werror', '-fpic',
                         '-D_GNU_SOURCE'])
@@ -113,6 +119,10 @@ def scons():
     env.Append(CCFLAGS=['-DCART_VERSION=\\"' + CART_VERSION + '\\"'])
 
     env.Append(CFLAGS=['-std=gnu99'])
+
+    if GetOption("fault-injection"):
+        env.Append(CCFLAGS=['-DFAULT_INJECTION=1'])
+
     if not GetOption('clean'):
         env.AppendIfSupported(CCFLAGS=DESIRED_FLAGS)
 

--- a/SConstruct
+++ b/SConstruct
@@ -53,7 +53,7 @@ DESIRED_FLAGS = ['-Wno-gnu-designator',
                  '-Wno-gnu-zero-variadic-macro-arguments',
                  '-Wno-tautological-constant-out-of-range-compare']
 
-CART_VERSION = "4.7.0"
+CART_VERSION = "4.8.0"
 
 def save_build_info(env, prereqs, platform):
     """Save the build information"""

--- a/SConstruct
+++ b/SConstruct
@@ -107,10 +107,10 @@ def scons():
         env.Append(SHLIBSUFFIX='.so')
 
     AddOption('--with-fault-injection',
-          dest='fault-injection',
-          action='store_true',
-          default=False,
-          help='Enable fault injection framework in this build')             
+              dest='fault-injection',
+              action='store_true',
+              default=False,
+              help='Enable fault injection framework in this build')
 
     # Compiler options
     env.Append(CCFLAGS=['-g3', '-Wshadow', '-Wall', '-Werror', '-fpic',

--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -279,7 +279,7 @@ crt_init_opt(crt_group_id_t grpid, uint32_t flags, crt_init_options_t *opt)
 
 	/* d_fault_inject_init() is reference counted */
 	rc = d_fault_inject_init();
-	if (rc != DER_SUCCESS) {
+	if (rc != DER_SUCCESS && rc != -DER_NOSYS) {
 		D_ERROR("d_fault_inject_init() failed, rc: %d.\n", rc);
 		D_GOTO(out, rc);
 	}
@@ -598,7 +598,7 @@ crt_finalize(void)
 out:
 	/* d_fault_inject_fini() is reference counted */
 	local_rc = d_fault_inject_fini();
-	if (local_rc != 0)
+	if (local_rc != 0 && local_rc != -DER_NOSYS)
 		D_ERROR("d_fault_inject_fini() failed, rc: %d\n", local_rc);
 
 direct_out:

--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2016-2019 Intel Corporation
+/* Copyright (C) 2016-2020 Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -52,9 +52,9 @@ crt_hdlr_ctl_fi_toggle(crt_rpc_t *rpc_req)
 	out_args = crt_reply_get(rpc_req);
 
 	if (in_args->op)
-		d_fault_inject_enable();
+		rc = d_fault_inject_enable();
 	else
-		d_fault_inject_disable();
+		rc = d_fault_inject_disable();
 
 	out_args->rc = rc;
 	rc = crt_reply_send(rpc_req);

--- a/src/gurt/fault_inject.c
+++ b/src/gurt/fault_inject.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2018-2019 Intel Corporation
+/* Copyright (C) 2018-2020 Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -50,7 +50,15 @@
 #include <gurt/hash.h>
 #include "fi.h"
 
+/**
+ * global switxh for fault injection. zero globally turns off fault injection,
+ * non-zero turns on fault injection
+ */
+unsigned int			d_fault_inject;
+unsigned int			d_fault_config_file;
 struct d_fault_attr_t *d_fault_attr_mem;
+
+#if FAULT_INJECTION
 
 static struct d_fault_attr *
 fa_link2ptr(d_list_t *rlink)
@@ -108,12 +116,6 @@ struct d_fi_gdata_t {
 	struct d_hash_table	  dfg_fa_table;
 };
 
-/**
- * global swith for fault injection. zero globally turns off fault injection,
- * non-zero turns on fault injection
- */
-unsigned int			d_fault_inject;
-unsigned int			d_fault_config_file;
 static uint32_t			d_fault_inject_seed;
 static struct d_fi_gdata_t	d_fi_gdata;
 static pthread_once_t		d_fi_gdata_init_once = PTHREAD_ONCE_INIT;
@@ -586,21 +588,23 @@ d_fault_inject_fini()
 }
 
 
-void
+int
 d_fault_inject_enable(void)
 {
 	if (!d_fault_config_file) {
 		D_ERROR("No fault config file.\n");
-		return;
+		return -DER_NOSYS;
 	}
 
 	d_fault_inject = 1;
+	return 0;
 }
 
-void
+int
 d_fault_inject_disable(void)
 {
 	d_fault_inject = 0;
+	return 0;
 }
 
 bool
@@ -669,4 +673,59 @@ out:
 	D_SPIN_UNLOCK(&fault_attr->fa_lock);
 	return rc;
 };
+#else /* FAULT_INJECT */
+int d_fault_inject_init(void)
+{
+	D_WARN("Fault Injection not initialized feature not included in build");
+	return -DER_NOSYS;
+}
 
+int d_fault_inject_fini(void)
+{
+	D_WARN("Fault Injection not finalized feature not included in build");
+	return -DER_NOSYS;
+}
+
+int d_fault_inject_enable(void)
+{
+	D_WARN("Fault Injection not enabled feature not included in build");
+	return -DER_NOSYS;
+}
+
+int d_fault_inject_disable(void)
+{
+	D_WARN("Fault Injection not disabled feature not included in build");
+	return -DER_NOSYS;
+}
+
+bool
+d_fault_inject_is_enabled(void)
+{
+	return false;
+}
+
+bool
+d_should_fail(struct d_fault_attr_t *fault_attr)
+{
+	return false;
+}
+
+int
+d_fault_attr_set(uint32_t fault_id, struct d_fault_attr_t fa_in)
+{
+	D_WARN("Fault Injection attr not set feature not included in build");
+	return 0;
+}
+
+struct d_fault_attr_t *
+d_fault_attr_lookup(uint32_t fault_id)
+{
+	return NULL;
+}
+
+int
+d_fault_attr_err_code(uint32_t fault_id)
+{
+	return 0;
+}
+#endif /* FAULT_INJECT */

--- a/src/gurt/fault_inject.c
+++ b/src/gurt/fault_inject.c
@@ -51,7 +51,7 @@
 #include "fi.h"
 
 /**
- * global switxh for fault injection. zero globally turns off fault injection,
+ * global switch for fault injection. zero globally turns off fault injection,
  * non-zero turns on fault injection
  */
 unsigned int			d_fault_inject;

--- a/src/include/gurt/fault_inject.h
+++ b/src/include/gurt/fault_inject.h
@@ -129,13 +129,17 @@ int d_fault_inject_fini(void);
 
 /**
  * Start injecting faults.
+ * 
+ * \return                   DER_SUCCESS on success, -DER_NOSYS if not supported
  */
-void d_fault_inject_enable(void);
+int d_fault_inject_enable(void);
 
 /**
  * Stop injecting faults.
+ * 
+ * \return                   DER_SUCCESS on success, -DER_NOSYS if not supported
  */
-void d_fault_inject_disable(void);
+int d_fault_inject_disable(void);
 
 bool d_fault_inject_is_enabled(void);
 

--- a/src/include/gurt/fault_inject.h
+++ b/src/include/gurt/fault_inject.h
@@ -129,14 +129,14 @@ int d_fault_inject_fini(void);
 
 /**
  * Start injecting faults.
- * 
+ *
  * \return                   DER_SUCCESS on success, -DER_NOSYS if not supported
  */
 int d_fault_inject_enable(void);
 
 /**
  * Stop injecting faults.
- * 
+ *
  * \return                   DER_SUCCESS on success, -DER_NOSYS if not supported
  */
 int d_fault_inject_disable(void);

--- a/src/test/SConscript
+++ b/src/test/SConscript
@@ -57,6 +57,7 @@ SWIM_TESTS = ['test_swim.c', 'test_swim_net.c']
 HLC_TESTS = ['test_hlc_net.c']
 TEST_GROUP_NP_TESTS = ['test_group_np_srv.c', 'test_group_np_cli.c',
                        'no_pmix_group_version.c']
+FI_TEST = ['fault_status.c']
 
 def scons():
     """scons function"""
@@ -100,6 +101,11 @@ def scons():
         target = tenv.Program(test)
         tenv.Requires(target, [cart_lib, gurt_lib])
         tenv.Install(os.path.join("$PREFIX", 'TESTING', 'tests'), target)
+
+    target = tenv.Program(FI_TEST)
+    tenv.Requires(target, [cart_lib, gurt_lib])
+    tenv.Install(os.path.join("$PREFIX", 'bin'), target)
+
 #    test_rpc_err = tenv.Program([TEST_RPC_ERR_SRC])
 #    tenv.Requires(test_rpc_err, [cart_lib, gurt_lib])
 #    tenv.Install(os.path.join("$PREFIX", 'TESTING', 'tests'), test_rpc_err)

--- a/src/test/fault_status.c
+++ b/src/test/fault_status.c
@@ -28,3 +28,4 @@ int main(void)
     return 1;
 #endif
 }
+

--- a/src/test/fault_status.c
+++ b/src/test/fault_status.c
@@ -1,0 +1,30 @@
+/**
+ * (C) Copyright 2020 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+ * The Government's rights to use, modify, reproduce, release, perform, display,
+ * or disclose this software are subject to the terms of the Apache License as
+ * provided in Contract No. B620873.
+ * Any reproduction of computer software, computer software documentation, or
+ * portions thereof marked with this legend must also reproduce the markings.
+ */
+int main(void)
+{
+#if FAULT_INJECTION
+    return 0;
+#else
+    return 1;
+#endif
+}

--- a/utils/rpms/cart.spec
+++ b/utils/rpms/cart.spec
@@ -4,7 +4,7 @@
 
 Name:          cart
 Version:       4.7.0
-Release:       2%{?relval}%{?dist}
+Release:       3%{?relval}%{?dist}
 Summary:       CaRT
 
 License:       Apache
@@ -145,9 +145,13 @@ ln %{?buildroot}%{carthome}/{TESTING/.build_vars,.build_vars-Linux}.sh
 %{carthome}/multi-node-test.sh
 %{carthome}/.build_vars-Linux.sh
 %{_bindir}/crt_launch
+%{_bindir}/fault_status
 
 
 %changelog
+* Wed May 19 2020 Maureen Jean <maureen.jean@intel.com> - 4.7.0-3
+- add fault_status to cart-tests files list
+
 * Tue May 19 2020 Alexander Oganezov <alexander.a.oganezov@intel.com> - 4.7.0-2
 - Updated OFI to 8fa7c5bbbfee7df5194b65d9294929a893eb4093
 - Added custom sockets_provider.patch to build.config

--- a/utils/rpms/cart.spec
+++ b/utils/rpms/cart.spec
@@ -3,8 +3,8 @@
 %global mercury_version 2.0.0a1-0.8.git.4871023%{?dist}
 
 Name:          cart
-Version:       4.7.0
-Release:       3%{?relval}%{?dist}
+Version:       4.8.0
+Release:       1%{?relval}%{?dist}
 Summary:       CaRT
 
 License:       Apache
@@ -149,7 +149,7 @@ ln %{?buildroot}%{carthome}/{TESTING/.build_vars,.build_vars-Linux}.sh
 
 
 %changelog
-* Wed May 19 2020 Maureen Jean <maureen.jean@intel.com> - 4.7.0-3
+* Wed May 19 2020 Maureen Jean <maureen.jean@intel.com> - 4.8.0-1
 - add fault_status to cart-tests files list
 
 * Tue May 19 2020 Alexander Oganezov <alexander.a.oganezov@intel.com> - 4.7.0-2


### PR DESCRIPTION
The fault injection framework in CART is a developer/test focused feature. The
feature should not be present in production systems so it is not built in by
default. It can be enabled by specifying --with-fault-injection on the scons
build line.

Signed-off-by: David Quigley <david.quigley@intel.com>