### PR TITLE
DAOS-5269 cart: optimiza (un)packing

### DIFF
--- a/src/include/cart/api.h
+++ b/src/include/cart/api.h
@@ -1289,6 +1289,8 @@ typedef enum {
 	CRT_PROC_FREE
 } crt_proc_op_t;
 
+#define crt_proc_raw crt_proc_memcpy
+
 /**
  * Get the operation type associated to the proc processor.
  *
@@ -1302,7 +1304,6 @@ crt_proc_get_op(crt_proc_t proc, crt_proc_op_t *proc_op);
 
 /**
  * Base proc routine using memcpy().
- * Only uses memcpy() / use crt_proc_raw() for encoding raw buffers.
  *
  * \param[in,out] proc         abstract processor object
  * \param[in,out] data         pointer to data
@@ -1411,18 +1412,6 @@ crt_proc_uint64_t(crt_proc_t proc, uint64_t *data);
  */
 int
 crt_proc_bool(crt_proc_t proc, bool *data);
-
-/**
- * Generic processing routine.
- *
- * \param[in,out] proc         abstract processor object
- * \param[in,out] buf          pointer to buffer
- * \param[in] buf_size         buffer size
- *
- * \return                     DER_SUCCESS on success, negative value if error
- */
-int
-crt_proc_raw(crt_proc_t proc, void *buf, size_t buf_size);
 
 /**
  * Generic processing routine.

--- a/src/include/gurt/common.h
+++ b/src/include/gurt/common.h
@@ -72,6 +72,9 @@
 extern "C" {
 #endif
 
+#define likely(x)	__builtin_expect((x), 1)
+#define unlikely(x)	__builtin_expect((x), 0)
+
 /* Check if bit is set in passed val */
 #define D_BIT_IS_SET(val, bit) (((val) & bit) ? 1 : 0)
 


### PR DESCRIPTION
Don't memcpy inline data and use pointer in request buffer instead.
Use direct assignment for basic types instead of memcpy.