### PR TITLE
CART-89 mallopt: Ignore mallopt() errors at startup

### DIFF
--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -83,12 +83,11 @@ mem_pin_workaround(void)
 		D_GOTO(exit, crt_rc = -DER_MISC);
 	}
 
-	/** Disable fastbins */
+	/* Disable fastbins; this option is not available on all systems */
 	rc = mallopt(M_MXFAST, 0);
-	if (rc != 1) {
-		D_ERROR("Failed to disable malloc fastbins: %d\n", errno);
-		D_GOTO(exit, crt_rc = -DER_MISC);
-	}
+	if (rc != 1)
+		D_WARN("Failed to disable malloc fastbins: %d (%s)\n",
+			errno, strerror(errno));
 
 	D_DEBUG(DB_ALL, "Memory pinning workaround enabled\n");
 exit:

--- a/utils/rpms/cart.spec
+++ b/utils/rpms/cart.spec
@@ -4,7 +4,7 @@
 
 Name:          cart
 Version:       4.8.0
-Release:       1%{?relval}%{?dist}
+Release:       2%{?relval}%{?dist}
 Summary:       CaRT
 
 License:       Apache
@@ -149,6 +149,9 @@ ln %{?buildroot}%{carthome}/{TESTING/.build_vars,.build_vars-Linux}.sh
 
 
 %changelog
+* Thu May 28 2020 Alexander Oganezov <alexander.a.oganezov@intel.com> - 4.8.0-2
+- Ignore mallopt() failures at startup
+
 * Wed May 19 2020 Maureen Jean <maureen.jean@intel.com> - 4.8.0-1
 - add fault_status to cart-tests files list
 


### PR DESCRIPTION
- Some systems do not have fastbins; ignore mallopt errors
at startup and instead emit warning

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>